### PR TITLE
Fixes Sirran behavior for Sister of the Spire

### DIFF
--- a/airplane/Sirran_the_Lunatic.lua
+++ b/airplane/Sirran_the_Lunatic.lua
@@ -23,7 +23,7 @@ function event_say(e)
 		end
 	elseif(e.message:findi("citanul eht narris, liah") and qglobals["sirran"] == "6") then 	--island6
 		e.self:Say("Lortap llaw taerg eht fo lahsram, Narris lahsram ma I. Flesym ecudortni ot em wolla. Sgniteerg");
-	elseif(e.message:findi("llaw eht htiw eno I ma") and qglobals["sirran"] == "6") then 		--island6
+	elseif(e.message:findi("llaw eht htiw eno I ma") and (globals["sirran"] == "6") or qglobals["sirran"] == "7") then 		--island6
 		e.self:Say("Kcul doog! Ouy rof ydaer si erips eht fo retsis eht won, sdik boj doog.");
 		if(eq.get_entity_list():IsMobSpawnedByNpcTypeID(71076) == false) then
 			eq.spawn2(71076,0,0,-929,-1035,1093,128); 							--used Magelo to get the closest loc as possible.

--- a/airplane/Sirran_the_Lunatic.lua
+++ b/airplane/Sirran_the_Lunatic.lua
@@ -23,7 +23,7 @@ function event_say(e)
 		end
 	elseif(e.message:findi("citanul eht narris, liah") and qglobals["sirran"] == "6") then 	--island6
 		e.self:Say("Lortap llaw taerg eht fo lahsram, Narris lahsram ma I. Flesym ecudortni ot em wolla. Sgniteerg");
-	elseif(e.message:findi("llaw eht htiw eno I ma") and (globals["sirran"] == "6") or qglobals["sirran"] == "7") then 		--island6
+	elseif(e.message:findi("llaw eht htiw eno I ma") and (qglobals["sirran"] == "6") or qglobals["sirran"] == "7") then 		--island6
 		e.self:Say("Kcul doog! Ouy rof ydaer si erips eht fo retsis eht won, sdik boj doog.");
 		if(eq.get_entity_list():IsMobSpawnedByNpcTypeID(71076) == false) then
 			eq.spawn2(71076,0,0,-929,-1035,1093,128); 							--used Magelo to get the closest loc as possible.


### PR DESCRIPTION
Per https://wiki.project1999.com/Plane_of_Sky#Island_7:_Drake_Island, Sister of the Spire should be repeatedly triggerable from Isle 6 by saying this phrase to Sirran. Right now it gets disabled when you first kill her but this doesn't match Live or P99 behavior.

This change makes it so that you can re-trigger Sister still after killing her to match expected behavior.