### PR TITLE
Applies misc fixes to a ton of invalid quest scripts

### DIFF
--- a/eastkarana/Sir_Morgan.pl
+++ b/eastkarana/Sir_Morgan.pl
@@ -37,7 +37,7 @@ sub EVENT_ITEM {
 		#:: Ding!!
 		quest::ding();
 		#:: Give a random reward: Patchwork cloak, Patchwork boots, Rusty Weapons, Silver Earring, Bloodstone, Halfling knife, Bronze Dagger, Belt pouch, Damask cap, Mountain Lion Cape, Highkeep Flask, Snakeskin Mask, Drom's Champagne
-		quest::summonitem(1quest::ChooseRandom(2106, 2112, 2041, 13944, 2307, 3829, 1331, 17002, 7012, 8306, 10006, 10019, 5013, 5019, 5021, 5022, 6011, 5023, 7007, 7008));
+		quest::summonitem(quest::ChooseRandom(2106, 2112, 2041, 13944, 2307, 3829, 1331, 17002, 7012, 8306, 10006, 10019, 5013, 5019, 5021, 5022, 6011, 5023, 7007, 7008));
 		#:: Set Factions
 		quest::faction(262, 1);		#:: + Guards of Qeynos
 		quest::faction(345, 1);		#:: + Karana Residents

--- a/erudnext/Breya_Nostulia.pl
+++ b/erudnext/Breya_Nostulia.pl
@@ -15,7 +15,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 17056 - Kobold Shaman's Pouch, and a 1766 - Diviner's Bowl
-	if (plugin::takeItems(17056 => 1, 1766 => 1)) {
+	if (plugin::check_handin(\%itemcount, 17056 => 1, 1766 => 1)) {
 		quest::say("Well done, $name. I had a feeling you would return victorious. Here is your reward, the Leggings of Midnight Sea. Wear them with pride for the Ocean Lord. If you are interested in aiding us further, you may want to ask Gans about his brother.");
 		#:: Give a 1762 - Midnight Sea Mail Leggings
 		quest::summonitem(11762);

--- a/erudnext/Depnar_Bulrious.pl
+++ b/erudnext/Depnar_Bulrious.pl
@@ -21,7 +21,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match turn in for 18726 -  tattered note
-	if (plugin::takeItems(18726 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18726 => 1)) {
 		quest::say("Welcome to the Temple of Divine Light. I am Master Bulrious. Here. we study and spread the will of Quellious. Here is your guild tunic. Go find Jras Solsier. he will get you started with your first lesson.");
 		#:: Give item 13546 - Faded silver Tunic*
 		quest::summonitem(13546);

--- a/erudnext/Dleria_Mausrel.pl
+++ b/erudnext/Dleria_Mausrel.pl
@@ -47,12 +47,12 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 13922 - Snapped Pole
-	if (plugin::takeItems(13922 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13922 => 1)) {
 		#:: Match if faction is Amiable or better
 		if ($faction <= 4) {
 			quest::say("Good work, young priest. Soon you shall carry the word of the Ocean Lord to distant lands. For now, continue your training. As for your reward, I have this which has been sitting in our vault. I hope it can be of use to a young priest such as yourself.");
 			#:: Give a random reward: 2144 - Raw-hide Sleeves, 2146 - Raw-hide Gloves, 2147 - Raw-hide Leggings, 17005 - Backpack
-			quest::summonitem(1quest::ChooseRandom(2144, 2146, 2147, 17005));
+			quest::summonitem(quest::ChooseRandom(2144, 2146, 2147, 17005));
 			#:: Ding!
 			quest::ding();
 			#:: Set factions
@@ -80,7 +80,7 @@ sub EVENT_ITEM {
 		
 	}
 	#:: Match a 13880 - Bag of Zombie Flesh
-	elsif (plugin::takeItems(13880 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13880 => 1)) {
 		#:: Match if faction is Amiable or better
 		if ($faction <= 4) {
 			quest::say("Peeuww!! That most certainly is zombie flesh!! Here is your reward. You have done a fine service in the name of Prexus. Soon you shall advance and we may tell you of greater dangers lurking in the depths.");

--- a/erudnext/Gans_Paust.pl
+++ b/erudnext/Gans_Paust.pl
@@ -36,7 +36,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 18724 - Tattered Note
-	if (plugin::takeItems(18724 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18724 => 1)) {
 		quest::say("Yes. welcome friend! Here is your guild tunic. You'll make a fine addition to the Deepwater Knights.  Go see Lumi Stergnon, he will get you started in your studies. Return to me when you have become more experienced in our art, I will be able to further instruct you on how to progress through your early ranks, as well as in some of the various [trades] you will have available to you.");
 		#:: Give a 13544 - Old Blue Tunic*
 		quest::summonitem(13544);
@@ -50,7 +50,7 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Match a 1771 - Yelesom's Reports
-	elsif (plugin::takeItems(1771 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 1771 => 1)) {
 		quest::say("Excellent! Thank you for checking on my brother, I am glad to hear that he is well.  Here is something that shall help you on your way.");
 		#:: Give a 1763 - Midnight Sea Mail Sleeves
 		quest::summonitem(11763);

--- a/erudnext/Jras_Solsier.pl
+++ b/erudnext/Jras_Solsier.pl
@@ -45,7 +45,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 13825 - Poacher's Head
-	if (plugin::takeItems(13825 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13825 => 1)) {
 		#:: Match if faction is Amiable or better
 		if ($faction <= 4) {
 			quest::say("You have served us well. The harmony of the forest shall be preserved. I have word that theses infidels were all working for one man. Find me evidence pertaining to this man. Surely one of these poachers has something which could aid in finding this man. We must stop him to stop the poachers. Go in peace.");
@@ -77,7 +77,7 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Match a 13913 - Barbarian Head
-	elsif (plugin::takeItems(13913 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13913 => 1)) {
 		#:: Match if faction is Amiable or better
 		if ($faction <= 4) {
 			quest::say("It is done! Quellious will look favorably upon our church and we will look favorably upon you. Go in peace");

--- a/erudnext/Laoni_Reista.pl
+++ b/erudnext/Laoni_Reista.pl
@@ -32,12 +32,12 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 13881 -  Nicked Coin
-	if (plugin::takeItems(13881 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13881 => 1)) {
 		#:: Match if faction is Amiable or better
 		if ($faction <= 4) {
 			quest::say("Good work. You have shown these rogues who are the better swimmers. Now we have proof of their involvement. You are a fine addition to the temple. Take this small reward. Go, and serve Prexus.");
 			#:: Give a random reward: 13003 - Small Lantern, 10004 - Copper Band
-			quest::summonitem(1quest::ChooseRandom(13003, 10004));
+			quest::summonitem(quest::ChooseRandom(13003, 10004));
 			#:: Ding!
 			quest::ding();
 			#:: Set factions

--- a/erudnext/Leraena_Shelyrak.pl
+++ b/erudnext/Leraena_Shelyrak.pl
@@ -62,7 +62,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 18723 - Tattered Note
-	if (plugin::takeItems(18723 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18723 => 1)) {
 		quest::say("Greetings. and welcome to the Temple of Divine Light! Here is your guild tunic. Serve Quellious well. Please see Lumi Stergnon - he has a task for you.");
 		#:: Give item 135546 - Faded Silver Tunic
 		quest::summonitem(13546);
@@ -89,12 +89,12 @@ sub EVENT_ITEM {
 		#quest::givecash(8,2,0,0);	#:: Give a small amount of cash copper - plat
 	#}
 	#:: Match three 13883 - Odd Kobold Paw
-	elsif (plugin::takeItems(13883 => 3)) {
+	elsif (plugin::check_handin(\%itemcount, 13883 => 3)) {
 		#:: Match if faction is Amiable or better 
 		if ($faction <= 4) {
 			quest::say("Fine work. They shall never lay hands upon another kobold again. I mean paws. Here is a small reward for a fine job. Unfortunatly we have recently learned that the shamen in the forest are merely underlings to more [powerful kobold shaman] that reside in the kobold warrens. Continue the work of Quellious.");
 			#:: Give a random reward: 15011 - Spell: Holy Armor, 15213 - Spell: Cure Disease, 15216 - Spell: Stun, 15212 - Spell: Cure Blindness
-			quest::summonitem(1quest::ChooseRandom(15011, 15213, 15216, 15212));
+			quest::summonitem(quest::ChooseRandom(15011, 15213, 15216, 15212));
 			#:: Ding!
 			quest::ding();
 			#:: Set factions
@@ -121,7 +121,7 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Match two 13883 - Odd Kobold Paw
-	elsif (plugin::takeItems(13883 => 2)) {
+	elsif (plugin::check_handin(\%itemcount, 13883 => 2)) {
 		#:: Match if faction is Amiable or better 
 		if ($faction <= 4) {
 			quest::say("I instructed you to return THREE paws.");
@@ -141,7 +141,7 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Match one 13883 - Odd Kobold Paw
-	elsif (plugin::takeItems(13883 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13883 => 1)) {
 		#:: Match if faction is Amiable or better 
 		if ($faction <= 4) {
 			quest::say("I instructed you to return THREE paws.");

--- a/erudnext/Lumi_Stergnon.pl
+++ b/erudnext/Lumi_Stergnon.pl
@@ -68,12 +68,12 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 13882 - Box of Bones
-	if (plugin::takeItems(13882 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13882 => 1)) {
 		#:: Match if faction is Amiable or better
 		if ($faction <= 4) {
 			quest::say("This is fabulous work, my friend! You have served your people well. Take this as a gift. I hope it can be of use to you. We need proof of these skeletons' origins. Continue the eradication of the undead and find out who creates them. Once you know, bring their head to me.");
 			#:: Give a random reward:  17005 - Backpack, 17002 - Belt Pouch, 10018 - Hematite, 2144 - Raw-hide Sleeves, 2145 - Raw-hide Wristbands, 2146 - Raw-hide Gloves, 6011 - Rusty Mace, 6016 - Rusty Morning Star, 15203 - Spell: Cure Poison, 15207 - Spell: Divine Aura, 15201 - Spell: Flash of Light, 15209 - Spell: Spook the Dead, 15014 - Spell: Strike, 15205 - Spell: True North, 15210 - Spell: Yaulp, 6012 - Worn Great Staff
-			quest::summonitem(1quest::ChooseRandom(17005, 17002, 10018, 2144, 2145, 2146, 6011, 6016, 15203, 15207, 15201,15208, 15209, 15014, 15205, 15210, 6012));
+			quest::summonitem(quest::ChooseRandom(17005, 17002, 10018, 2144, 2145, 2146, 6011, 6016, 15203, 15207, 15201,15208, 15209, 15014, 15205, 15210, 6012));
 			#:: Ding!
 			quest::ding();
 			#:: Set factions
@@ -100,12 +100,12 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Match a 13816 - Peacekeeper staff
-	elsif (plugin::takeItems(13816 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13816 => 1)) {
 		#:: Match if faction is Amiable or better
 		if ($faction <= 4) {
 			quest::say("You have done well, neophyte. Let me add the touch of harmony to finish the job.. Here, then. Take these supplies. I am sure you'll need them. Soon you may be able to assist us in [important missions]");
 			#:: Give a random reward:  17005 - Backpack, 17002 - Belt Pouch, 10018 - Hematite, 2144 - Raw-hide Sleeves, 2145 - Raw-hide Wristbands, 2146 - Raw-hide Gloves, 6011 - Rusty Mace, 6016 - Rusty Morning Star, 6012 - Worn Great Staff
-			quest::summonitem(1quest::ChooseRandom(17005, 17002, 10018, 2144, 2145, 2146, 6011, 6016, 6012));
+			quest::summonitem(quest::ChooseRandom(17005, 17002, 10018, 2144, 2145, 2146, 6011, 6016, 6012));
 			#:: Ding!
 			quest::ding();
 			#:: Set factions

--- a/erudnext/Nolusia_Finharn.pl
+++ b/erudnext/Nolusia_Finharn.pl
@@ -24,7 +24,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 13118 - Erud's Tonic
-	if (plugin::takeItems(13118 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13118 => 1)) {
 		quest::say("Good work! Now, hold the bottle by the label! When you hand Flynn the bottle, the label will slide off. Bring me the label as proof of the deed.");
 		#:: Give a 13122 - Erud's Tonic
 		quest::summonitem(13122);
@@ -39,10 +39,10 @@ sub EVENT_ITEM {
 		quest::exp(500);
 	}
 	#:: Match a 13123 - Label of Erud's Tonic 
-	elsif (plugin::takeItems(13123 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13123 => 1)) {
 		quest::say("Fantastic. Now I can rest assured that my brother stands a better chance of finding the right path without that manipulating little man around. Master Lanken can rest assured that the waters are safe from abuse.");
 		#:: Give a random reward:  13122 - Erud's Tonic, 5019 - Rusty Long Sword, 6017 - Splintering Club
-		quest::summonitem(1quest::ChooseRandom(13122, 5019, 6017));
+		quest::summonitem(quest::ChooseRandom(13122, 5019, 6017));
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/erudnext/Raine_Beteria.pl
+++ b/erudnext/Raine_Beteria.pl
@@ -46,7 +46,7 @@ sub EVENT_ITEM {
 			quest::summonitem(16339);
 		}
 	}
-  	elsif (plugin::takeItems(10792 => 1)) {
+  	elsif (plugin::check_handin(\%itemcount, 10792 => 1)) {
 		quest::say("Thank you very much. I have always wanted one of these! Hehehe? just kidding. I see that you have enchanted this coin. I have placed the final enchantment on it - take it back to Romar.");
 		#:: Give a 10793 - Radiant Coin of Tash
 		quest::summonitem(10793);

--- a/erudnext/Rarnan_Lapice.pl
+++ b/erudnext/Rarnan_Lapice.pl
@@ -15,10 +15,10 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Turn in for 13991 -  Testament of Vanear
-	if (plugin::takeItems(13991 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13991 => 1)) {
 		quest::say("I sent you after that book ages ago! What took you so long? I have already completed my studies. Luckily I found the original manuscript under my bedroll. I forgot I had kept it there. Take this as a token of my apology. Maybe it will aid you in your next book hunt. I know how cunning those books can be.");
 		#:: Give a random reward: 15302 - Spell: Languid Pace, 6351 - Fine Steel Morning Star, 16647 - Aged Platinum Bloodstone Earring
-		quest::summonitem(1quest::ChooseRandom(15302, 6351, 16647));
+		quest::summonitem(quest::ChooseRandom(15302, 6351, 16647));
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/erudnext/Sinnkin_Highbrow.pl
+++ b/erudnext/Sinnkin_Highbrow.pl
@@ -12,7 +12,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 13121 - Innoruuk's Kiss of Death
-	if (plugin::takeItems(13121 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13121 => 1)) {
 		quest::say("It's about time you figured it out, genius! Maybe you should spend more time in the library. Here, take this tonic and get out of here before they see me giving it to you and turn us both inside out.");
 		#:: Give a 13118 - Erud's Tonic
 		quest::summonitem(13118);

--- a/erudnext/Vynon_Estaliun.pl
+++ b/erudnext/Vynon_Estaliun.pl
@@ -15,7 +15,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 13884 - Fishy Cat Tail
-	if (plugin::takeItems(13884 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13884 => 1)) {
 		#:: Match if faction is Amiable or better
 		if ($faction <= 4) {
 			quest::say("Good work. I knew you could do it. Take this as reward.");

--- a/erudnext/Weligon_Steelherder.pl
+++ b/erudnext/Weligon_Steelherder.pl
@@ -113,7 +113,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 18725 - Tattered Note
-	if (plugin::takeItems(18725 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18725 => 1)) {
 		quest::say("Greetings and welcome to the Deepwater Knights. Here is your guild tunic. Wear it with pride, and Prexus will keep a watchful eye on you. Go find sister Laoni, she will help you get started with your studies.");
 		#:: Give a 13544 - Old Blue Tunic*
 		quest::summonitem(13544);
@@ -127,7 +127,7 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Match a 13876 - Bag of Shark remains
-	elsif (plugin::takeItems(13876 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13876 => 1)) {
 		#:: Match if faction is Amiable or better
 		if ($faction <= 4 ) {
 			quest::say("Very good, my dear young follower of Prexus. You will learn that swimming is a strong skill among the Deepwater Knights. Keep this up and you may wield a Deepwater harpoon soon enough. For now, you shall wear this barnacle breastplate. It is strong enough to aid a young knight in his quest for perfection.");
@@ -155,12 +155,12 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Match a 13879 - Full bag of pearls
-	elsif (plugin::takeItems(13879 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13879 => 1)) {
 		#:: Match if faction is Amiable or better
 		if ($faction <= 4 ) {
 			quest::say("Fine work, Deepwater Knight. You have proven yourself an excellent addition to our ranks. These shall be used to create more Peacekeeper staffs. Oh yes, I almost forgot your reward. Here you are. Now, go, and serve Prexus.");
 			#:: Give a random reward: 2104 - Patchwork Tunic, 2106 - Patchwork Cloak, 2108 - Patchwork Sleeves, 2111 - Patchwork Pants, 2112 - Patchwork Boots
-			quest::summonitem(1quest::ChooseRandom(2104, 2106, 2108, 2111, 2112));
+			quest::summonitem(quest::ChooseRandom(2104, 2106, 2108, 2111, 2112));
 			#:: Ding!
 			quest::ding();
 			#:: Set factions
@@ -183,7 +183,7 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Match a 18835 - Sealed List, a 13838 - Human Decapitated Head, a 13839 - Dwarf Decapitated Head, and a 13840 - Gnome Decapitated Head
-	elsif (plugin::takeItems(18835 => 1, 13838 => 1, 13839 => 1, 13840 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 18835 => 1, 13838 => 1, 13839 => 1, 13840 => 1)) {
 		#:: Match if faction is Amiable or better
 		if ($faction <= 4 ) {
 			quest::say("It is done!! I pray to Prexus that the knowledge of the bridge's design has departed from this world with the passing of these intelligent men. A pity they had to die. As for you, the other states may not tolerate your presence any longer, but you have proven that allegiance to Erudin is paramount among all Erudites. I am afraid the [Deepwater harpoon] is no more!! I bestow upon you Deep Six, my personal cutlass!! May you wield it in the name of Erudin.");

--- a/erudnint/Agryn_Moonfield.pl
+++ b/erudnint/Agryn_Moonfield.pl
@@ -12,7 +12,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match 13989 - Peacekeeper Token
-	if (plugin::takeItems(13989 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13989 => 1)) {
 		quest::say("Ah!! A Peacekeeper. I have some Vasty Deep water sitting out already. Here you are. Do not let it fall into the wrong hands.");
 		#:: Give a 13939 - Clear Water
 		quest::summonitem(13939);

--- a/erudnint/Ghanlin_Skyphire.pl
+++ b/erudnint/Ghanlin_Skyphire.pl
@@ -12,7 +12,7 @@ sub EVENT_ENTER {
 	
 sub EVENT_ITEM {
 	#:: Match turn in for 18727 -  tattered note
-	if (plugin::takeItems(18727 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18727 => 1)) {
 		quest::say("Greetings. I am Ghanlin Skyphire, Master Wizard of the Crimson Hands. All of us here have devoted our lives to the studies of the arcane and mystical. Let's get you started. Here's your training robe.  Now, go find Raskena. She'll help train you and give you your first lesson.");
 		#:: Give item 13550 - Old Used Robe*
 		quest::summonitem(13550);

--- a/erudnint/Josper_Kenshed.pl
+++ b/erudnint/Josper_Kenshed.pl
@@ -37,7 +37,7 @@ sub EVENT_SAY {
 				
 sub EVENT_ITEM {
 	#:: Match a 13898 - Bag of Ice Necklaces
-	if (plugin::takeItems(13898 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13898 => 1)) {
 		#:: Match if faction is Amiable or better
 		if ($faction <= 4) {
 			quest::say("Well done, my young apprentice. I call you apprentice for you are nothing but a spark to my fire. This is the final component for my greatest creation. AHA!! I call it - iced tea!! Never again shall I boil under the hot sun. As for you, take this. It should serve you well. Now go away. There is no iced tea for you");
@@ -70,7 +70,7 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Match a 12207 - Half of a Spell
-	elsif (plugin::takeItems(12207 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 12207 => 1)) {
 		#:: Match if faction is Amiable or better
 		if ($faction <= 4) {
 			quest::say("Go now and use his research to aid yourself. Seems that I lack the will to use Ilanic's knowledge for my better good.");

--- a/erudnint/Lanken_Rjarn.pl
+++ b/erudnint/Lanken_Rjarn.pl
@@ -22,7 +22,7 @@ sub EVENT_SAY {
 	
 sub EVENT_ITEM {
 	#:: Match a 18729 - Tattered Note
-	if (plugin::takeItems(18729 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18729 => 1)) {
 		quest::say("Welcome to the Craft Keepers! You have much to learn. and I'm sure you are anxious to get started. Here's your training robe. Go see Nolusia. she'll give you your first lesson.");
 		#:: Give a 13549 - Old Patched Robe*
 		quest::summonitem(13549);

--- a/erudnint/Markus_Jaevins.pl
+++ b/erudnint/Markus_Jaevins.pl
@@ -36,7 +36,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match turn in for 18728 - Tattered Note
-	if (plugin::takeItems(18728 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18728 => 1)) {
 		quest::say("Welcome. young one! I see you show interest in the circle of magic. Nowhere upon Norrath will you find a greater school than this - the Gatecallers. You shall wear this tunic as a sign that you have begun the training of this circle. Remember, the power of the Gatecaller is the power of summoning. Go find Vasile, he will help teach you the basics of summoning. Good luck, friend!");
 		#:: Give item 13548 - Old Torn Robe*
 		quest::summonitem(13548);
@@ -51,7 +51,7 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Match turn in for 13128 - Bones
-	elsif (plugin::takeItems(13128 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13128 => 1)) {
 		quest::say("This is fine work, young one. You keep this up and you shall be knighted before long.");
 		#:: Ding!
 		quest::ding();
@@ -68,7 +68,7 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Match turn in for 13127 - Bones
-	elsif (plugin::takeItems(13127 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13127 => 1)) {
 		quest::say("This is fine work, young one. You keep this up and you shall be knighted before long.");
 		#:: Ding!
 		quest::ding();

--- a/erudnint/Raskena_Djor.pl
+++ b/erudnint/Raskena_Djor.pl
@@ -15,7 +15,7 @@ sub EVENT_ITEM {
 	if (plugin::check_handin(\%itemcount, 10307 => 2, 13250 => 2)) {
 		quest::say("You have passed your first task. Nice work. Take this spell as your payment.");
 		#:: Randomly reward 15373 - Spell: Sphere of Light, 15054 - Spell: Frost Bolt, 15205 - Spell: True North, 15288 - Spell: Minor Shielding, 15372 - Spell: Blast of Cold, 15374 - Spell: Numbing Cold
-		quest::summonitem(1quest::ChooseRandom(15373, 15054, 15205, 15288, 15372, 15374));
+		quest::summonitem(quest::ChooseRandom(15373, 15054, 15205, 15288, 15372, 15374));
 		#:: Ding!
 		quest::ding();
 		#:: Grant a small amount of XP

--- a/erudnint/Slansin.pl
+++ b/erudnint/Slansin.pl
@@ -6,7 +6,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match turn in for 13983 - Inert Potion
-	if (plugin::takeItems(13983 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13983 => 1)) {
 		#:: Create a scalar variable for mob class
 		my $mobclass = $npc->GetClass();
 		#:: Match if class is 41 - shopkeeper

--- a/erudnint/Trilani_Parlone.pl
+++ b/erudnint/Trilani_Parlone.pl
@@ -9,7 +9,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 1598 - Black Stone Candlestick
-	if (plugin::takeItems(1598 => 1)) {
+	if (plugin::check_handin(\%itemcount, 1598 => 1)) {
 		quest::say("I sense a great evil power in this candlestick. I will need you to concoct a divinatory aid for me before I can discern more. Take this suspension and brew it in a brew barrel with one white hellebore, a pouch of the red dust created by the Fire Peak Goblin Wizards, and the caustic substance used by the werebats in Unrest.");
 		#:: Give item 1596 - Magical Suspension Fluid
 		quest::summonitem(11596);
@@ -19,7 +19,7 @@ sub EVENT_ITEM {
 		quest::exp(1500);
 	}
 	#:: Match a 1597 - Divinatory Concoction
-	elsif (plugin::takeItems(1597 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 1597 => 1)) {
 		quest::emote("performs a subtle divinatory ritual. 'This is a powerful evil indeed. The smoke from special candles crafted by the Teir'Dal and burned in this candlestick allows the creation of undead of unordinary might. The Ghasts are only one of its many possible creations. I will concoct a powder for you to take back to Yeolarn that will assist in defeating the monstrosities the candle has produced. The candlestick itself will remain here within the High Tower of Erudin for the time being.'");
 		#:: Give item 1599 - Powder of Unanimation
 		quest::summonitem(11599);
@@ -34,7 +34,7 @@ sub EVENT_ITEM {
 		quest::exp(1500);
 	}
 	#:: Match a 1056 - Faded Cloak
-	elsif (plugin::takeItems(1056 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 1056 => 1)) {
 		quest::say("Oh my lord Tunare! I did not know my daughter was in trouble. I thank you for saving her. Here, I have returned the once lost power to this cloak. Wear it with my humblest gratitude.");
 		#:: Give item 1057 - Mystic Cloak
 		quest::summonitem(11057);

--- a/erudsxing/Yelesom_Paust.pl
+++ b/erudsxing/Yelesom_Paust.pl
@@ -12,7 +12,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 18173 -  Gan's Note to Yelesom
-	if (plugin::takeItems(18173 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18173 => 1)) {
 		quest::say("Gans sent you to check on me did he? Well you can tell my dear brother that the surveying has been halted. One of those furballs has stolen my tools, making my job impossible. Kerrans, kobolds, gnolls, we're constantly under siege by these primitives. Anyway, perhaps you could [help me]?");
 		#:: Ding!
 		quest::ding();
@@ -20,7 +20,7 @@ sub EVENT_ITEM {
 		quest::exp(150);
 	}
 	#:: Match a 1768 -  Yelesom's Tools
-	elsif (plugin::takeItems(1768 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 1768 => 1)) {
 		quest::say("Thank you for recovering my tools, please take this to my brother for your reward.");
 		#:: Give a 1771 - Yelesom's Reports
 		quest::summonitem(11771);

--- a/everfrost/Arnis_McLish.pl
+++ b/everfrost/Arnis_McLish.pl
@@ -34,7 +34,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 13243 - One Half of Elixir
-	if (plugin::takeItems(13243 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13243 => 1)) {
 		quest::say("Mmmm.. Thank you stranger. I feel a lot warmer now. You should now go and find [Megan] O'Reilly.");
 		#:: Give a 13244 - One Quarter of Elixir
 		quest::summonitem(13244);

--- a/everfrost/Iceberg.pl
+++ b/everfrost/Iceberg.pl
@@ -25,7 +25,7 @@ sub EVENT_COMBAT {
 
 sub EVENT_ITEM {
 	#:: Match a 12221 - Lion Delight
-	if (plugin::takeItems(12221 => 1)) {
+	if (plugin::check_handin(\%itemcount, 12221 => 1)) {
 		quest::emote("growls with happiness and licks your face.  Just enough time to swipe the sweaty shirt from his collar!!  Iceberg then runs off to enjoy his lion delight!!");
 		#:: Send a signal '2' to Everfrost Peaks >> Tundra_Jack (30061) with no delay
 		quest::signalwith(30061, 2, 0);

--- a/everfrost/Megan_OReilly.pl
+++ b/everfrost/Megan_OReilly.pl
@@ -23,7 +23,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 13244 - One Quarter of Elixir
-	if (plugin::takeItems(13244 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13244 => 1)) {
 		quest::say("Oh thank you. Sorry, but the bottle is empty now. I hope you did't need any. Take the empty bottle back to Dargon. He may refill it for you.");
 		#:: Give a 13245 - Empty Bottle of Elixir
 		quest::summonitem(13245);

--- a/everfrost/Sulgar.pl
+++ b/everfrost/Sulgar.pl
@@ -22,7 +22,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 14360 - Staff of the Wheel, and a 14361 - Star of Eyes
-	if (plugin::takeItems(14360 => 1, 14361 => 1)) {
+	if (plugin::check_handin(\%itemcount, 14360 => 1, 14361 => 1)) {
 		quest::say("Wonderful, you have brought me the Wheel. Here is the reward I promised you.");
 		#:: Give 11880 - Rune of Frost
 		quest::summonitem(11880);

--- a/fearplane/Cazic_Thule.pl
+++ b/fearplane/Cazic_Thule.pl
@@ -15,7 +15,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 8226 - Satchel of Cazic-Thule, a 18898 - Flayed Skin Tome, and a 18899 - Flayed Skin Tome
-	if (plugin::takeItems(8226 => 1, 18898 => 1, 18899 => 1)){
+	if (plugin::check_handin(\%itemcount, 8226 => 1, 18898 => 1, 18899 => 1)){
 		quest::emote("seems pleased with the amount of pain that you have been able to inflict. Cazic Thule then grabs your hands and begins to infuse them with his power. Your hands burn like they were placed in lava for a moment, then feel cool as ice. You can feel the sheer power flowing through your new weapons of pain.");
 		#:: Give a 7836 - Whistling Fists
 		quest::summonitem(17836);

--- a/fearplane/a_broken_golem.pl
+++ b/fearplane/a_broken_golem.pl
@@ -1,5 +1,5 @@
 sub EVENT_ITEM {
-	if (plugin::takeItems(14319 => 1)) {
+	if (plugin::check_handin(\%itemcount, 14319 => 1)) {
 		quest::say("Error! Malfunction! Destroy!");
 		quest::say("A $class like you always brings out the worst in me.");
 		#:: Spawn a The Plane of Fear >> an_enraged_golem (72106) at the current location

--- a/feerrott/Innkeep_Gub.pl
+++ b/feerrott/Innkeep_Gub.pl
@@ -17,7 +17,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 1839 - Full Muffin Crate
-	if (plugin::takeItems(1839 => 1)) {
+	if (plugin::check_handin(\%itemcount, 1839 => 1)) {
 		quest::say("MMmmm... Deez look like gud muffins. Here's sum money. Tanks. Now meez all stocked again.");
 		#:: Ding!
 		quest::ding();
@@ -35,7 +35,7 @@ sub EVENT_ITEM {
 		quest::MerchantSetItem(47114, 13014, 20);
 	}
 	#:: Match a 1838 - Bag of Bread Loaves
-	elsif (plugin::takeItems(1838 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 1838 => 1)) {
 		quest::say("You take some money. Weeze happy now dat weeze got more bread for sale. You maybe check back later if weeze run out of bread again.");
 		#:: Ding!
 		quest::ding();

--- a/feerrott/Innkeep_Morpa.pl
+++ b/feerrott/Innkeep_Morpa.pl
@@ -17,7 +17,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 1839 - Full Muffin Crate
-	if (plugin::takeItems(1839 => 1)) {
+	if (plugin::check_handin(\%itemcount, 1839 => 1)) {
 		quest::say("Nice muffins, very stinky. Weeze tank you. Here some money. Weeze need more muffins later. You check back again sum time.");
 		#:: Ding!
 		quest::ding();
@@ -35,7 +35,7 @@ sub EVENT_ITEM {
 		quest::MerchantSetItem(47145, 13014, 20);
 	}
 	#:: Match a 1838 - Bag of Bread Loaves
-	elsif (plugin::takeItems(1838 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 1838 => 1)) {
 		quest::say("You nice for getting bread loaves for us. You take some money. Weeze happy now dat weeze got more bread for sale. You maybe check back later if weeze run out of bread again");
 		#:: Ding!
 		quest::ding();

--- a/felwithea/General_Jyleel.pl
+++ b/felwithea/General_Jyleel.pl
@@ -21,10 +21,10 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Turn in for the Illegible Scroll Quest, 13225 Illegible Scroll
-	if (plugin::takeItems(13225=> 1)) {
+	if (plugin::check_handin(\%itemcount, 13225=> 1)) {
 		quest::say("Very fine work. A pity you are not Koada'Vie. Here is a small reward for you. Anytime you come upon an oracle. remember to return its scroll to me. Go and find your fate on the field of battle.");
 		#:: Randomly choose Spell: Minor Healing, Spell: Invisibility, Spell: Endure Disease, Rotted Illegible Scroll, Spell: Lesser Shielding, Spell: Serpent Sight
-		quest::summonitem(1quest::ChooseRandom(15200, 15042, 15226, 13360, 15246, 15276));
+		quest::summonitem(quest::ChooseRandom(15200, 15042, 15226, 13360, 15246, 15276));
 		#:: Give a little xp
 		quest::exp(500);
 		#:: Ding!
@@ -39,7 +39,7 @@ sub EVENT_ITEM {
 		quest::faction(5001,25); 		#:: + Anti Mage
 	}
 	#:: Turn in for the Orc Runner Quest , 13226 Runner Pouch
-	if (plugin::takeItems(13226=> 1)) {
+	if (plugin::check_handin(\%itemcount, 13226=> 1)) {
 		quest::say("So, you succeeded in stopping a Crushbone runner! That is good. Now take this as reward. Keep up your fine work. The people of Felwithe are grateful.");
 		#:: Give a little xp
 		quest::exp(500);
@@ -55,7 +55,7 @@ sub EVENT_ITEM {
 		quest::faction(5001,7); 		#:: + Anti Mage
 	}
 	#:: Turn in for the Orc Runner Quest , 18840 A Sealed Letter
-	if (plugin::takeItems(18840=> 1)) {
+	if (plugin::check_handin(\%itemcount, 18840=> 1)) {
 		quest::say("So, the Teir'Dal are behind the recent advances of the orcs?!! Your news has shed light on their union. It is time to step forth and prove yourself a [faithful paladin of this court].");
 		#:: Give a little xp
 		quest::exp(500);
@@ -67,7 +67,7 @@ sub EVENT_ITEM {
 		quest::faction(5001,3); 		#:: + Anti Mage
 	}
 	#:: Turn in for the Falchion Quest , 12330 A Large Locked Crate, 12329 Blue Orc Head, 13227 Black Heart
-	if (plugin::takeItems(12330 => 1, 12329 => 1, 13227 => 1)) {
+	if (plugin::check_handin(\%itemcount, 12330 => 1, 12329 => 1, 13227 => 1)) {
 		quest::say("A noble deed has been done and the alliance of evil has been stalled. I present you with the falchion of the Koada`Vie. You are now an honorable member of our order. Hail Felwithe, and may you defender her with honor.");
 		#:: Give item 5379 - Falchion of the KoadaVie*
 		quest::summonitem(15379);

--- a/felwithea/Guard_Settine.pl
+++ b/felwithea/Guard_Settine.pl
@@ -1,6 +1,6 @@
 sub EVENT_ITEM {
 	#:: Match item 18901 - Ragged Cloth Note
-	if (plugin::takeItems(18901 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18901 => 1)) {
 		quest::say("I.. but.. she.. You can take this. I guess I don't need it any more.");
 		#:: Ding!
 		quest::ding();

--- a/felwithea/Tolkar_Parlone.pl
+++ b/felwithea/Tolkar_Parlone.pl
@@ -15,7 +15,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Turn in for 5573 -  A Folded Note
-	if (plugin::takeItems(5573 => 1)) {
+	if (plugin::check_handin(\%itemcount, 5573 => 1)) {
 		quest::say("Oh, my, she did get herself into some trouble! I thank you for rescuing her, my friend. Here, take this old cloak. I am afraid its power has faded, but if you bring it to my wife, she might be able to do something for you. She is currently studying in Erudin.");
 		#:: Ding!
 		quest::ding();

--- a/felwithea/Tolon_Nurbyte.pl
+++ b/felwithea/Tolon_Nurbyte.pl
@@ -62,7 +62,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 18841 - Sealed Letter
-	if (plugin::takeItems(18841 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18841 => 1)) {
 		quest::say("So I see you completed your mission. Good work. You just may be a member of the Silent Watch someday. Well my friend. I will be keeping my eye on you. No doubt we will meet again. Oh, I almost forgot. The Princess wanted you to have this. Now show yourself the door.");
 		#:: Give a 13353 - Thex Dagger
 		quest::summonitem(13353);

--- a/felwithea/Tynkale.pl
+++ b/felwithea/Tynkale.pl
@@ -60,7 +60,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Turn in for 18781 -  A Tattered Note
-	if (plugin::takeItems(18781 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18781 => 1)) {
 		quest::say("Greetings. young paladin!  I am Master Tynkale of the Clerics of Tunare.  Here, we shall teach and train you in the skills needed to defeat our evil and diseased enemies.  Take this, our guild tunic - it will help protect you.  Once you are ready to begin your training please make sure that you see Seria Woodwind, she can assist you in experienced in our art, I will be able to further instruct you on how to progress through your early ranks, as well as in some of the various [trades] you will have available to you.");
 		#:: Give item 13591 - Used Gold Training Tunic*
 		quest::summonitem(13591);
@@ -74,7 +74,7 @@ sub EVENT_ITEM {
 		quest::faction(5001,75); 		#:: + Anti-mage
 	}
 	#:: Turn in for 13351 -  A Very Large Pelt
-	if (plugin::takeItems(13351 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13351 => 1)) {
 		#:: Match if faction is better than indifferent
 		if ($faction < 5) {
 			quest::say("So you have proven yourself to be a great slayer of beasts. Now it is time to prove yourself to be an asset to the Crown. You are to meet a man named Tolon Nurbyte, he will be at the local inn. Go to him and repeat the phrase, 'The glory of the Mother shines bright.' I can say no more.");

--- a/felwithea/Yeolarn_Bronzeleaf.pl
+++ b/felwithea/Yeolarn_Bronzeleaf.pl
@@ -44,7 +44,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Turn in for 18780 -  A Tattered Note
-	if (plugin::takeItems(18780 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18780 => 1)) {
 		quest::say("Welcome, friend, to the Clerics of Tunare. I am Yeolarn Bronzeleaf, head of the guild and devout follower of Tunare. Here is your guild tunic - it will help to protect you against this world's evils. Once you are ready to begin your training please make sure that you see Terren Starwatcher, he can assist you in developing your hunting and gathering skills. Return to me when you have become more experienced in our art, I will be able to further instruct you on how to progress through your early ranks, as well as in some of the various [trades] you will have available to you.");
 		#:: Ding!
 		quest::ding();
@@ -58,7 +58,7 @@ sub EVENT_ITEM {
 		quest::faction(5001,75); 		#:: + Anti-mage
 	}
 	#:: Turn in for 13073 - Bone Chips x4
-	if (plugin::takeItems(13073 => 4)) {
+	if (plugin::check_handin(\%itemcount, 13073 => 4)) {
 		quest::say("Praise Tunare! I knew you would be victorious. I reward you with this spell, and pray that it will help you in your fight against the unholy forces of Innoruk. When you are ready you will make a fine [Initiate of Tunare].");
 		#:: Ding!
 		quest::ding();
@@ -72,7 +72,7 @@ sub EVENT_ITEM {
 		quest::faction(5001,15); 		#:: + Anti-mage
 	}
 	#:: Turn in for 10199 - Putrescent Heart x4
-	if (plugin::takeItems(10199 => 4)) {
+	if (plugin::check_handin(\%itemcount, 10199 => 4)) {
 		quest::say("Praise Tunare!! You have done well young Initiate. Here the symbol of your station within our faith. Return to me when you are ready to [slay the necromancer] that has been creating the undead.");
 		#:: Ding!
 		quest::ding();
@@ -86,7 +86,7 @@ sub EVENT_ITEM {
 		quest::faction(5001,15); 		#:: + Anti-mage
 	}
 	#:: Turn in for 1570, 12514, 19065, 12513 -  Initiate Symbol of Tunare, Larik Z`Vole's Head, Teir`Dal Couriers Head, Teir`Dal Crate
-	if (plugin::takeItems(1570 => 1, 12514 => 1, 19065 => 1, 12513 => 1)) {
+	if (plugin::check_handin(\%itemcount, 1570 => 1, 12514 => 1, 19065 => 1, 12513 => 1)) {
 		quest::say("Praise Tunare! The Mother smiles on you this day Disciple Angelsyn! I present you with the symbol of your new station among the Priests of Tunare. Return to me when you are ready to become a [Warden of Tunare]?");
 		#:: Ding!
 		quest::ding();
@@ -100,7 +100,7 @@ sub EVENT_ITEM {
 		quest::faction(5001,15); 		#:: + Anti-mage
 	}
 	#:: Turn in for 1571, 1599 -  Disciple Symbol of Tunare, Powder of Unanimation
-	if (plugin::takeItems(1571 => 1, 1599 => 1)) {
+	if (plugin::check_handin(\%itemcount, 1571 => 1, 1599 => 1)) {
 		quest::say("Praise Tunare!! I will have our sorcerers examine this power immediately to see if we can reproduce it in quantities enough to eliminate the undead plague. I award you the rank of Warden of Tunare, the All Mother smiles upon you, $name!");
 		#:: Ding!
 		quest::ding();

--- a/felwitheb/Kinool_Goldsinger.pl
+++ b/felwitheb/Kinool_Goldsinger.pl
@@ -46,7 +46,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 18778 - Enrollment Letter
-	if (plugin::takeItems(18778 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18778 => 1)) {
 		quest::say("Greetings and welcome aboard!  My name's Kinool. Master Enchanter of the Keepers of the Art.  Here is your guild tunic. Make us proud, young pupil! Once you are ready to begin your training please make sure that you see Yuin Starchaser, he can assist you in developing your hunting and gathering skills. Return to me when you have become more experienced in our art, I will be able to further instruct you on how to progress through your early ranks, as well as in some of the various [trades] you will have available to you.");
 		#:: Give item 13593 - Torn Training Robe*
 		quest::summonitem(13593);

--- a/felwitheb/Niola_Impholder.pl
+++ b/felwitheb/Niola_Impholder.pl
@@ -31,10 +31,10 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Turn in for 13068 -  Bat Wings
-	if (plugin::takeItems(13068 => 4)) {
+	if (plugin::check_handin(\%itemcount, 13068 => 4)) {
 		quest::say("Ah yes.  These are exactly what I need.  Thank you very much.");
 		#:: Give random item 15310 or 15332 - Spell: Flare or Spell: Shield of Fire
-		quest::summonitem(1quest::ChooseRandom(15310,15332));
+		quest::summonitem(quest::ChooseRandom(15310,15332));
 		#:: Ding!
 		quest::ding();
 		#:: Set faction
@@ -46,7 +46,7 @@ sub EVENT_ITEM {
 		quest::exp(40);
 	}
 	#:: Turn in for 18777 -  Enrollment Letter
-	elsif (plugin::takeItems(18777 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 18777 => 1)) {
 		quest::say("Welcome. I am Niola Impholder. Master Magician of the Keepers of the Art. Here is our guild tunic. Once you are ready to begin your training please make sure that you see Yuin Starchaser, he can assist you in developing your hunting and gathering skills. Return to me when you have become more experienced in our art, I will be able to further instruct you on how to progress through your early ranks, as well as in some of the various [trades] you will have available to you.");
 		#:: Give item 13592 - Faded Training Robe*
 		quest::summonitem(13592);
@@ -61,7 +61,7 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Turn in for 18902 -  Torn Drawing
-	elsif (plugin::takeItems(18902 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 18902 => 1)) {
 		quest::say("What? Not as supposed? What can he... Well, that's all well and good. You, I assume, wish a reward for your 'valiant work'? Well, here you go, adventurer.");
 		#:: Give item 1307 - Gossamer Robe
 		quest::summonitem(11307);

--- a/felwitheb/Tarker_Blazetoss.pl
+++ b/felwitheb/Tarker_Blazetoss.pl
@@ -31,7 +31,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Turn in for 18779 -  Enrollment letter
-	if (plugin::takeItems(18779 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18779 => 1)) {
 		quest::say("Welcome to the wizards' guild of the Keepers of the Art. My name's Tarker, and I run this guild. You've got a lot of training ahead of you, so let's get started. Here, take this - it's our guild tunic. Wear it with honor, friend. Once you are ready to begin your training please make sure that you see Yuin Starchaser, he can assist you in developing your hunting and gathering skills. Return to me when you have become more experienced in our art, I will be able to further instruct you on how to progress through your early ranks, as well as in some of the various [trades] you will have available to you.");
 		#:: Give item 13594 - Singed Training Robe*
 		quest::summonitem(13594);
@@ -46,10 +46,10 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Turn in for 13758 - Black Wolf Skin
-	elsif (plugin::takeItems(13758 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13758 => 1)) {
 		quest::say("Ah yes.  This is exactly what I need.  Thank you very much.");
 		#:: Randomly choose Rusty Dagger, Bandages, Simple Copper Ring, Spell: Numbing Cold, Worn Great Staff
-		quest::summonitem(1quest::ChooseRandom(7007,13009,58094,59964,6012));
+		quest::summonitem(quest::ChooseRandom(7007,13009,58094,59964,6012));
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/freporte/10000.pl
+++ b/freporte/10000.pl
@@ -1,6 +1,6 @@
 sub EVENT_ITEM {
 	#:: Turn in of Large Crate of Mining Supplies 19930 for Rogue Errands Quest - spawned by Rigg_Nostra
-	if (plugin::takeItems(19930 => 1)) {
+	if (plugin::check_handin(\%itemcount, 19930 => 1)) {
 		quest::say("Arg");
 		#:: Give a 19918 - Rough Blue Gem
 		quest::summonitem(19918);

--- a/freporte/Beur_Tenlah.pl
+++ b/freporte/Beur_Tenlah.pl
@@ -16,7 +16,7 @@ sub EVENT_SIGNAL {
 
 sub EVENT_ITEM {
 	#:: Turn in for 13036 -  Dwarven Ale
-	if (plugin::takeItems(13036 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13036 => 1)) {
 		quest::say("Well, well, well.. It's about time. Whatta ya got, boots fulla stones? Or maybe yer just part turtle? Bah, anyways, thanks for the ale. Maybe I'll buy you one sometime, eh? Bwahaha!");
 		#:: Ding!
 		quest::ding();

--- a/freporte/Brutol_Rhaksen.pl
+++ b/freporte/Brutol_Rhaksen.pl
@@ -16,7 +16,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 18857 - A Tattered Note
-	if (plugin::takeItems(18857 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18857 => 1)) {
 		quest::say("Hahaha... I sure hope you prove more valuable than you look, little one. Once you are ready to begin your training please let me know and I will get you started. I will be able to further instruct you on how to progress through your early ranks, as well as in some of the various [trades] you will have available to you.");
 		#:: Give a 13561 - Faded Crimson Tunic
 		quest::summonitem(13561);

--- a/freporte/Elisi_Nasin.pl
+++ b/freporte/Elisi_Nasin.pl
@@ -11,7 +11,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 18745 - A Tattered Note
-	if (plugin::takeItems(18745 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18745 => 1)) {
 		quest::say("Welcome to the Coalition of Tradesfolk underground. We like to keep a low profile around here and not draw any unneeded attention to our operations. you following me? I hope so, for your sake, Anyways, Nestral T'Gaza is in charge with helping out our newest members. Go see her as soon as you get a chance.");
 		#:: Give item 13568 - Brown Faded Tunic
 		quest::summonitem(13568);

--- a/freporte/Fabian.pl
+++ b/freporte/Fabian.pl
@@ -18,7 +18,7 @@ sub EVENT_ITEM {
 		quest::faction(285, -1);		#:: - Mayong Mistmoore
 	}
 	#:: Match 13709 - Lute Strings
-	if (plugin::takeItems(13709 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13709 => 1)) {
 #::		2007 Release Era Addition to Quest
 #::		my $random_lute_strings_message = int(rand(5)) + 1;
 #::		if ($random_lute_strings_message == 4) {
@@ -43,7 +43,7 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum}); 
 	}
 #::	#:: 2007 era quest addition Match a 13710 - Etched Silver Coin
-#::	if (plugin::takeItems(13710 => 1)) {
+#::	if (plugin::check_handin(\%itemcount, 13710 => 1)) {
 #::		quest::say("'My lucky coin! How did it get in there? Well, never mind that. You are an honest person and although honesty is its own reward, I feel obligated to return the favor. Take this to Dionna if you enjoy music. Farewell friend!");
 #::		#:: Give a 13708 - Note from Fabian
 #::		quest::summonitem(13708);

--- a/freporte/Giz_Dinree.pl
+++ b/freporte/Giz_Dinree.pl
@@ -9,7 +9,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 18844 - Sealed Letter
-	if (plugin::takeItems(18844 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18844 => 1)) {
 		quest::say("I am glad to see you. We have a problem. The last runner and I attempted to carry the chest from a boat. It fell overboard! He went in after it, but the sharks made a meal of him. If you want to try and get it, it is down below in the water in the harbor. Be careful.");
 	}
 	#:: Return unused items

--- a/freporte/Gregor_Nasin.pl
+++ b/freporte/Gregor_Nasin.pl
@@ -30,7 +30,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Turn in for 13118. 13382, 13952, 13340 -  Erud's Tonic - Koalindl Fish - Honey Jum - Kiola Nut
-	if (plugin::takeItems(13118 => 1, 13383 => 1, 13952 => 1, 13340 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13118 => 1, 13383 => 1, 13952 => 1, 13340 => 1)) {
 		quest::say("Now I have every ingredient mentioned in the Barkeep Compendium. Here. You take it. <..click!.> Whoops!! I just closed it. It's magically sealed, I never closed it before. It's useless to you. I have no need for it any longer. Maybe you can return it to [Clurg] for some type of reward.");
 		#:: Give item 13379 - Barkeep Compendium
 		quest::summonitem(13379);

--- a/freporte/Gren_Frikniller.pl
+++ b/freporte/Gren_Frikniller.pl
@@ -17,7 +17,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Turn in for 13159 -  Broken Heirloom Necklace
-	if (plugin::takeItems(13159 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13159 => 1)) {
 		quest::say("What's this? Oh, ol' Grandpa Frikniller's lucky necklace, huh? I'll bet this broken piece of junk won't even get me a sip of ale up at the bar. And lucky? How lucky could this thing be? Poor gramps was lonely and copperless his whole life. Bah!! Oh, well. Here's some coin for your efforts, thanks, $name.");
 		#:: Ding!
 		quest::ding();

--- a/freporte/Groflah_Steadirt.pl
+++ b/freporte/Groflah_Steadirt.pl
@@ -18,7 +18,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 18818 - Tattered Flier
-	if (plugin::takeItems(18818 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18818 => 1)) {
 		quest::say("This used to be hanging in Zimel's Blades. It is the price list. It is badly faded though. There was a fire in Zimel's Blades and I was on the scene just afterward. I did not see this hanging. I wonder who took it . . . Hmmmm.. oh, yes.. the markings on the list! It is a code! Here. I will fill it in. Read it. You probably do not even know who [Ariska] is.");
 		#:: Give item 18819 - Tattered Flier
 		quest::summonitem(18819);
@@ -33,7 +33,7 @@ sub EVENT_ITEM {
 		quest::exp(15);
 	}
 	#:: Match four 12114 - Trumpy Tonic
-	elsif (plugin::takeItems(12114 => 4)) {
+	elsif (plugin::check_handin(\%itemcount, 12114 => 4)) {
 		quest::say("Ahh! I missed those. I was just telling myself the other... Uh oh! I have to use the little dwarf's facilities. Excuse me.' ");
 		#:: Ding!
 		quest::ding();
@@ -50,7 +50,7 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Match three 12114 - Trumpy Tonic
-	elsif (plugin::takeItems(12114 => 3)) {
+	elsif (plugin::check_handin(\%itemcount, 12114 => 3)) {
 		quest::say("Ahh! I missed those. I was just telling myself the other... Uh oh! I have to use the little dwarf's facilities. Excuse me.");
 		#:: Ding!
 		quest::ding();
@@ -67,7 +67,7 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});	
 	}	
 	#:: Match two 12114 - Trumpy Tonic
-	elsif (plugin::takeItems(12114 => 2)) {
+	elsif (plugin::check_handin(\%itemcount, 12114 => 2)) {
 		quest::say("Ahh! I missed those. I was just telling myself the other... Uh oh! I have to use the little dwarf's facilities. Excuse me. ");
 		#:: Ding!
 		quest::ding();
@@ -84,7 +84,7 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});	
 	}	
 	#:: Match a 12114 - Trumpy Tonic
-	elsif (plugin::takeItems(12114 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 12114 => 1)) {
 		quest::say("Ahh! I missed those. I was just telling myself the other... Uh oh! I have to use the little dwarf's facilities. Excuse me.");
 		#:: Ding!
 		quest::ding();

--- a/freporte/Harkin_Duskfoot.pl
+++ b/freporte/Harkin_Duskfoot.pl
@@ -30,7 +30,7 @@ sub EVENT_SIGNAL {
 
 sub EVENT_ITEM {
 	#:: Match a 18016 - Note to Harkin
-	if (plugin::takeItems(18016 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18016 => 1)) {
 		quest::say("Ah, good work, $name. And quick too, I'll makes sure that Elisi hears of your loyal work. Here... take this for your efforts.. it's not much, but it's all I have on me right now.");
 		#:: Give item 1054 - Used Merchants Gloves
 		quest::summonitem(11054);

--- a/freporte/Heneva_Jexsped.pl
+++ b/freporte/Heneva_Jexsped.pl
@@ -16,7 +16,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 18855 -  A Tattered note
-	if (plugin::takeItems(18855 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18855 => 1)) {
 		quest::say("Welcome, friend. I see more than a slight glimmer of hate in your eyes. Good, for we have much work to do. Once you are ready to begin your training please make sure that you see Marv Orilis, he can assist you in developing your hunting and gathering skills. Return to me when you have become more experienced in our art, I will be able to further instruct you on how to progress through your early ranks, as well as in some of the various [trades] you will have available to you.");
 		#:: Give item 13565 - Old Stained Robe*
 		quest::summonitem(13565);

--- a/freporte/Jheron_Felkis.pl
+++ b/freporte/Jheron_Felkis.pl
@@ -9,7 +9,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Turn in for 18508 -  Tesch Val Compilation
-	if (plugin::takeItems(18508 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18508 => 1)) {
 		quest::say("So you are from Umvera! What is this? Oh my! Intersting! I'll bind them right away! A little snip here..a little snip there.. All done! That didn't take long, did it? I won't be doing this forever, you know. After the milita burned down my father's home, he could not afford to send me through proper schooling. Ah well, such is life!");
 		#:: Give item 18510 - Pawbook
 		quest::summonitem(18510);

--- a/freporte/Jyle_Windshot.pl
+++ b/freporte/Jyle_Windshot.pl
@@ -9,10 +9,10 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 13003 - Small Lantern
-	if (plugin::takeItems(13003 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13003 => 1)) {
 		quest::say("Thanks, friend. I have run a long way to get here in time. Mostly at night. I lost my lantern in a card game in Highkeep.");
 		#:: Randomly choose from Wooden Shards 90% chance, or A Wooden Heart 10% chance
-		quest::summonitem(1quest::ChooseRandom(13824, 13824, 13824, 13824, 13824, 13824, 13824, 13824, 13824, 12334));
+		quest::summonitem(quest::ChooseRandom(13824, 13824, 13824, 13824, 13824, 13824, 13824, 13824, 13824, 12334));
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/freporte/Konious_Eranon.pl
+++ b/freporte/Konious_Eranon.pl
@@ -6,7 +6,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 18856 - A tattered Note
-	if (plugin::takeItems(18856 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18856 => 1)) {
 		quest::say("Hey, Nex, we got another sucker.. er.. volunteer, that is, to help us out around here. Here ya go friend, put this on and let's whip you into shape.");
 		#:: Give item 13566 - Blood Spotted Robe*
 		quest::summonitem(13566);

--- a/freporte/Lenka_Stoutheart.pl
+++ b/freporte/Lenka_Stoutheart.pl
@@ -86,7 +86,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 13818 - Boat Beakon
-	if (plugin::takeItems(13818 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13818 => 1)) {
 		quest::say("Oh!! You must work for that Erudite named Palatos. I guess he won't have to spend anymore money drinking in Freeport. Here. Here is the portrait I kept until he could get me a new boat beacon.");
 		#:: Give item 12146 - Ak'anon's Portrait
 		quest::summonitem(12146);
@@ -101,10 +101,10 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Match a 13814 - L.S. Pouch
-	elsif (plugin::takeItems(13814 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13814 => 1)) {
 		quest::say("You found my pouch! Thanks kid. Let me buy you A drink and this is for the good work. Hmmmm. It looks as though they took my voucher. Darn it! Hey... It looks like they were using my bag to hold items they were stealing. Here you go. You can have it. It looks like junk.");
 		#:: Give a random reward:  13922 - Snapped Pole or 13923 - Moggok's Right Eye
-		quest::summonitem(1quest::ChooseRandom(13922, 13923));
+		quest::summonitem(quest::ChooseRandom(13922, 13923));
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/freporte/Nestral_TGaza.pl
+++ b/freporte/Nestral_TGaza.pl
@@ -14,7 +14,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 13158 - Rebby's Rat Whiskers
-	if (plugin::takeItems(13158 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13158 => 1)) {
 		quest::say("Thank you $name, You have done well.");
 		#:: Ding!
 		quest::ding();

--- a/freporte/Netuk_Phenzon.pl
+++ b/freporte/Netuk_Phenzon.pl
@@ -9,7 +9,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Turn in for 18818 - Tattered Flier
-	if (plugin::takeItems(18818 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18818 => 1)) {
 		quest::say("It is about time you returned! Innoruuk would be proud of the red you have spread upon the land.");
 		#:: Give item 15343 - Spell: Siphon Strengh
 		quest::summonitem(15343);

--- a/freporte/Nexvok_Thirod.pl
+++ b/freporte/Nexvok_Thirod.pl
@@ -6,7 +6,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 18854 - A tattered note
-	if (plugin::takeItems(18854 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18854 => 1)) {
 		quest::say("Ah ha.. Fresh meat. here, put this on.. you're one of us now. Do your best to do your worst.");
 		#:: Give item 13564 - Dirty Torn Robe*
 		quest::summonitem(13564);

--- a/freporte/Olunea_Miltin.pl
+++ b/freporte/Olunea_Miltin.pl
@@ -9,7 +9,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 13922 - Snapped Pole
-	if (plugin::takeItems(13922 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13922 => 1)) {
 		quest::say("Great! Thank you stranger. The rogues must have broken it. At least I could repair it. It would be seasons before I could afford another pole.");
 		#:: Ding!
 		quest::ding();

--- a/freporte/Opal_Darkbriar.pl
+++ b/freporte/Opal_Darkbriar.pl
@@ -6,7 +6,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 18742 - A tattered note
-	if (plugin::takeItems(18742 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18742 => 1)) {
 		quest::say("Welcome to the Guild, here's your guild robe. Now, let's get to work.");
 		#:: Give item 13562 - Dark Stained Robe
 		quest::summonitem(13562);

--- a/freporte/Palatos_Kynarn.pl
+++ b/freporte/Palatos_Kynarn.pl
@@ -15,7 +15,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match four 13817 - Capt. Orlin's Spiced Ale
-	if (plugin::takeItems(13817 => 4)) {
+	if (plugin::check_handin(\%itemcount, 13817 => 4)) {
 		quest::say("Ahh... I... <Hic!> Need help... <Hic!> You... take this... Go build... boat beacon. <Hic!> Ask gnomes about... <Hic!> boat beacon. They know how... Then bring back... <Hic!> Unnnhh! Prexus help me! I will never drink again.");
 		#:: Give item 12145 - Beacon Mount
 		quest::summonitem(12145);
@@ -30,7 +30,7 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Match a 13818 - Boat Beacon
-	elsif (plugin::takeItems(13818 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13818 => 1)) {
 		quest::say("Thanks.. That saved me a lot of money. Now I can spend more time with the captain before I give this back to Lenka Stoutheart. Here is a little so...mething.");
 		#:: Ding!
 		quest::ding();
@@ -47,7 +47,7 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Match a 12146 - Ak'Anon's Portrait
-	elsif (plugin::takeItems(12146 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 12146 => 1)) {
 		quest::say("Wise decision!! Little reward for a large deed. Bye.");
 		#:: Ding!
 		quest::ding();

--- a/freporte/Pietro_Zarn.pl
+++ b/freporte/Pietro_Zarn.pl
@@ -16,7 +16,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 18743 - A tattered Note
-	if (plugin::takeItems(18743 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18743 => 1)) {
 		quest::say("A new member to carry the rage of Innoruuk into the city and beyond. How wonderful. I must admit that you do not appear to carry the rage within. Hopefully you shall color the battlefields with the blood of many knights from the Hall of Truth. Here. Wear this tunic with pride. Once you are ready to begin your training please make sure that yo see Gunex Eklar, he can assist you in developing your hunting and gathering skills. Return to me when you have become more experienced in our art, I will be able to further instruct you on how to progress through your early ranks, as well as in some of the various [trades] you will have available to you.");
 		#:: Give item 13561 - Faded Crimson Tunic
 		quest::summonitem(13561);
@@ -30,7 +30,7 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Match a 18961 - Translated Parchment
-	elsif (plugin::takeItems(18961 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 18961 => 1)) {
 		quest::say("ou have proven yourself truly evil. Your hatred shall shine from this day forth. Innoruuk commands that I reward you with this. It is called Rage and it serves the powers of hate. Use it to smite the forces of good. Hail Innoruuk!");
 		#:: Give item 12153 - Rage War Maul
 		quest::summonitem(12153);

--- a/freporte/Raltur_Caliskon.pl
+++ b/freporte/Raltur_Caliskon.pl
@@ -12,7 +12,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 18822 - A Note
-	if (plugin::takeItems(18822 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18822 => 1)) {
 		quest::say("So the great Antonius Bayle wishes to ally himself with the mighty Knights of Truth. How pathetic. It would appear that the alliance has spawned infiltrators of sorts. Of course, we of the Dismal Rage are already aware of this, but I am sure Sir Lucan D'Lere knows nothing as usual. I have a [mission] for any evil shadowknight of Innoruuk.");
 		#:: Ding!
 		quest::ding();
@@ -28,7 +28,7 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Match a 18810 - Bayle List III
-	elsif (plugin::takeItems(18810 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 18810 => 1)) {
 		#:: Data bucket to make sure this reward is only granted once
 		$key = $client->CharacterID() . "-bayle-list-iii";
 		#:: Match if the key exists

--- a/freporte/Tohsan_Hallard.pl
+++ b/freporte/Tohsan_Hallard.pl
@@ -9,10 +9,10 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match four 13885 - Orc Pawn Pick
-	if (plugin::takeItems(13885 => 4)) {
+	if (plugin::check_handin(\%itemcount, 13885 => 4)) {
 		quest::say("As I promised, some silver and of course, the Highpass lottery ticket. Oh yes, I forgot to mention the ticket was for last season's lottery. Ha Ha!! You now own a losing Highpass lottery ticket, lucky you! Ha!!");
 		#:: Give a random reward: 12264 - Lottery Ticket # 14350, 12265 - Lottery Ticket # 14001, 12261 - Lottery Ticket # 15600, 12262 - Lottery Ticket # 15601, 12263 - Lottery Ticket # 15602, 12266 - Lottery Ticket # 16568
-		quest::summonitem(1quest::ChooseRandom(12264, 12265, 12261, 12262, 12263, 12266));
+		quest::summonitem(quest::ChooseRandom(12264, 12265, 12261, 12262, 12263, 12266));
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/freporte/Tykar_Renlin.pl
+++ b/freporte/Tykar_Renlin.pl
@@ -29,7 +29,7 @@ sub EVENT_SIGNAL {
 
 sub EVENT_ITEM {
 	#:: Match four 13829 - Drom's Champagne
-	if (plugin::takeItems(13829 => 4)) {
+	if (plugin::check_handin(\%itemcount, 13829 => 4)) {
 		quest::say("Ahh!! That was good. Now where were we?. Oh yes. My friend Zimel is a fellow beggar. He was locked up in the arena. They were going to let him go when the Freeport Militia came for him. Ha!! He is crazy as a troll now. I took this blanket from his cell before I was released. I no longer need it and my guilt has reached its peak. I do not want crazy old Zimel to freeze. Perhaps you can return it to him.");
 		#:: Give item 12196 - Bunker Cell #1 (Zimel's Blanket)
 		quest::summonitem(12196);
@@ -39,7 +39,7 @@ sub EVENT_ITEM {
 		quest::exp(10);
 	}
 	#:: Match three 13829 - Drom's Champagne
-	elsif (plugin::takeItems(13829 => 3)) {
+	elsif (plugin::check_handin(\%itemcount, 13829 => 3)) {
 		if ($ItemCount < 1) {
 			quest::say("Oooh!! That is the taste. My lips are almost loose. Maybe another will do the trick.");
 			#:: Increment the item count variable
@@ -60,7 +60,7 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Match two 13829 - Drom's Champagne
-	elsif (plugin::takeItems(13829 => 2)) {
+	elsif (plugin::check_handin(\%itemcount, 13829 => 2)) {
 		if ($ItemCount < 2) {
 			quest::say("Oooh!! That is the taste. My lips are almost loose. Maybe another will do the trick.");
 			#:: Increment the item count variable
@@ -80,7 +80,7 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Match one 13829 - Drom's Champagne
-	elsif (plugin::takeItems(13829 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13829 => 1)) {
 		if ($ItemCount < 3) {
 			quest::say("Oooh!! That is the taste. My lips are almost loose. Maybe another will do the trick.");
 			#:: Increment the item count variable

--- a/freporte/Venox_Tarkog.pl
+++ b/freporte/Venox_Tarkog.pl
@@ -15,7 +15,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Turn in for 18744 -  A tattered note
-	if (plugin::takeItems(18744 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18744 => 1)) {
 		quest::say("Here we find a new follower.. Here we find a tunic of the Dismal Rage. Put the two together and let the hate grow. Let it be known from now on that your soul belongs to the Prince of Hate, Innoruuk. It is his power which flows within you. Destroy all those who oppose us. Please introduce your hate to the others in this shrine.");
 		#:: Give item 13561 - Faded Crimson Tunic
 		quest::summonitem(13561);

--- a/freporte/Vesagar_Nekio.pl
+++ b/freporte/Vesagar_Nekio.pl
@@ -39,13 +39,13 @@ sub EVENT_ITEM {
 		$npc->CastSpell(12,$client);
 	}		
 	#:: Match a 13074 - Zombie Skin
-	elsif (plugin::takeItems(13074 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13074 => 1)) {
 		quest::say("The malady which has overtaken your frail body shall be cast out and in its place, your hate shall grow.");
 		#:: Cast spell 213 - Cure Disease
 		$npc->CastSpell(213,$client);
 	}
 	#:: Match a 14018 - Spider Venom Sac
-	elsif (plugin::takeItems(14018 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 14018 => 1)) {
 		quest::say("Your offering has strengthened your faith in our ways. Let the spittle of Innoruuk wash the poison from your body.");
 		#:: Cast spell 203 - Cure Poison
 		$npc->CastSpell(203,$client);

--- a/freporte/Winda_Lylil.pl
+++ b/freporte/Winda_Lylil.pl
@@ -14,7 +14,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match 1839 - Full Muffin Crate
-	if (plugin::takeItems(1839 => 1)) {
+	if (plugin::check_handin(\%itemcount, 1839 => 1)) {
 		quest::say("Ah yes! This is exactly what I am looking for, dear. Let me put these on the shelf right away. Here is some coin for your trouble. Perhaps we can do business again sometime.");
 		#:: Ding!
 		quest::ding();
@@ -33,7 +33,7 @@ sub EVENT_ITEM {
 		quest::MerchantSetItem(10062, 13014, 20);
 	}
 	#:: Match a 1838 - Bag of Bread Loaves
-	elsif (plugin::takeItems(1838 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 1838 => 1)) {
 		quest::say("'Well now, what do we have here? You actually went out of your way to fetch bread for me? Thank ye so kindly. Please accept this payment for your service.");
 		#:: Ding!
 		quest::ding();

--- a/freporte/Xelha_Nevagon.pl
+++ b/freporte/Xelha_Nevagon.pl
@@ -15,7 +15,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match four 13099 - Spiderling Silk
-	if (plugin::takeItems(13099 => 4)) {
+	if (plugin::check_handin(\%itemcount, 13099 => 4)) {
 		#:: Match if faction is Indifferent or better
 		if ($faction <= 5) {
 			quest::say("Let's see here. One.. two.. three.. and.. four. Great!! Just enough for my needs. You are serving Xelha well. I give you Xelha's Sparkler. It is not much, but neither are you. You know what I really need is a cyclops eye. That would be worthy of a great reward.");
@@ -45,12 +45,12 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Match four 10307 - Fire Beetle Eye
-	elsif (plugin::takeItems(10307 => 4)) {
+	elsif (plugin::check_handin(\%itemcount, 10307 => 4)) {
 		#:: Match if faction is Indifferent or better
 		if ($faction <= 5) {
 			quest::say("This is a good sight. I needed these to complete the current mixture. Bah!! I shall reward you for this small, very small, deed!! I pass on to you the knowledge of summoning. The more you serve, the more your faith in Innoruuk grows.");
 			#:: Give a random reward: 15338 - Spell: Cavorting Bones or 15331 - Spell: Reclaim Energy
-			quest::summonitem(1quest::ChooseRandom(15338, 15331));
+			quest::summonitem(quest::ChooseRandom(15338, 15331));
 			#:: Ding!
 			quest::ding();
 			#:: Set factions
@@ -75,7 +75,7 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Match four 13073 - Bone Chips
-	elsif (plugin::takeItems(13073 => 4)) {
+	elsif (plugin::check_handin(\%itemcount, 13073 => 4)) {
 		#:: Match if faction is Indifferent or better
 		if ($faction <= 5) {
 			quest::say("Excellent work! You are quite the little helper. Here you go, then. A little something for your little work. Your service to me has caused Innoruuk to look upon you favorably. Your faith in our group has grown. Continue the work.");
@@ -103,7 +103,7 @@ sub EVENT_ITEM {
 		}	
 	}
 	#:: Match a 13927 - Cyclops Eye
-	elsif (plugin::takeItems(13927 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13927 => 1)) {
 		#:: Match if faction is Kindly or better
 		if ($faction <= 3) {
 			quest::say("A cyclops eye!! You are stronger than I believed. You will rise in the ranks of the Dismal Rage quickly with acts such as this!! I am most appreciative! Here, take this. It was lying around my shelves, just gettingg all dusty. I hope you can use it. And watch yourself in your journeys, the aura of your faith in Innoruuk surrounds you like a shroud. Our enemies will surely see you for what you are.");

--- a/freporte/Zenita_D-Rin.pl
+++ b/freporte/Zenita_D-Rin.pl
@@ -16,7 +16,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 22298 - King Card
-	if (plugin::takeItems(22298 => 1)) {
+	if (plugin::check_handin(\%itemcount, 22298 => 1)) {
 		quest::say("Why I will be.. You got it!! I thought I took it out of the deck. Very well. You win the Spare Lens fair and square. Here you are. Now get out of my sight.");
 		#:: Give item 13279 - Telescope Lens (Phiz's Lens)
 		quest::summonitem(13279);
@@ -26,17 +26,17 @@ sub EVENT_ITEM {
 		quest::exp(500);
 	}
 	#:: Match a 13121 - Innoruuk's Kiss of Death
-	elsif (plugin::takeItems(13121 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13121 => 1)) {
 		quest::say("Let see what card you pulled.");
 		#:: Give a random reward:  22293 - Castle Card, 22294 - Beggar Card, 22295 - Joker Card, 22296 - Wild Card, 22297 - Queen Card, 22298 - King Card, 22299 - Knight Card
-		quest::summonitem(1quest::ChooseRandom(22293, 22294, 22295, 22296, 22297, 22298, 22299));
+		quest::summonitem(quest::ChooseRandom(22293, 22294, 22295, 22296, 22297, 22298, 22299));
 	}
 	#:: Match any Card other than King or Joker 
-	elsif ((plugin::takeItems(22299 => 1)) || (plugin::takeItems(22297 => 1)) || (plugin::takeItems(22296 => 1)) || (plugin::takeItems(22294 => 1)) || (plugin::takeItems(22293 => 1))) {
+	elsif ((plugin::check_handin(\%itemcount, 22299 => 1)) || (plugin::check_handin(\%itemcount, 22297 => 1)) || (plugin::check_handin(\%itemcount, 22296 => 1)) || (plugin::check_handin(\%itemcount, 22294 => 1)) || (plugin::check_handin(\%itemcount, 22293 => 1))) {
 		quest::say("Bad luck must be one of your strong suits. You should have been a beggar because you sure aren't a very good $class. You lose! $name");
 	}
 	#:: Match a 22295 -  Joker Card
-	elsif (plugin::takeItems(22295 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 22295 => 1)) {
 		quest::say("I see you have drawn the card that best represents a $class such as yourself. You lose! $name");
 	}
 	#:: Return unused items

--- a/freportn/Caskin_Marsheart.pl
+++ b/freportn/Caskin_Marsheart.pl
@@ -25,7 +25,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Turn in for 18770 - Recruitment Summons
-	if (plugin::takeItems(18747 => 1 )) {
+	if (plugin::check_handin(\%itemcount, 18747 => 1 )) {
 		quest::say("Welcome to the guild. here's your guild tunic. Once you are ready to begin your training please make sure that you see Sten Harnak, he can assist you in developing your hunting and gathering skills. Return to me when you have become more experienced in our art, I will be able to further instruct you on how to progress through your early ranks, as well as in some of the various [trades] you will have available to you.");
 		#:: Give item 13571 - Colorfully Patched Tunic*
 		quest::summonitem(13571);

--- a/freportn/Celsar_Vestagon.pl
+++ b/freportn/Celsar_Vestagon.pl
@@ -14,12 +14,12 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Turn in for 13872 - Sack of Piranha
-	if (plugin::takeItems(13872 => 1 )) {
+	if (plugin::check_handin(\%itemcount, 13872 => 1 )) {
 		quest::say("You have done well. The Marr Minnow shall have a greater chance of flourishing. Please take this as a reward.");
 		#:: Ding!
 		quest::ding();
 		#:: Give a random reward: 15207 - Spell: Divine Aura, 13869 - Marr's Sustenance, 14003 - Potion of Disease Warding
-		quest::summonitem(1quest::ChooseRandom(15207, 13869, 14003));
+		quest::summonitem(quest::ChooseRandom(15207, 13869, 14003));
 		#:: Set factions
 		quest::faction(281, 20); 		#:: + Knights of Truth
 		quest::faction(362, 4); 		#:: + Priests of Marr

--- a/freportn/Eestyana_Naestra.pl
+++ b/freportn/Eestyana_Naestra.pl
@@ -9,7 +9,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 18735 - Tattered Note
-	if (plugin::takeItems(18735 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18735 => 1)) {
 		quest::say("The Truthbringer welcomes you into his life. Here is the tunic of Marr. Wear it with pride and be sure to conduct yourself with valor. Once you are ready to begin your training please make sure that you see Salinsa Delfdosan, she can assist you in developing your hunting and gathering skills. Return to me when you have become more experienced in our art, I will be able to further instruct you on how to progress through your early ranks.");
 		#:: Give a 13554 - Faded Purple Tunic*
 		quest::summonitem(13554);
@@ -25,7 +25,7 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Match a 18822 - A Note
-	elsif (plugin::takeItems(18822 => 1 )) {
+	elsif (plugin::check_handin(\%itemcount, 18822 => 1 )) {
 		quest::say("You must be the young member of the Hall of Truth who was sent by Theron. I am glad to see you avoided any interference. Please take this as a reward for your service.");
 		#:: Give item 9985 - Spell: Courage*
 		quest::summonitem(19985);
@@ -45,10 +45,10 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Match a 18816 - A Note
-	elsif (plugin::takeItems(18816 => 1 )) {
+	elsif (plugin::check_handin(\%itemcount, 18816 => 1 )) {
 		quest::say("Thank you, defender of Karana! We have heard rumors of the followers of Bertoxxulous gaining knowledge of our knight who infiltrated the ranks of the [Militia]. They would have tried to sell the information to the Militia. We will inform our knight immediately. As for you, here is a donation to your journey's expenses. Stay clear of the Freeport Militia. There is no doubt they have learned of your alliance with us.");
 		#:: Give random reward: 6016 - Rusty Morning Star or 13296 - Prayer Beads
-		quest::summonitem(1quest::ChooseRandom(6016, 13296));
+		quest::summonitem(quest::ChooseRandom(6016, 13296));
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/freportn/Falia_Frikniller.pl
+++ b/freportn/Falia_Frikniller.pl
@@ -6,7 +6,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Turn in for 18925 - Letter to Falia
-	if (plugin::takeItems(18925 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18925 => 1)) {
 		quest::say("Heh, that good for nothing fool. I've been here for over a month already, and I haven't seen him yet. Bah, anyway, could you take this back to him for me? It was our grandfather's lucky necklace. He passed it down to our father, and now onto my brother. Knowing that little worm, Grenny, he'll probably trade it for a mug of ale. Oh well, thanks for delivering the letter, friend. Good day to you, and safe travels.");
 		#:: Give item 13159 - Broken Heirloom Necklace
 		quest::summonitem(13159);

--- a/freportn/Felisity_Starbright.pl
+++ b/freportn/Felisity_Starbright.pl
@@ -6,7 +6,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 18158 - A Bardic Letter (Freeport)
-	if (plugin::takeItems(18158 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18158 => 1)) {
 		quest::say("Mail from the front - thank you very much! Please take this gold for your troubles. If you are interested in more work, just ask Ton Twostring");
 		#:: Ding!
 		quest::ding();
@@ -24,7 +24,7 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Match a 18157 - A Bardic Letter (Freeport)
-	elsif (plugin::takeItems(18157 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 18157 => 1)) {
 		quest::say("Incoming mail - very good!  Please take this gold for your troubles.");
 		#:: Ding!
 		quest::ding();
@@ -42,7 +42,7 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Match a 18159 - A Bardic Letter (Freeport)
-	elsif (plugin::takeItems(18159 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 18159 => 1)) {
 		quest::say("'Mail from the front - thank you very much! Please take this gold for your troubles. If you are interested in more work, just ask Ton Twostring.'");
 		#:: Ding!
 		quest::ding();
@@ -60,7 +60,7 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Match a 18155 - A Bardic Letter (Freeport)
-	elsif (plugin::takeItems(18155 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 18155 => 1)) {
 		quest::say("Incoming mail - very good!  Please take this gold for your troubles.");
 		#:: Ding!
 		quest::ding();
@@ -78,7 +78,7 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Match a 18166 - Pouch of Mail (Freeport)
-	elsif (plugin::takeItems(18166 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 18166 => 1)) {
 		quest::say("'Mail from the front - thank you very much! Please take this gold for your troubles. If you are interested in more work, just ask Ton Twostring");
 		#:: Ding!
 		quest::ding();

--- a/freportn/Gern_Tassel.pl
+++ b/freportn/Gern_Tassel.pl
@@ -17,7 +17,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match 1839 - Full Muffin Crate
-	if (plugin::takeItems(1839 => 1)) {
+	if (plugin::check_handin(\%itemcount, 1839 => 1)) {
 		quest::say("These are quality muffins! You are obviously quite a skilled baker. Here is your payment as promised. Now I can get back to business again.");
 		#:: Ding!
 		quest::ding();
@@ -36,7 +36,7 @@ sub EVENT_ITEM {
 		quest::MerchantSetItem(8014, 13014, 20);
 	}
 	#:: Match a 1838 - Bag of Bread Loaves
-	elsif (plugin::takeItems(1838 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 1838 => 1)) {
 		quest::say("Thanks for the bread!!");
 		#:: Ding!
 		quest::ding();

--- a/freportn/Groflah_Steadirt.pl
+++ b/freportn/Groflah_Steadirt.pl
@@ -9,13 +9,13 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Turn in for 18818 - a tattered flier
-	if (plugin::takeItems(18818 => 1 )) {
+	if (plugin::check_handin(\%itemcount, 18818 => 1 )) {
 		quest::say("Where did you find this? This was the main price list of Zimel's Blades, but it should be all burnt up. I was at Zimel's right after the fire and I did not see it hanging where it should have been. The entire inside was gutted and . . . wait . . . the sequence of the dots!! Hmmm. I cannot talk with you here. Meet me at the Seafarer's by the docks at night. Give me the note when next we meet.");
 		#:: Give item 18818 - a tattered flier
 		quest::summonitem(18818);
 	}
 	#:: Turn in for 13919 Reward Raw Short Sword
-	if (plugin::takeItems(13919 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13919 => 1)) {
 		quest::say("I heard you were on your way back. Here, then. Let us sharpen that blade for you. There you are. That should be much better in a fray now.");
 		#:: Give a 5418- Groflah's Stoutbie
 		quest::summonitem(15418);

--- a/freportn/Gygus_Remnara.pl
+++ b/freportn/Gygus_Remnara.pl
@@ -6,7 +6,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Turn in for 18738 - A Tattered Note
-	if (plugin::takeItems(18738 => 1 )) {
+	if (plugin::check_handin(\%itemcount, 18738 => 1 )) {
 		quest::say("Welcome to the Sentries of Passion. We are the protectors of the Temple of Marr. Wear our tunic with pride, young knight! Find your wisdom within these walls and in the words of our priests. And remember to aid all who follow the twin deities, Mithaniel and Erollisi Marr.");
 		#:: Give item 13556 - White and Blue Tunic*
 		quest::summonitem(13556);

--- a/freportn/Jemoz_Lerkarson.pl
+++ b/freportn/Jemoz_Lerkarson.pl
@@ -32,14 +32,14 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Turn in for 13921 - Damaged Militia Helm
-	if (plugin::takeItems(13921 => 1 )) {
+	if (plugin::check_handin(\%itemcount, 13921 => 1 )) {
 		quest::say("Bless you, my child. Marr is grateful, as are we. Here is our thanks. Let it bring you greater strength to defeat the Militia. Go and continue the crusade. Soon you will be strong enough to slay the [true organizer].");
 		#:: Ding!
 		quest::ding();
 		#:: Grant a large amount of experience
 		quest::exp(5000);
 		#:: Give a random reward: 15019 - Spell: Armor of Faith, 15013 - Spell: Complete Healing, 15045 - Spell: Pacify
-		quest::summonitem(1quest::ChooseRandom(15019, 15013, 15045));
+		quest::summonitem(quest::ChooseRandom(15019, 15013, 15045));
 		#:: Set factions
 		quest::faction(362, 3); 		#:: + Priests of Marr
 		quest::faction(336, -10); 		#:: - Coalition of Tradefolk Underground
@@ -49,10 +49,10 @@ sub EVENT_ITEM {
 		$npc->CastSpell(12,$userid);
 	}
 	#:: Turn in for 12142 - Human Head
-	if (plugin::takeItems(12142 => 1 )) {
+	if (plugin::check_handin(\%itemcount, 12142 => 1 )) {
 		quest::say("We heard of your assault. We even attempted to slay Lucan. Alas, we failed. You have done your part and as such have earned our thanks. Beware of the Freeport Militia. They will no doubt be on the lookout for you. May Marr protect you. Perhaps you should speak with Valeron Dushire, paladin of the Knights of Truth. He seeks other to slay the fallen knight.");
 		#:: Give a random reward: 15560 - Spell: Furor, 15230 - Spell: Root, 15219 - Spell: Center, 15229 - Spell: Fear, 15222 - Spell: Invigor, 15012 - Spell: Healing
-		quest::summonitem(1quest::ChooseRandom(15560,15230,15219,15229,15222,15012));
+		quest::summonitem(quest::ChooseRandom(15560,15230,15219,15229,15222,15012));
 		#:: Ding!
 		quest::ding();
 		#:: Grant a large amount of experience

--- a/freportn/Kalatrina_Plossen.pl
+++ b/freportn/Kalatrina_Plossen.pl
@@ -29,7 +29,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Turn in for 18818 - A Tattered Flier
-	if (plugin::takeItems(18818 => 1 )) {
+	if (plugin::check_handin(\%itemcount, 18818 => 1 )) {
 		quest::say("Zimel's Blades?! Hmmmmm. It doesn't ring a bell and the remainder of the writing is too hard to make out. It kind of looks like a list of prices. You know, down at the Office of the People they might be able to tell us if this place exists. Go speak with Rashinda. She knows all about Freeport. If [Zimel's Blades] existed, you must report back to me what happened to it.");
 		#:: Ding!
 		quest::ding();

--- a/freportn/Merko_Quetalis.pl
+++ b/freportn/Merko_Quetalis.pl
@@ -26,7 +26,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Turn in for 14018 - Spider Venom Sac
-	if (plugin::takeItems(14018 => 1 )) {
+	if (plugin::check_handin(\%itemcount, 14018 => 1 )) {
 		quest::say("You have earned the token of bravery. Now you must ask yourself if you are ready to face true fear. You will have but one chance. If you feel you are powerful enough to easily slay that desert tarantula, then hand me both tokens earned and you shall face the Test of Truth.");
 		#:: Give item 12144 - Token of Bravery
 		quest::summonitem(12144);
@@ -42,7 +42,7 @@ sub EVENT_ITEM {
 		quest::faction(330,-1); 	#:: - Freeport Militia
 	}
 	#:: Turn in for 12144 - Token of Bravery & 13865 - Token of Generosity
-	if (plugin::takeItems(12144 => 1, 13865 =>1 )) {
+	if (plugin::check_handin(\%itemcount, 12144 => 1, 13865 =>1 )) {
 		quest::say("Go to the open sewer across the way. Inside you shall find your opponent. Victory shall bring your final token. Return it to me. Remember our ways and remember our foes. Send them to their judgement in the afterlife. Be swift with your thoughts. May Marr be with you.");
 		#:: Spawn 8110 - Guard Willia
 		quest::spawn2(8110,0,0,-257,132,-17,120);
@@ -58,7 +58,7 @@ sub EVENT_ITEM {
 		quest::faction(330,-1); 	#:: - Freeport Militia
 	}
 	#:: Turn in for 13866 - Token of Truth
-	if (plugin::takeItems(13866 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13866 => 1)) {
 		quest::say("You have performed well. You have shown your allegiance to truth and cast aside the Freeport Militia. The militia will surely despise you from now on. This is how they treat the Knights of Truth. Beware. The followers of Marr stand alone in this city.");
 		#:: Give item 18828 - Testimony
 		quest::summonitem(18828);

--- a/freportn/Plur_Etinu.pl
+++ b/freportn/Plur_Etinu.pl
@@ -15,7 +15,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Turn in for 13074 - 2x Zombie Skin
-	if (plugin::takeItems(13074 => 2 )) {
+	if (plugin::check_handin(\%itemcount, 13074 => 2 )) {
 		quest::say("May the Power of Passion purge you of disease!");
 		#:: Cast spell 203 - Cure Poison
 		$npc->CastSpell(203,$userid);
@@ -23,7 +23,7 @@ sub EVENT_ITEM {
 		quest::ding();
 	}	
 	#:: Turn in for 14029 - 3x Bixie Stinger
-	elsif (plugin::takeItems(14029 => 3 )) {
+	elsif (plugin::check_handin(\%itemcount, 14029 => 3 )) {
 		quest::say("May the Power of Passion forced you free of poison!");
 		#:: Cast spell 203 - Cure Poison
 		$npc->CastSpell(203,$userid);

--- a/freportn/Sentry_Andlin.pl
+++ b/freportn/Sentry_Andlin.pl
@@ -6,7 +6,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Turn in for 12127- Full Potion of Marr
-	if (plugin::takeItems(12127 => 1 )) {
+	if (plugin::check_handin(\%itemcount, 12127 => 1 )) {
 		quest::say("My thanks to you. I feel much strength. You may take the bottle to the next sentry.");
 		#:: Give item 12128 - Part of Potion of Marr
 		quest::summonitem(12128);

--- a/freportn/Sentry_Boris.pl
+++ b/freportn/Sentry_Boris.pl
@@ -6,7 +6,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Turn in for 12128 - Part of Potion of Marr
-	if (plugin::takeItems(12128 => 1 )) {
+	if (plugin::check_handin(\%itemcount, 12128 => 1 )) {
 		quest::say("Ahhh!! That has given me back lost energy. Thank you. Please take this to the next sentry.");
 		#:: Give item 12129 - Part of Potion of Marr
 		quest::summonitem(12129);

--- a/freportn/Sentry_Gallius.pl
+++ b/freportn/Sentry_Gallius.pl
@@ -6,7 +6,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Turn in for 12129 - Part of Potion of Marr
-	if (plugin::takeItems(12129 => 1 )) {
+	if (plugin::check_handin(\%itemcount, 12129 => 1 )) {
 		quest::say("Excellent!! I feel quite refreshed with but a sip. You may take this to the next sentry.");
 		#:: Give item 12130 - Part of Potion of Marr
 		quest::summonitem(12130);

--- a/freportn/Sentry_Janeal.pl
+++ b/freportn/Sentry_Janeal.pl
@@ -6,7 +6,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Turn in for 12130 - Part of Potion of Marr
-	if (plugin::takeItems(12130 => 1 )) {
+	if (plugin::check_handin(\%itemcount, 12130 => 1 )) {
 		quest::say("I feel quite alert now. Thank you. You should take this to the next sentry.");
 		#:: Give item 12131 - Half of Potion of Marr
 		quest::summonitem(12131);

--- a/freportn/Sentry_Meighan.pl
+++ b/freportn/Sentry_Meighan.pl
@@ -6,7 +6,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Turn in for 12131 - Half of Potion of Marr
-	if (plugin::takeItems(12131 => 1 )) {
+	if (plugin::check_handin(\%itemcount, 12131 => 1 )) {
 		quest::say("Very good. Nothing more than a sip and I feel much more alert. The next sentry awaits you.");
 		#:: Give item 12132 - Part of Potion of Marr
 		quest::summonitem(12132);

--- a/freportn/Sentry_Theo.pl
+++ b/freportn/Sentry_Theo.pl
@@ -6,7 +6,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Turn in for 12132 - Part of Potion of Marr
-	if (plugin::takeItems(12132 => 1 )) {
+	if (plugin::check_handin(\%itemcount, 12132 => 1 )) {
 		quest::say("That gives me new life. Take it to the next sentry.");
 		#:: Give item 12133 - Part of Potion of Marr
 		quest::summonitem(12133);

--- a/freportn/Sentry_Warren.pl
+++ b/freportn/Sentry_Warren.pl
@@ -9,7 +9,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Turn in for 12133 - Part of Potion of Marr
-	if (plugin::takeItems(12133 => 1 )) {
+	if (plugin::check_handin(\%itemcount, 12133 => 1 )) {
 		quest::say("Thank you. I believe you need to seek out Sentry Xyrin. She is not at the temple. I believe she left to speak with [Sisterhood of Erollisi]. She was to speak with Styria.");
 		#:: Give item 12134 - Last of Potion of Marr
 		quest::summonitem(12134);

--- a/freportn/Serna_Tasknon.pl
+++ b/freportn/Serna_Tasknon.pl
@@ -34,7 +34,7 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Turn in for 13983 - Inert Potion 
-	elsif (plugin::takeItems(13983 => 1 )) {
+	elsif (plugin::check_handin(\%itemcount, 13983 => 1 )) {
 		quest::say("I see Tonmerk has found a use for my shark powder. We agreed to this trade when last we met. Unfortunately, I am out of it. If you desire the shark powder you will have to get me three shark bones. I wish you luck. Oh. I also require a payment of ten gold pieces. The taxes in Freeport are fierce.");
 		#:: Ding!
 		quest::ding();
@@ -46,7 +46,7 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Turn in for 12135- Empty Potion of Marr
-	elsif (plugin::takeItems(12135 => 1 )) {
+	elsif (plugin::check_handin(\%itemcount, 12135 => 1 )) {
 		quest::say("The Sentries of Passion informed me of your journey to the Ocean of Tears and the demise of Sentry Xyrin. You performed beyond the call of duty. This is what makes an exceptional person. Take this for your great deed. The twin deities would wish it so.");
 		#:: Give item 15207 - Spell: Divine Aura
 		quest::summonitem(15207);

--- a/freportn/Theron_Rolius.pl
+++ b/freportn/Theron_Rolius.pl
@@ -29,7 +29,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 13921 - Damaged Militia Helm
-	if (plugin::takeItems(13921 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13921 => 1)) {
 		quest::say("Fantastic work, my young knight.  Here is a small token of the my appreciation.  I would offer you a sharkskin shield, but I have made only a few and the paladins are testing them.");
 		#:: Ding!
 		quest::ding();
@@ -47,7 +47,7 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Match a 13873 - Sack of Sharkskins
-	elsif (plugin::takeItems(13873 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13873 => 1)) {
 		quest::say("Fantastic work, my young knight. Here is a small token of my appreciation -- a fine Sharkskin Shield. It should serve you well in battle.");
 		#:: Give a 13868 - Sharkskin Shield
 		quest::summonitem(13868);

--- a/freportn/Tholius_Quey.pl
+++ b/freportn/Tholius_Quey.pl
@@ -12,7 +12,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 18735 - A Tattered Note
-	if (plugin::takeItems(18735 => 1 )) {
+	if (plugin::check_handin(\%itemcount, 18735 => 1 )) {
 		quest::say("Welcome to the Priests of Marr. Here, you will be taught how powerful passion truly is. The passion of Erollisi Marr, the Queen of Love, shall flow through you and into all those you meet. Wear this tunic in the name of Love.");
 		#:: Give a 13556 - White and Blue Tunic*
 		quest::summonitem(13556);
@@ -31,7 +31,7 @@ sub EVENT_ITEM {
 
 sub EVENT_ITEM {
 	#:: Match a 18736 - A Tattered Note
-	if (plugin::takeItems(18736 => 1 )) {
+	if (plugin::check_handin(\%itemcount, 18736 => 1 )) {
 		quest::say("Welcome to the Priests of Marr. Here, you will be taught how powerful passion truly is. The passion of Erollisi Marr, the Queen of Love, shall flow through you and into all those you meet. Wear this tunic in the name of Love.");
 		#:: Give a 13556 - White and Blue Tunic*
 		quest::summonitem(13556);

--- a/freportn/Ton_Twostring.pl
+++ b/freportn/Ton_Twostring.pl
@@ -34,7 +34,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Turn in for 18164 or 18166 - both identify as Pouch of Mail (Freeport)
-	if (plugin::takeItems(18164 => 1) || plugin::takeItems(18166 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18164 => 1) || plugin::takeItems(18166 => 1)) {
 		quest::say("Incoming mail - very good! Please take this gold for your troubles.");
 		#:: Ding!
 		quest::ding();

--- a/freportn/Valeron_Dushire.pl
+++ b/freportn/Valeron_Dushire.pl
@@ -18,7 +18,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Turn in for 18737 - A tattered note
-	if (plugin::takeItems(18737 => 1 )) {
+	if (plugin::check_handin(\%itemcount, 18737 => 1 )) {
 		quest::say("Welcome to the Guild, here's your guild tunic. Now, let's get to work.");
 		#:: Give item 13554 - Faded Purple Tunic*
 		quest::summonitem(13554);
@@ -34,7 +34,7 @@ sub EVENT_ITEM {
 		quest::faction(311, 10);		#:: + Steel Warriors
 	}
 	#:: Turn in for 18827 - A Testimony of Truth
-	if (plugin::takeItems(18827 => 1 )) {
+	if (plugin::check_handin(\%itemcount, 18827 => 1 )) {
 		quest::say("Praise be to Marr!! You have done the impossible!! Sir Lucan is finally sent to the higher courts of the Tribunal. The city now has a chance to prosper. The Hall of Truth has been redeemed and gives you thanks. Take this, it is the Sword of Faith. May you wield it with righteousness. Beware of the remainder of the militia. They will be hunting for your head.");
 		#:: Give item 13947 - Brilliant Sword of Faith
 		quest::summonitem(13947);

--- a/freportn/a_minnow.pl
+++ b/freportn/a_minnow.pl
@@ -1,9 +1,9 @@
 sub EVENT_ITEM {
 	#:: Turn in for 13861 - A jar of liquid
-	if (plugin::takeItems(13861 => 1 )) {
+	if (plugin::check_handin(\%itemcount, 13861 => 1 )) {
 		quest::emote("darts into the jar, or just darted past it!! The Knights of Truth do not tolerate people attempting to catch these fish!!");
 		#:: Give a random reward: 13861 - A Jar of Liquid, or 13862 - Fish in a Jar
-		quest::summonitem(1quest::ChooseRandom(13861,13862));
+		quest::summonitem(quest::ChooseRandom(13861,13862));
 		#:: Ding!
 		quest::ding();
 		#:: Set factions
@@ -14,5 +14,5 @@ sub EVENT_ITEM {
 		quest::faction(311, -2);		#:: - Steel Warriors
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+    plugin::returnUnusedItems();quest::summonitem(quest::ChooseRandom($item1));
 }

--- a/freportw/Armorer_Dellin.pl
+++ b/freportw/Armorer_Dellin.pl
@@ -6,7 +6,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Turn in for 12273 - Militia Armory Token
-	if (plugin::takeItems(12273 => 1 )) {
+	if (plugin::check_handin(\%itemcount, 12273 => 1 )) {
 		quest::say("Welcome to the Freeport Militia. As a reserve member we require you to wear this tunic and fight when, who and wherever Sir Lucan commands, no questions asked!! There is no turning back!! Remember to keep clear of North Freeport. You have made a wise decision. Hail Sir Lucan!!");
 		#:: Grant a large amount of xp
 		quest::exp(10000);

--- a/freportw/Cain_Darkmoore.pl
+++ b/freportw/Cain_Darkmoore.pl
@@ -21,7 +21,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match two 13916 - Deathfist Slashed Belt
-	if (plugin::takeItems(13916 => 2 )) {
+	if (plugin::check_handin(\%itemcount, 13916 => 2 )) {
 		quest::say("Very fine work $name. With your help, we shall soon rid the commonlands of the orcs. Then we can move on to a [bigger problem].");
 		#:: Ding!
 		quest::ding();
@@ -39,13 +39,13 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Match one 13916 - Deathfist Slashed Belt
-	elsif (plugin::takeItems(13916 => 1 )) {
+	elsif (plugin::check_handin(\%itemcount, 13916 => 1 )) {
 		quest::say("I must have two Deathfist belts.");
 		#:: Return a 13916 - Deathfist Slashed Belt
 		quest::summonitem(13916);
 	}
 	#:: Match a 18742 - A Tattered Note
-	elsif (plugin::takeItems(18742 => 1 )) {
+	elsif (plugin::check_handin(\%itemcount, 18742 => 1 )) {
 		quest::say("Welcome to the Steel Warriors, young warrior. It is time to prove your mettle. Look to the outskirts of Freeport and join the fray. Show Clan Deathfist what a warrior of the bunker can do.");
 		#:: Give item 13572 - Dirty Training Tunic
 		quest::summonitem(13572);		
@@ -61,7 +61,7 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Match a 13319 - Crushbone Shoulderpads x2 and 13917 Deathfist Shoulderpads x2
-	elsif (plugin::takeItems(13319 => 2, 13917 => 2)) {
+	elsif (plugin::check_handin(\%itemcount, 13319 => 2, 13917 => 2)) {
 		quest::say("Very fine work, $name. With your help, we shall soon rid the commonlands of the orcs. Then we can move on to a [bigger problem]");
 		#:: Give item 5369 - Bunker Battle Blade
 		quest::summonitem(15369);		

--- a/freportw/Captain_Hazran.pl
+++ b/freportw/Captain_Hazran.pl
@@ -9,7 +9,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match four 13916 - Deathfist Slashed Belt
-	if (plugin::takeItems(13916 => 4)) {
+	if (plugin::check_handin(\%itemcount, 13916 => 4)) {
 		quest::say("Good work, warrior. You are good militia material. Beware though, there are some who dare to call us foe. You have performed so well!");
 		#:: Ding!
 		quest::ding();
@@ -26,7 +26,7 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Match three 13916 - Deathfist Slashed Belt
-	elsif (plugin::takeItems(13916 => 3)) {
+	elsif (plugin::check_handin(\%itemcount, 13916 => 3)) {
 		quest::say("Good work, warrior. You are good militia material. Beware though, there are some who dare to call us foe. You have performed so well!");
 		#:: Ding!
 		quest::ding();
@@ -43,7 +43,7 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Match two 13916 - Deathfist Slashed Belt
-	elsif (plugin::takeItems(13916 => 2)) {
+	elsif (plugin::check_handin(\%itemcount, 13916 => 2)) {
 		quest::say("Good work, warrior. You are good militia material. Beware though, there are some who dare to call us foe. You have performed so well!");
 		#:: Ding!
 		quest::ding();
@@ -60,7 +60,7 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Match a 13916 - Deathfist Slashed Belt
-	elsif (plugin::takeItems(13916 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13916 => 1)) {
 		quest::say("Good work, warrior. You are good militia material. Beware though, there are some who dare to call us foe. You have performed so well!");
 		#:: Ding!
 		quest::ding();

--- a/freportw/Driana_Poxsbourne.pl
+++ b/freportw/Driana_Poxsbourne.pl
@@ -9,7 +9,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Turn in for 1797 - Reagent Pouch x3
-	if (plugin::takeItems(1797 => 3)) {
+	if (plugin::check_handin(\%itemcount, 1797 => 3)) {
 		quest::say("Ahh wonderful work $name Here is the substance....don't spill it HAHAHAaahhahehehe...yes......you don't want to spill that heheh..");
 		#:: Give a small amount of xp
 		quest::exp(200);

--- a/freportw/Guard_Alayle.pl
+++ b/freportw/Guard_Alayle.pl
@@ -11,7 +11,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Turn in for 18817 - Sealed Letter
-	if (plugin::takeItems(18817 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18817 => 1)) {
 		if (plugin::HasClassName($client, "Paladin")) {
 			quest::say("This is not good news. I must leave immediately. Here. Take this to Kala.. I mean my father. I found it on the floor of Sir Lucan D'Lere's quarters. Thanks again, messenger. I got this just in time");
 			#:: Give a 18818 - A Tattered Flier

--- a/freportw/Hemia_Skemner.pl
+++ b/freportw/Hemia_Skemner.pl
@@ -15,7 +15,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 13863 - A Locked Book
-	if (plugin::takeItems(13863 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13863 => 1)) {
 		quest::say("It is a shame we had to take such actions. I mourn for the sanity of Lydl. I cheer for the addition of such a fine wizard as yourself. I found this while rummaging through my vault. Take it as thanks. It is not much.");
 		#:: Ding!
 		quest::ding();

--- a/freportw/Hyrill_Pon.pl
+++ b/freportw/Hyrill_Pon.pl
@@ -20,7 +20,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 18010 - Torn Parchment
-	if (plugin::takeItems(18010 => 1 )) {
+	if (plugin::check_handin(\%itemcount, 18010 => 1 )) {
 		quest::say("Peh! He thinks this old skull he found is a legendary skull of Wun Toque. It is said, a wizard who possesses one is granted power and intelligence far beyond those of his peers. Yiz was searching for the skulls missing ruby eyes. It seems he found the location of the first eye. Hmm.. Lynuga.. Lynuga.. I think I have heard that name before.. Yeah! Now I remember. I met her in the Foreign Quarter of Neria.. um.. Highpass Hold. She was trying to hawk some stolen gems! I think she mumbled something about going home to Grobb. I sure don't have time to track her down.");
 		#:: Ding!
 		quest::ding();
@@ -33,7 +33,7 @@ sub EVENT_ITEM {
 		quest::exp(1000);
 	}
 	#:: Match a 13987 - Jeweled Skull
-	elsif (plugin::takeItems(13987 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13987 => 1)) {
 		quest::say("You found it!? My sap of a brother was right after all! I sure don't want that thing. It sends shivers down my spine just holding it. Here. Take it!");
 		#:: Give a 13988 - Jeweled Skull
 		quest::summonitem(13988);
@@ -48,7 +48,7 @@ sub EVENT_ITEM {
 		quest::exp(1000);
 	}
 	#:: Match a 13988 - Jeweled Skull
-	elsif (plugin::takeItems(13988 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13988 => 1)) {
 		quest::say("You found it!? My sap of a brother was right after all! I sure don't want that thing. It sends shivers down my spine just holding it. Here. Take it!");
 		#:: Ding!
 		quest::ding();

--- a/freportw/Jyle_Windshot.pl
+++ b/freportw/Jyle_Windshot.pl
@@ -18,7 +18,7 @@ sub EVENT_ITEM {
 	if (plugin::check_handin(\%itemcount, 13003 => 1)) {
 		quest::say("Thanks, friend. I have run a long way to get here in time. Mostly at night. I lost my lantern in a card game in Highkeep.");
 		#:: Randomly choose from Wooden Shards 90% chance, or A Wooden Heart 10% chance
-		quest::summonitem(1quest::ChooseRandom(13824, 13824, 13824, 13824, 13824, 13824, 13824, 13824, 13824, 12334));
+		quest::summonitem(quest::ChooseRandom(13824, 13824, 13824, 13824, 13824, 13824, 13824, 13824, 13824, 12334));
 		#:: Give a small amount of xp
 		quest::exp(500);
 		#:: Ding!

--- a/freportw/Lady_Shae.pl
+++ b/freportw/Lady_Shae.pl
@@ -53,7 +53,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match four 13031 - White Wine
-	if (plugin::takeItems(13031 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13031 => 1)) {
 		quest::say("Thank you. Pandos has been telling me to try white wine forever. I mostly only drink red wine. Pardon me for getting off track. Anyway, it is a good thing you showed up. The lady in room 2 has been receiving mail from a Dark Elf. Tell Swin you [need the mail for room two]. The Innkeeper usually holds it for the guests.");
 		#:: Ding!
 		quest::ding();
@@ -66,7 +66,7 @@ sub EVENT_ITEM {
 		quest::exp(150);
 	}
 	#:: Match four 13030 - Red Wine
-	elsif (plugin::takeItems(13030 => 4)) {
+	elsif (plugin::check_handin(\%itemcount, 13030 => 4)) {
 		quest::say("Oh my.. You are so kind. I can not tell you the last time I had so much fine wine. Well, there was the time Antonius Bayle told me he no longer had the time for a committed relationship. Mister big ruler of the world. Make it to the top and find someone younger. I know his plan. I hate him. I will never trust another human again. After all that, he goes and asks me to hold on to this list for him. Well I am glad it was taken from me by that [Dyllin]. Antonius Bayle has no ties to me any more!! Good riddance! Oooooh! I love him.");
 		#:: Ding!
 		quest::ding();
@@ -81,7 +81,7 @@ sub EVENT_ITEM {
 		$ItemCount = 0;
 	}					
 	#:: Match three 13030 - Red Wine
-	elsif (plugin::takeItems(13030 => 3)) {
+	elsif (plugin::check_handin(\%itemcount, 13030 => 3)) {
 		if ($ItemCount == 0) {
 			quest::say("Thank you... Oh my! Another of these and I will be spilling my secrets.");
 			#:: Increment the item count variable
@@ -105,7 +105,7 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Match two 13030 - Red Wine
-	elsif (plugin::takeItems(13030 => 2)) {
+	elsif (plugin::check_handin(\%itemcount, 13030 => 2)) {
 		if ($ItemCount <= 1) {
 			quest::say("Thank you... Oh my! A few more of these and I will be spilling my secrets.");
 			#:: Increment the item count variable
@@ -128,7 +128,7 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Match one 13030 - Red Wine
-	elsif (plugin::takeItems(13030 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13030 => 1)) {
 		if ($ItemCount <= 2) {
 			quest::say("Thank you... Oh my! A few more of these and I will be spilling my secrets.");
 			#:: Increment the item count variable

--- a/freportw/Larn_Brugal.pl
+++ b/freportw/Larn_Brugal.pl
@@ -23,7 +23,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Turn in for 12241 - Raw Short Sword 1, 12242 - Raw Short Sword 2, 12243 - Raw Short Sword 3, 12244 - Raw Short Sword 4
-	if (plugin::takeItems(12241 => 1, 12242 => 1, 12243 => 1, 12244 => 1)) {
+	if (plugin::check_handin(\%itemcount, 12241 => 1, 12242 => 1, 12243 => 1, 12244 => 1)) {
 		quest::say("Good work, $name. The bunker shall be well stocked. Here you are, my friend. Take this raw blade. You can take it to Groflah - he will sharpen and polish it for you. It should be a formidable weapon.");
 		#:: Give a 13919 - Reward Raw Short Sword
 		quest::summonitem(13919);

--- a/freportw/Lorme_Tredore.pl
+++ b/freportw/Lorme_Tredore.pl
@@ -1,6 +1,6 @@
 sub EVENT_ITEM {
 	#:: Match a 18740 - A Tattered Note
-	if (plugin::takeItems(18740 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18740 => 1)) {
 		quest::say("Welcome to the Academy of Arcane Sciences. I am Lorme Tredore, Master Magician. Here is our guild robe, wear it with pride and represent us well, young $name. Now, let's get to work.");
 		#:: Give a 13559 - Used Violet Robe*
 		quest::summonitem(13559);
@@ -15,10 +15,10 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Match a 13951 - Fleshy Orb
-	elsif (plugin::takeItems(13951 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13951 => 1)) {
 		quest::say("Ah. Thank you for bringing this to me! I will make very good use of it. Here take this small token of my appreciation in return. Guard Jenkins will no longer require it as he was killed on the training field yesterday. Tsk. tsk. tsk.");
 		#:: Choose a random reward: 5353 - Fine Steel Scimitar, 5351 - Fine Steel Two Handed Sword, 6351 - Fine Steel Morning Star, 6350 - Fine Steel Warhammer, 7352 - Fine Steel Rapier, 6352 - Fine Steel Great Staff
-		quest::summonitem(1quest::ChooseRandom(5353, 5351, 6351, 6350, 7352, 6352));
+		quest::summonitem(quest::ChooseRandom(5353, 5351, 6351, 6350, 7352, 6352));
 		#:: Ding!
 		quest::ding();
 		#:: Grant a small amount of experience

--- a/freportw/Nusk_Treton.pl
+++ b/freportw/Nusk_Treton.pl
@@ -49,7 +49,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 13860 - A Strongbox
-	if (plugin::takeItems(13860 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13860 => 1)) {
 		#:: Match if faction with Arcane Scientists is better than Indifferent	
 		if ($faction < 5) {
 			quest::say("Grand and fantastic!! You have made my day complete. Here is what little I can offer. Most of my money goes into my research. Thank you.");

--- a/freportw/Opal_Darkbriar.pl
+++ b/freportw/Opal_Darkbriar.pl
@@ -6,7 +6,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 18739 - Tattered Note
-	if (plugin::takeItems(18739 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18739 => 1)) {
 		quest::say("Welcome to the Academy of Arcane Sciences. Here's one of our guild robes for you to wear. Now, let's get to work.");
 		#:: Give a 13558 - Patched Violet Robe
 		quest::summonitem(13558);

--- a/freportw/Palon_Deskeb.pl
+++ b/freportw/Palon_Deskeb.pl
@@ -14,10 +14,10 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 13862 - Fish in a Jar
-	if (plugin::takeItems(13862 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13862 => 1)) {
 		quest::say("Oh! A beautiful Marr Minnow. This shall look grand in my aquarium! How lucky that you are a friend to the Academy of Arcane Science. Take your reward.");
 		#:: Give a random reward: 13005 - Iron Ration, 13006 - Water Flask
-		quest::summonitem(1quest::ChooseRandom(13005, 13006));
+		quest::summonitem(quest::ChooseRandom(13005, 13006));
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/freportw/Pandos_Flintside.pl
+++ b/freportw/Pandos_Flintside.pl
@@ -62,7 +62,7 @@ sub EVENT_SIGNAL {
 
 sub EVENT_ITEM {
 	#:: Match four 13014 - Muffin
-	if (plugin::takeItems(13014 => 4)) {
+	if (plugin::check_handin(\%itemcount, 13014 => 4)) {
 		quest::say("Mmmm. This smells delicious. Oh great!! No milk!! Don't you have any sense ?! Just tell me the name of the bakery and I will run and get it myself. I am sure Lady Shae will be safe.");
 		#:: Ding!
 		quest::ding();
@@ -76,7 +76,7 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Match three 13014 - Muffin
-	elsif (plugin::takeItems(13014 => 3)) {
+	elsif (plugin::check_handin(\%itemcount, 13014 => 3)) {
 		quest::say("Mmmm. This smells delicious. Oh great!! No milk!! Don't you have any sense ?! Just tell me the name of the bakery and I will run and get it myself. I am sure Lady Shae will be safe.");
 		#:: Ding!
 		quest::ding();
@@ -90,7 +90,7 @@ sub EVENT_ITEM {
 		quest::exp(75);
 	}
 	#:: Match two 13014 - Muffin
-	elsif (plugin::takeItems(13014 => 2)) {
+	elsif (plugin::check_handin(\%itemcount, 13014 => 2)) {
 		quest::say("Mmmm. This smells delicious. Oh great!! No milk!! Don't you have any sense ?! Just tell me the name of the bakery and I will run and get it myself. I am sure Lady Shae will be safe.");
 		#:: Ding!
 		quest::ding();
@@ -104,7 +104,7 @@ sub EVENT_ITEM {
 		quest::exp(50);
 	}
 	#:: Match a 13014 - Muffin
-	elsif (plugin::takeItems(13014 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13014 => 1)) {
 		quest::say("Mmmm. This smells delicious. Oh great!! No milk!! Don't you have any sense ?! Just tell me the name of the bakery and I will run and get it myself. I am sure Lady Shae will be safe.");
 		#:: Ding!
 		quest::ding();

--- a/freportw/Ping_Fuzzlecutter.pl
+++ b/freportw/Ping_Fuzzlecutter.pl
@@ -26,13 +26,13 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Turn in for 6710 - Full Gem Bag
-	if (plugin::takeItems(6710 => 1 )) {
+	if (plugin::check_handin(\%itemcount, 6710 => 1 )) {
 		quest::emote("smiles broadly as he rifles through the bag, then looks up at you and says, 'Bout time! Here is the coffin as promised.'");
 		#:: Give item 17080 - Gem Encrusted Casket
 		quest::summonitem(17080);
 	}
 	#:: Turn in for Clumps of Hair ID- 12335 - Lock of Hair ID- 12338 - Tattered Toupee ID- 12337
-	if (plugin::takeItems(12335 => 2, 12338 =>1, 12337 =>1)) {
+	if (plugin::check_handin(\%itemcount, 12335 => 2, 12338 =>1, 12337 =>1)) {
 		quest::say("You are a good helper. Here you go. One genuine, charismatic, lady magnet, zero to hero making Mane Attraction!! Guaranteed to lower prices world wide. Guaranteed to last forever.. Err.. Well,.. It has a 1000 year warranty at least.");
 		#:: Give item 12254 - Mane Attraction
 		quest::summonitem(12254);

--- a/freportw/Puab_Closk.pl
+++ b/freportw/Puab_Closk.pl
@@ -32,7 +32,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 18746 - A Tattered Note
-	if (plugin::takeItems(18746 => 1 )) {
+	if (plugin::check_handin(\%itemcount, 18746 => 1 )) {
 		quest::say("Oh my! Opal? She is providing these agents of Neriak with information regarding the Acedemy's secrets. I can not tell Cain about this. He will be furious. Show this to Toala. She will know what to do.");
 		#:: Give a 13507 - Torn Cloth Tunic
 		quest::summonitem(13507);
@@ -46,7 +46,7 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Match a 28055 - Tattered Parchment
-	if (plugin::takeItems(28055 => 1 )) {
+	if (plugin::check_handin(\%itemcount, 28055 => 1 )) {
 		quest::say("You have performed a great service to one who is your brother. Your loyalty shines brightly, as does your skill. Take the treant fists. They are yours now.");
 		#:: Give a 12344 - Treant Fists
 		quest::summonitem(12344);

--- a/freportw/Reyia_Beslin.pl
+++ b/freportw/Reyia_Beslin.pl
@@ -33,7 +33,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 10400 - Greater Lightstone, a 1903 - Cutthroat Insignia Ring, a 2299 - Legionnaire's Bracer, and a 10131 - Yellow Sash of Order
-	if (plugin::takeItems(10400 => 1, 1903 => 1, 2299 => 1, 10131 => 1)) {
+	if (plugin::check_handin(\%itemcount, 10400 => 1, 1903 => 1, 2299 => 1, 10131 => 1)) {
 		quest::say("You have proven yourself a mighty warrior. I am honored to present you, $name, with the orange Sash of Order.");
 		#:: Give item 10132 - Sash of Order
 		quest::summonitem(10132);
@@ -47,7 +47,7 @@ sub EVENT_ITEM {
 		quest::exp(300);
 	}
 	#:: Match a 13237 - Blackened Wand, a 13238 - Blackened Sapphire, and a 10132 - Orange Sash of Order
-	elsif (plugin::takeItems(13237 => 1, 13238 => 1, 10132 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13237 => 1, 13238 => 1, 10132 => 1)) {
 		quest::say("$name, Congratulations. With the destruction of these evil items, the wand of the Burning Dead will never bring harm to anyone on Norrath again. It is my honor to present to you, on behalf of Master Closk and the Ashen Order, the red sash. May Quellious be with you always.You have proven yourself a mighty warrior. I am honored to present you, $name, with the Red Sash of Order.");
 		#:: Give item 10133 - Red Sash of Order
 		quest::summonitem(10133);

--- a/freportw/Romiak_Jusathorn.pl
+++ b/freportw/Romiak_Jusathorn.pl
@@ -1,6 +1,6 @@
 sub EVENT_ITEM {
 	#:: Match a 18741 - A Tattered Note
-	if (plugin::takeItems(18741 => 1 )) {
+	if (plugin::check_handin(\%itemcount, 18741 => 1 )) {
 		quest::say("Greetings, I am Romiak Jusathorn, Master Enchanter of the Academy. Take this.. it's our guild robe; it will help protect you in this harsh environment. Now, let's get to work!");
 		#:: Give item 13560 - Old Violet Robe
 		quest::summonitem(13560);

--- a/freportw/Swin_Blackeye.pl
+++ b/freportw/Swin_Blackeye.pl
@@ -16,7 +16,7 @@ sub EVENT_SIGNAL {
 
 sub EVENT_ITEM {
 	#:: Match a 12147 - Hog Key #2
-	if (plugin::takeItems(12147 => 1 )) {
+	if (plugin::check_handin(\%itemcount, 12147 => 1 )) {
 		quest::say("Here you go then.");
 		#:: Give a 18814 - Sealed Letter
 		quest::summonitem(18814); 

--- a/freportw/Tara_Neklene.pl
+++ b/freportw/Tara_Neklene.pl
@@ -25,10 +25,10 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 13845 - Illegible Cantrip
-	if (plugin::takeItems(13845 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13845 => 1)) {
 		quest::say("Very fine work, my young apprentice. This shall be very useful in understanding their ways. I have heard rumors of a scribe who can decipher these scrolls. He is said to frequent the local taverns. Bah!! If I cannot decipher them, no one can!! Continue with your work. Soon you shall advance enough to [test the might of the orc oracles].");
 		#:: Give a random reward: 13005 - Iron Ration, 13002 - Torch, or 13006 - Water Flask
-		quest::summonitem(1quest::ChooseRandom(13005, 13002, 13006));
+		quest::summonitem(quest::ChooseRandom(13005, 13002, 13006));
 		#:: Ding!
 		quest::ding();
 		#:: Set factions
@@ -44,12 +44,12 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Match a 13225 - Illegible Scroll
-	elsif (plugin::takeItems(13225 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13225 => 1)) {
 		#:: Match if faction is Amiable or better
 		if ($faction <= 4) {
 			quest::say("Wonderful! You have survived the might of an oracle. With this we can now continue our experiments. Now you may continue your teaching and study the power to summon those of earth, air, water and fire.");
 			#:: Give a random reward: 15317 - Spell: Elementalkin: Air, 15058 - Spell: Elementalkin: Earth, 15316 - Spell: Elementalkin: Fire, 15315 - Spell: Elementalkin: Water, 23516 - Spell: Summon Brass Choker
-			quest::summonitem(1quest::ChooseRandom(15317, 15058, 15316, 15315, 23516));
+			quest::summonitem(quest::ChooseRandom(15317, 15058, 15316, 15315, 23516));
 			#:: Ding!
 			quest::ding();
 			#:: Set factions

--- a/freportw/Toala_Nehron.pl
+++ b/freportw/Toala_Nehron.pl
@@ -13,7 +13,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 18814 - Sealed Letter
-	if (plugin::takeItems(18814 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18814 => 1)) {
 		#:: Match if faction with Steel Warriors is Amiable or better
 		if ($faction <= 4) {
 			quest::say("Why, that little trollop! What is she up to? Cain will never believe this! She must be in league with some faction of the dark elves, but why? Neither the Academy of Arcane Science nor Cain will believe this note. I will see what I can do. As for you, I command you to kill this Shintl and her dark elf courier Hollish!! Put their heads into this box and combine them. We shall cut the link. Bring me thier heads.");
@@ -37,7 +37,7 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Match a 12246 - Box with Two heads
-	elsif (plugin::takeItems(12246 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 12246 => 1)) {
 		#:: Match if faction with Steel Warriors is Amiable or better
 		if ($faction <= 4) {
 			quest::say("Good work!! We will soon catch Opal. I have started to formulate a plan to stop her. When I complete it, I shall notify you. Here. Take this small reward. I am sure killing Shintl was no trouble. She was just a halfling.");

--- a/freportw/Toxdil.pl
+++ b/freportw/Toxdil.pl
@@ -13,7 +13,7 @@ sub EVENT_SAY {
 sub EVENT_ITEM {
 	if (plugin::HasClassName($client, "Rogue")) {
 		#:: Match a 12353 - A Sparkling Sapphire
-		if (plugin::takeItems(12353 => 1)) {
+		if (plugin::check_handin(\%itemcount, 12353 => 1)) {
 			quest::say("The gem!! I would notice it's sparkle anywhere!! I cannot believe you are handing it back to me!! What a fool. Here you are fool. You can have this worthless key now.");
 			#:: Give a 12351 - A Tiny Key
 			quest::summonitem(12351);
@@ -39,7 +39,7 @@ sub EVENT_ITEM {
 			quest::summonitem(14017);
 		}
 		#:: Match two 14017 - Snake Venom Sac
-		elsif (plugin::takeItems(14017 => 2)) {
+		elsif (plugin::check_handin(\%itemcount, 14017 => 2)) {
 			quest::say("I require two snake venom sacs and my fee of 20 gold coins before I shall create the snake venom");
 			#:: Return two 14017 - Snake Venom Sac
 			quest::summonitem(14017);

--- a/freportw/Velan_Torresk.pl
+++ b/freportw/Velan_Torresk.pl
@@ -31,7 +31,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match two 13794 - Deathfist Pawn Scalp, a 13067 - Snake Fang, and a 13073 - Bone Chips
-	if (plugin::takeItems(13794 => 2, 13067 => 1, 13073 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13794 => 2, 13067 => 1, 13073 => 1)) {
 		#:: Match if faction with Ashen Order is Amiable or better
 		if ($faction <= 4) {
 			quest::say("Good work, $name, you've worked hard and proven yourself a valuable addition to the Ashen Order. Here's your white sash, wear it with pride.");
@@ -57,7 +57,7 @@ sub EVENT_ITEM {
 			
 	}
 	#:: Match a 10130 - White Training Sash, a 13058 - Giant Snake Rattle, a 13916 - Deathfist Slashed Belt, and a 20901 - Desert Tarantula Chitin
-	if (plugin::takeItems(10130 => 1, 13058 => 1, 13916 => 1,  20901 => 1)) {
+	if (plugin::check_handin(\%itemcount, 10130 => 1, 13058 => 1, 13916 => 1,  20901 => 1)) {
 		#:: Match if faction with Ashen Order is Amiable or better
 		if ($faction <= 4) {
 			quest::say("Ah, well done, $name. You have proven that you are a very skillful fighter and it is a honor to have you as a member of the Ashen Order. On behalf of Master Closk, and under the watchful eyes of Quellious, I present you, $name, with this, the yellow Sash of Order. Go out and make us proud.");

--- a/freportw/a_prisoner.pl
+++ b/freportw/a_prisoner.pl
@@ -31,7 +31,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 12196 - Bunker Cell #1, a 16581 - Bog Juice, and a 13498 - Edible Goo
-	if (plugin::takeItems(12196 => 1, 16581 => 1, 13498 => 1)) {
+	if (plugin::check_handin(\%itemcount, 12196 => 1, 16581 => 1, 13498 => 1)) {
 		quest::say("Hide, hide, safe, cee.. lerk has the clue.. Must travel.. Travel.. Travel.. Tunaria's corridor.");
 		#:: Give a 12143 - H.K. 102
 		quest::summonitem(12143);

--- a/gfaydark/Heartwood_Master.pl
+++ b/gfaydark/Heartwood_Master.pl
@@ -31,7 +31,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 18786 - Tattered Note
-	if (plugin::takeItems(18786 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18786 => 1)) {
 		quest::say("Welcome! We are the Soldiers of Tunare, the sworn protectors of Faydark. I thank you for joining our cause, we can always use the help. Once you are ready to begin your training please make sure that you see Aliafya Mistrunner, she can assist you in developing your hunting and gathering skills. Return to me when you have become more experienced in our art, I will be able to further instruct you on how to progress through your early ranks, as well as in some of the various [" . quest::saylink("trades") . "] you will have available to you.");
 		#:: Give a 13537 - Green and Tan Tunic*
 		quest::summonitem(13537); # Item: Green and Tan Tunic*
@@ -45,7 +45,7 @@ sub EVENT_ITEM {
 		quest::faction(246,15);		#:: + Faydark's Champions
 	}
 	#:: Match a 5013 - Rusty Short Sword, 5016 - Rusty Broad Sword, 5019 - Rusty Long Sword and 5022 - Rusty Bastard Sword
-	if (plugin::takeItems(5013 => 1, 5016 => 1, 5019 => 1, 5022 => 1)) {
+	if (plugin::check_handin(\%itemcount, 5013 => 1, 5016 => 1, 5019 => 1, 5022 => 1)) {
 		quest::say("You have done well, child! Take this as a blessing from Tunare for doing her will.");
 		#:: Randomly give a 5047 - Tarnished Scimitar or 6012 - Worn Great Staff
 		quest::summonitem(quest::ChooseRandom(5047,6012)); # Item(s): Tarnished Scimitar (5047), Worn Great Staff (6012)

--- a/global/Priest_of_Discord.pl
+++ b/global/Priest_of_Discord.pl
@@ -14,7 +14,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 18700 - Tome of Order and Discord
-	if (plugin::takeItems(18700 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18700 => 1)) {
 		quest::say("I see you wish to join us in Discord! Welcome! By turning your back on the protection of Order you are now open to many more opportunities for glory and power. Remember that you can now be harmed by those who have also heard the call of Discord.");
 		#:: Ding!
 		quest::ding();

--- a/global/Zapf.pl
+++ b/global/Zapf.pl
@@ -38,7 +38,7 @@ sub EVENT_ITEM {
 		quest::say("Now your faction will be adjusted by $change_amount points.");
 	}
 	#:: Match a 66615 - Gold Ticket
-	if (plugin::takeItems(66615 => 1)) {
+	if (plugin::check_handin(\%itemcount, 66615 => 1)) {
 		my @prizes = (11668, 59509);
 		foreach $prizes (@prizes) {
 			next if (plugin::check_hasitem($client, $prizes));

--- a/grobb/Basher_Nanrum.pl
+++ b/grobb/Basher_Nanrum.pl
@@ -14,10 +14,10 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match three 10307 - Fire Beetle Eye
-	if (plugin::takeItems(10307 => 3)) {
+	if (plugin::check_handin(\%itemcount, 10307 => 3)) {
 		quest::say("Heh heh. All da eyeballses! I didn't think ya could do it but ya did. Here is da shiny. If you gets more I always have more shinies.");
 		#:: Give a random reward: 10351 - Brass Earring, 10026 - Cat's Eye Agate, 10060 - Chunk of Metal Ore, 10018 - Hematite, 10006 - Silver Earring, 10017 - Turquoise
-		quest::summonitem(1quest::ChooseRandom(10351, 10026, 10060, 10018, 10006, 10017));
+		quest::summonitem(quest::ChooseRandom(10351, 10026, 10060, 10018, 10006, 10017));
 		#:: Ding!
 		quest::ding();
 		#:: Grant a small amount of experience
@@ -27,13 +27,13 @@ sub EVENT_ITEM {
 		quest::faction(222, -5);		#:: - Broken Skull Clan
 	}
 	#:: Match two 10307 - Fire Beetle Eye
-	elsif (plugin::takeItems(10307 => 2)) {
+	elsif (plugin::check_handin(\%itemcount, 10307 => 2)) {
 	 	quest::say("Well dat be some of da eyeballses I askeded for. But I you needs ta give me three for da shiny.");
 		#:: Return two 10307 - Fire Beetle Eye
 		quest::summonitem(10307,2);
 	}
 	#:: Match one 10307 - Fire Beetle Eye
-	elsif (plugin::takeItems(10307 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 10307 => 1)) {
 	 	quest::say("Well dat be some of da eyeballses I askeded for. But I you needs ta give me three for da shiny.");
 		#:: Return one 10307 - Fire Beetle Eye
 		quest::summonitem(10307,1);

--- a/grobb/Bregna.pl
+++ b/grobb/Bregna.pl
@@ -21,7 +21,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 13984 - Crate of Potions
-	if (plugin::takeItems(13984 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13984 => 1)) {
 		quest::say("Now Kaglari won't be mad at Bregna.");
 		#:: Give a 12212 - Kaglari Mana Doll
 		quest::summonitem(12212);
@@ -35,7 +35,7 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Match a 26632 - Blood Raven Tailfeather, a 26640 - Wrulon Claw,  a 29921 - Arachnae Fangs, a 26662 - Swirling Banshee Essence
-	elsif (plugin::takeItems(26632 => 1, 26640 => 1, 29921 => 1, 26662 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 26632 => 1, 26640 => 1, 29921 => 1, 26662 => 1)) {
 		#:: Match if Expansion Setting is Planes of Power (8) or greater
 		if ($ExpansionSetting > 7) {
 			quest::say("Dis am gud. I see you've been talkin' to Garuuk. Methanks you fer da help. Take dis note back ta Garuuk so he knows you helped me. Tanks again!");

--- a/grobb/Carver_Cagrek.pl
+++ b/grobb/Carver_Cagrek.pl
@@ -28,7 +28,7 @@ sub EVENT_ITEM {
 		quest::faction(222, -1);	#:: - Broken Skull Clan
 	}
 	#:: Match four 12191 - Spore Mushroom
-	elsif (plugin::takeItems(12191 => 4)) {
+	elsif (plugin::check_handin(\%itemcount, 12191 => 4)) {
 		quest::say("Gud werk!! Me already, err, founds, dung part of meal. Here we go. One Fungus Dung Pie!! Enjoys.");
 		#:: Give a 12210 - Fungus Dung Pie
 		quest::summonitem(12210);
@@ -45,7 +45,7 @@ sub EVENT_ITEM {
 		quest::faction(222, -1);	#:: - Broken Skull Clan
 	}
 	#:: Match three 13368 - HEHE Meat and a 18940 - Tattered Recipe
-	elsif (plugin::takeItems(13368 => 3, 18940 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13368 => 3, 18940 => 1)) {
 		quest::say("Finally!! What takes yous so long? Now carver Cagrek try and makes meat and feeds to trolls. Yous getting to be deputy carver. Mes give you Grobb cleaver!! Make strong and smarts on you it will. Just like carver Cagrek.");
 		#:: Give a 5413 - Grobb Cleaver
 		quest::summonitem(15413);

--- a/grobb/Hergor.pl
+++ b/grobb/Hergor.pl
@@ -20,11 +20,11 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 12210 - Fungus Dung Pie
-	if (plugin::takeItems(12210 => 1)) {
+	if (plugin::check_handin(\%itemcount, 12210 => 1)) {
 		quest::say("Mmmmm..Mm..Mmm!!! Dat smells gud!! Me gets more fat and get more strength. You dus gud job weekiling. Me gives you dis armer. Now gos away. Me no share pie wit weekling.");
 		#:: Give a random reward: 2125 - Large Tattered Skullcap, 2126 - Large Tattered Mask, 2127 - Large Tattered Gorget, 2129 - Large Tattered Shoulderpads, 2131 - Large Tattered Belt, 2133 - Large Tattered Wristbands, 2134 - Large Tattered Gloves, 2161 - Large Raw-hide Skullcap, 2162 - Large Raw-hide Mask
 		#:: 2163 - Large Raw-hide Gorget, 2164 - Large Raw-hide Tunic, 2165 - Large Raw-hide Shoulderpads, 2166 - Large Raw-hide Cloak, 2167 - Large Raw-hide Belt, 2168 - Large Raw-hide Sleeves, 2169 - Large Raw-hide Wristbands, 2170 - Large Raw-hide Gloves, 2171 - Large Raw-hide Leggings, 2172 - Large Raw-hide Boots
-		quest::summonitem(1quest::ChooseRandom(2125, 2126, 2127, 2129, 2131, 2133, 2134, 2161, 2162, 2163, 2164, 2165, 2166, 2167, 2168, 2169, 2170, 2171, 2172));
+		quest::summonitem(quest::ChooseRandom(2125, 2126, 2127, 2129, 2131, 2133, 2134, 2161, 2162, 2163, 2164, 2165, 2166, 2167, 2168, 2169, 2170, 2171, 2172));
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/grobb/Hukulk.pl
+++ b/grobb/Hukulk.pl
@@ -30,7 +30,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 18792 - Tattered Note
-	if (plugin::takeItems(18792 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18792 => 1)) {
 		quest::say("Haaah!! Bow to Hukulk!! Hukulk make you feared.. make you powered! Dark power flow through you! Hate and Fear in your blood!");
 		#:: Give a 13530 - Black and Green Tunic*
 		quest::summonitem(13530);
@@ -45,7 +45,7 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Match four 13073 - Bone Chips
-	elsif (plugin::takeItems(13073 => 4)) {
+	elsif (plugin::check_handin(\%itemcount, 13073 => 4)) {
 		quest::say("You good. Take dis. Make much pain and hurt. Make tings bleeds. Kill, hurt all. Innoruuk and me say do, now go. You do much, come bak. Teach you how more hurt and pain make. Go.");
 		#:: Give a 5023 - Rusty Two Handed Sword
 		quest::summonitem(15023);
@@ -58,7 +58,7 @@ sub EVENT_ITEM {
 		quest::faction(235, 10);		#:: - Da Bashers
 	}
 	#:: Match a 12201 - Troll Head and 12202 - Happy Love Bracers
-	elsif (plugin::takeItems(12201 => 1, 12202 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 12201 => 1, 12202 => 1)) {
 		quest::say("Ha!! Ha!! Who have last laugh now!! You do good werk.  Now me give you extra helm of Hukulk. Now go away!!");
 		#:: Give a 3316 - Helm of Hukulk
 		quest::summonitem(13316);

--- a/grobb/Kaglari.pl
+++ b/grobb/Kaglari.pl
@@ -24,7 +24,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match two 13073 - Bone Chips and two 13187 - Froglok Tadpole Flesh
-	if (plugin::takeItems(13073 => 2, 13187 => 2)) {
+	if (plugin::check_handin(\%itemcount, 13073 => 2, 13187 => 2)) {
 		quest::say("Good. Innoruuk get special gift. Not you, dis time. Here. Learning majik wid dis. You more want to [help Innoruuk]?");
 		#:: Give a 15093 - Spell: Burst of Flame
 		quest::summonitem(15093);
@@ -38,7 +38,7 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Match a 13916 - Deathfist Slashed Belt
-	elsif (plugin::takeItems(13916 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13916 => 1)) {
 		quest::say("Good job. Dat help lerns um. Takes dis ta help ya lerns how ta do more hateful tings. Ya gots a good starts fer Him ta be prouds a ya.");
 		#:: Give a 15272 - Spell: Spirit Pouch
 		quest::summonitem(15272);
@@ -52,7 +52,7 @@ sub EVENT_ITEM {
 		quest::exp(150);
 	}							
 	#:: Match a 18791 - Tattered Note
-	elsif (plugin::takeItems(18791 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 18791 => 1)) {
 		quest::say("Good.. Kaglari need you help.. Kaglari teach you majik now.  When you ready for task you tell Kaglari!!  Yooz reeturn to mez when yooz ar strongur, mez teech yooz bout da mor advanced tings.");
 		#:: Give a 13529 - Muck Stained Tunic*
 		quest::summonitem(13529);

--- a/grobb/Ranjor.pl
+++ b/grobb/Ranjor.pl
@@ -21,7 +21,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match 18790 - Tattered Note
-	if (plugin::takeItems(18790 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18790 => 1)) {
 		quest::say("Arhh.. Ranjor mighty warrior.. Ranjor teach you warrior.. you fight for Ranjor now.");
 		#:: Give a 13528 - Mud Covered Tunic*
 		quest::summonitem(13528);
@@ -34,7 +34,7 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Match a 13409 - Froglok Meat and two 13187 - Froglok Tadpole Flesh
-	elsif (plugin::takeItems(13409 => 1, 13187 => 2)) {
+	elsif (plugin::check_handin(\%itemcount, 13409 => 1, 13187 => 2)) {
 		quest::say("You is berry slow. Me too hungry. Me shood eats you for being slow. Gib me dat stuff. Here, take dis and git more stuff fer us. You much kllin, come backs sees me. I teeches ya hows ta kill bedder. Now git and kill stuff. We be Da Bashers fer a reesun.");
 		#:: Give a 5025 - Rusty Two Handed Battle Axe
 		quest::summonitem(15025);

--- a/grobb/Treskar.pl
+++ b/grobb/Treskar.pl
@@ -97,7 +97,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 12190 - Huge Mushroom Head
-	if (plugin::takeItems(12190 => 1)) {
+	if (plugin::check_handin(\%itemcount, 12190 => 1)) {
 		#:: Match if faction is Amiable or better
 		if ($faction <= 4) {
 			quest::say("You do it! You am great knight. Me give you special froglok skin mask. Shaman make for Nightkeep. It am make you smarter like Treskar... Me tink so!");
@@ -130,7 +130,7 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Match three 13782 - Ruined Wolf Pelt and a 10307 - Fire Beetle Eye
-	elsif (plugin::takeItems(13782 => 3, 10307 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13782 => 3, 10307 => 1)) {
 		#:: Match if faction is Amiable or better
 		if ($faction <= 4) {
 			quest::say("Dats gud, here take dis armor to helps you be stronger. Come sees me when you want [another] job");
@@ -158,12 +158,12 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Match two 13088 - Snake Egg
-	elsif (plugin::takeItems(13088 => 2)) {
+	elsif (plugin::check_handin(\%itemcount, 13088 => 2)) {
 		#:: Match if faction is Amiable or better
 		if ($faction <= 4) {
 			quest::say("Dis is good.  I go make a pie now. Here is sumting for your help. Come see me agin when you want your [next] job.");
 			#:: Give a random reward: 2145 - Raw-hide Wristbands, 2140 - Raw-hide Tunic, 2144 - Raw-hide Sleeves, 2137 - Raw-hide Skullcap, 2138 - Raw-hide Mask, 2147 - Raw-hide Leggings, 2139 - Raw-hide Gorget, 2146 - Raw-hide Gloves, 2142 - Raw-hide Cloak, 2148 - Raw-hide Boots, 2143 - Raw-hide Belt
-			quest::summonitem(1quest::ChooseRandom(2145, 2140, 2144, 2137, 2138, 2147, 2139, 2146, 2142, 2148, 2143));
+			quest::summonitem(quest::ChooseRandom(2145, 2140, 2144, 2137, 2138, 2147, 2139, 2146, 2142, 2148, 2143));
 			#:: Ding!
 			quest::ding();
 			#:: Grant a moderate amount of experience
@@ -190,12 +190,12 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Match three 13916 - Deathfist Slashed Belt
-	elsif (plugin::takeItems(13916 => 3)) {
+	elsif (plugin::check_handin(\%itemcount, 13916 => 3)) {
 		#:: Match if faction is Amiable or better
 		if ($faction <= 4) {
 			quest::say("Very good! We turn you into a basher yet. Here you go. Come see me when you want your [final] task.");
 			#:: Give a random reward: 6031 - Tarnished Warhammer, 5070 - Tarnished Two Handed Sword, 5071 - Tarnished Two Handed Battle Axe, 7024 - Tarnished Spear, 5042 - Tarnished Short Sword, 5047 - Tarnished Scimitar, 6033 - Tarnished Morning Star
-			quest::summonitem(1quest::ChooseRandom(6031, 5070, 5071, 7024, 5042, 5047, 6033));
+			quest::summonitem(quest::ChooseRandom(6031, 5070, 5071, 7024, 5042, 5047, 6033));
 			#:: Ding!
 			quest::ding();
 			#:: Grant a moderate amount of experience
@@ -226,12 +226,12 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Match two 13403 - Wolf Meat and two 13070 - Snake Scales
-	elsif (plugin::takeItems(13403 => 2,13070 => 2)) {
+	elsif (plugin::check_handin(\%itemcount, 13403 => 2,13070 => 2)) {
 		#:: Match if faction is Amiable or better
 		if ($faction <= 4) {
 			quest::say("Dats what I needed. Here you go.");
 			#:: Give a random reward: 6014 - Rusty Warhammer, 5023 - Rusty Two Handed Sword, 6013 - Rusty Two Handed Hammer, 7009 - Rusty Spear, 5013 - Rusty Short Sword, 5021 - Rusty Scimitar
-			quest::summonitem(1quest::ChooseRandom(6014, 5023, 6013, 7009, 5013, 5021));
+			quest::summonitem(quest::ChooseRandom(6014, 5023, 6013, 7009, 5013, 5021));
 			#:: Ding!
 			quest::ding();
 			#:: Grant a moderate amount of experience
@@ -271,7 +271,7 @@ sub EVENT_ITEM {
 		if ($faction <= 4) {
 			quest::say("Hmm... You do good job. You surprise Treskar. Maybe you good after all. Maybe Treskar give you [secret mission]. Maybe not.");
 			#:: Give a random reward: 5071 - Tarnished Two Handed Battle Axe, 5025 - Rusty Two Handed Battle Axe, 5037 - Bronze Two Handed Battle Axe
-			quest::summonitem(1quest::ChooseRandom(5071, 5025, 5037, 5025, 5071));
+			quest::summonitem(quest::ChooseRandom(5071, 5025, 5037, 5025, 5071));
 			#:: Ding!
 			quest::ding();
 			#:: Set factions
@@ -307,7 +307,7 @@ sub EVENT_ITEM {
 		}
 	}	
 	#:: Match one 12199 - Black Shadow Tunic
-	elsif (plugin::takeItems(12199 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 12199 => 1)) {
 		quest::say("Me change mind! Me want total of THREE ogre black shadow tunics. Ha Ha! And you also pay two gold for Nightkeep tax! Ha! Ha!");
 		#:: Return a 12199 - Black Shadow Tunic
 		quest::summonitem(12199);

--- a/grobb/Urako.pl
+++ b/grobb/Urako.pl
@@ -60,7 +60,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 12213 - The Baker, a 12214 - The Butcher, a 12215 - The Captain, a 12216 - The Minstrel
-	if (plugin::takeItems(12213 => 1, 12214 => 1, 12215 => 1, 12216 => 1)) {
+	if (plugin::check_handin(\%itemcount, 12213 => 1, 12214 => 1, 12215 => 1, 12216 => 1)) {
 		#:: Match if faction is Amiable or better
 		if ($faction <= 4) {
 			quest::say("Tank you. You saved me neck. Kaglari not learn me mistake now. Me give you a [Kaglari mana doll].");

--- a/grobb/a_prisoner.pl
+++ b/grobb/a_prisoner.pl
@@ -9,7 +9,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 13311 - Intestine Necklace
-	if (plugin::takeItems(13311 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13311 => 1)) {
 		quest::say("Groak.. So you are a friend to the froglok. ..Grooakk.. I am soon to die. My precious legs are a delicacy here. Before I go I must contact my brother Grikk. He is a froglok forager in Innothule. Give him this vial. He will know what it means");
 		#:: Give a 13375 - Empty Vial
 		quest::summonitem(13375);
@@ -19,10 +19,10 @@ sub EVENT_ITEM {
 		$client->AddLevelBasedExp(10,1);
 	}
 	#:: Match a 13376 - Ochre Liquid
-	elsif (plugin::takeItems(13376 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13376 => 1)) {
 		quest::say("Grooak.. You have done much to help me. This will come in handy soon. Thank you. Here is Marda's information. Take it to her. They must know. Farewell.");
 		#:: Give a random reward: 18884 - Tattered Note or 18885 - Tattered Cloth Note
-		quest::summonitem(1quest::ChooseRandom(18884,18885));
+		quest::summonitem(quest::ChooseRandom(18884,18885));
 		#:: Ding!
 		quest::ding();
 		#:: Grant a small amount of experience based on level

--- a/halas/Cindl.pl
+++ b/halas/Cindl.pl
@@ -26,10 +26,10 @@ sub EVENT_SAY {
 	
 sub EVENT_ITEM {
 	#:: Match a 13761 - Polar Bear Skin
-	if (plugin::takeItems(13761 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13761 => 1)) {
 		quest::say("This is much appreciated.  Please accept this used armor in return and also a gold piece for yer troubles.  You have done well! I may have a [second job] fer ye, if ye like?");
 		#:: Give a random item: 2130 - Large Patchwork Cloak, 2131 - Large Tattered Belt, 2132 - Large Patchwork Sleeves, 2134 - Large Tattered Gloves, 2135 - Large Patchwork Pants, 2136 - Large Patchwork Boots, 2127 - Large Tattered Gorget, 2126 - Large Tattered Mask, 2128 - Large Patchwork Tunic, 2129 - Large Tattered Shoulderpads, 2125 - Large Tattered Skullcap, 2133 - Large Tattered Wristbands
-		quest::summonitem(1quest::ChooseRandom(2130, 2131, 2132, 2134, 2135, 2136, 2127, 2126, 2128, 2129, 2125, 2133));
+		quest::summonitem(quest::ChooseRandom(2130, 2131, 2132, 2134, 2135, 2136, 2127, 2126, 2128, 2129, 2125, 2133));
 		#:: Ding!
 		quest::ding();
 		#:: Set factions
@@ -45,10 +45,10 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Match two 12223 - Wrath Orc Wristbands
-	elsif (plugin::takeItems(12223 => 2)) {
+	elsif (plugin::check_handin(\%itemcount, 12223 => 2)) {
 		quest::say("Fine work hunter!  As your reward please accept this item which I have fashioned for you.");
 		#:: Give a random item: 2034 - Large Leather Gloves, 2171 - Large Raw-hide Leggings, 2164 - Large Raw-hide Tunic
-		quest::summonitem(1quest::ChooseRandom(2034, 2171, 2164));
+		quest::summonitem(quest::ChooseRandom(2034, 2171, 2164));
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/halas/Dargon_McPherson.pl
+++ b/halas/Dargon_McPherson.pl
@@ -34,12 +34,12 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 13245 - Empty Bottle of Elixir
-	if (plugin::takeItems(13245 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13245 => 1)) {
 		#:: Match if faction is Amiable or better
 		if ($faction <= 4) {
 			quest::say("Ye've proven yerself to be a cut above the rest and aided yer fellow warriors, no matter how worthless they were. Ye may take this. It was found in the snow by one of our foraging parties. I hope it can be of use to a warrior like yerself.");
 			#:: Give a random reward: 2012 - Leather Boots, 17001 - Wrist Pouch, 10004 - Copper Band, 10017 - Turquoise, 1038 - Tattered Cloth Sandal, 10016 - Lapis Lazuli, 13877 - Corroded Buckler, 2135 - Large Patchwork Pants, 7007 - Rusty Dagger, 8008 - Throwing Axe, 10009 - Bead Necklace, 13007 - Ration, 5014 - Rusty Axe, 13003 - Small Lantern
-			quest::summonitem(1quest::ChooseRandom(2012, 17001, 10004, 10017, 1038, 10016, 13877, 2135, 7007, 8008, 10009, 13007, 5014, 13003));
+			quest::summonitem(quest::ChooseRandom(2012, 17001, 10004, 10017, 1038, 10016, 13877, 2135, 7007, 8008, 10009, 13007, 5014, 13003));
 			#:: Ding!
 			quest::ding();
 			#:: Set factions

--- a/halas/Dok.pl
+++ b/halas/Dok.pl
@@ -29,7 +29,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 12222 - Full Honeycomb Jar
-	if (plugin::takeItems(12222 => 1)) {
+	if (plugin::check_handin(\%itemcount, 12222 => 1)) {
 		quest::say("Great work!! Now I can make more candles! Here ye are, me friend. I call this the Everburn Candle. It has a wee bit o' magic in it. I hope ye like it.");
 		#:: Give a 12220 - Everburn Candle
 		quest::summonitem(12220);
@@ -47,7 +47,7 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Match 12275 - Foot of Candlestick, 12276 - Stem of Candlestick, 12282 - Soil of Underfoot and 13953 - Honeycomb
-	elsif (plugin::takeItems(12275 => 1, 12276 => 1, 12282 => 1, 13953 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 12275 => 1, 12276 => 1, 12282 => 1, 13953 => 1)) {
 		quest::say("Here is your Candle o' Bravery.");
 		#:: Give a 12277 - Candle of Bravery
 		quest::summonitem(12277);

--- a/halas/Dun_McDowell.pl
+++ b/halas/Dun_McDowell.pl
@@ -25,7 +25,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 18762 - Tattered Note
-	if (plugin::takeItems(18762 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18762 => 1)) {
 		quest::say("Ah.. ye wish to be a member o' the White Rose, then. eh? Well, let's train ye fer a bit. and see if ye've got what it takes. Once you are ready to begin adventuring make sure you see Lysbith first, she might have a few tasks for you.  Return to me for guidance anytime, I have much to teach you, from the secrets of the profession, to the various [trades] you may wish to dabble in.");
 		#:: Give a 13513 - Torn White Tunic*
 		quest::summonitem(13513);

--- a/halas/Hetie_McDonald.pl
+++ b/halas/Hetie_McDonald.pl
@@ -17,7 +17,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 1839 - Full Muffin Crate
-	if (plugin::takeItems(1839 => 1)) {
+	if (plugin::check_handin(\%itemcount, 1839 => 1)) {
 		quest::say("Oh, yes, this is exactly what I needed. These muffins look very fresh too, good work! Here is your payment, as promised. It was a pleasure doing business with you.");
 		#:: Ding!
 		quest::ding();
@@ -35,7 +35,7 @@ sub EVENT_ITEM {
 		quest::MerchantSetItem(29038, 13014, 20);
 	}
 	#:: Match a 1838 - Bag of Bread Loaves
-	elsif (plugin::takeItems(1838 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 1838 => 1)) {
 		quest::say("Fresh Bread!  Thank you!");
 		#:: Ding!
 		quest::ding();

--- a/halas/Holana_Oleary.pl
+++ b/halas/Holana_Oleary.pl
@@ -28,14 +28,14 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 13962 - Karana Clover Shipment
-	if (plugin::takeItems(13962 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13962 => 1)) {
 		#:: Match if faction is Amiable or better
 		if ($faction <= 4) {
 			quest::say("Good work. We Shamans o' Justice are like no other. We must remain in top physical form for we never know when justice must be served. I was commanded to give ye a reward. Take this. It was doing nothing more than collecting dust. Go, and serve justice well.");
 			#:: Give a random reward: 15270 - Spell: Drowsy, 15275 - Spell: Frost Rift, 15075 - Spell: Sicken, 15271 - Spell: Fleeting Fury, 15279 - Spell: Spirit of Bear, 15212 - Spell: Cure Blindness, 15079 - Spell: Spirit Sight, 15274 - Spell: Scale Skin, 15272 - Spell: Spirit Pouch
 			#:: 2031 - Large Leather Belt, 2036 - Large Leather Boots, 2030 - Large Leather Cloak, 2034 - Large Leather Gloves, 2027 - Large Leather Gorget, 2038 - Large Leather Kilt, 2026 - Large Leather Mask, 2029 - Large Leather Shoulderpads, 2025 - Large Leather Skullcap, 2032 - Large Leather Sleeves, 2028 - Large Leather Tunic, 2033 - Large Leather Wristbands
 			#:: 2912 - Polar Bear Cloak, 5043 - Tarnished Axe, 6032 - Tarnished Flail, 6030 - Tarnished Mace, 7022 - Tarnished Shortened Spear, 7024 - Tarnished Spear, 6031 - Tarnished Warhammer
-			quest::summonitem(1quest::ChooseRandom(15270, 15275, 15075, 15271, 15279, 15212, 15079, 15274, 15272, 2031, 2036, 2030, 2034, 2027, 2038, 2026, 2029, 2025, 2032, 2028, 2033, 2912, 5043, 6032, 6030, 7022, 7024, 6031, 2912));
+			quest::summonitem(quest::ChooseRandom(15270, 15275, 15075, 15271, 15279, 15212, 15079, 15274, 15272, 2031, 2036, 2030, 2034, 2027, 2038, 2026, 2029, 2025, 2032, 2028, 2033, 2912, 5043, 6032, 6030, 7022, 7024, 6031, 2912));
 			#:: Ding!
 			quest::ding();
 			#:: Set factions

--- a/halas/Jinkus_Felligan.pl
+++ b/halas/Jinkus_Felligan.pl
@@ -58,7 +58,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 12621 - Mammoth Hide Parchment and 12619 - Vial of Datura Ink
-	if (plugin::takeItems(12621 => 1, 12619 => 1)) {
+	if (plugin::check_handin(\%itemcount, 12621 => 1, 12619 => 1)) {
 		quest::say("Here is th' bounty poster. Take it to a bank guard in Qeynos, immediately!");
 		#:: Give a 12620 - Wanted Poster
 		quest::summonitem(12620);
@@ -72,7 +72,7 @@ sub EVENT_ITEM {
 		quest::faction(244, -1); 	#:: - Ebon Mask
 	}
 	#:: Match a 12622 - List of Qeynos Most Wanted
-	elsif (plugin::takeItems(12622 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 12622 => 1)) {
 		quest::say("Ye're learnin' to serve the church well, young Initiate $name. I grant ye yer holy symbol and the blessing o' the Tribunal that They may grant ye wisdom in serving Their will..");
 		#:: Give a 1376 - Initiate Symbol of the Tribunal
 		quest::summonitem(11376);

--- a/halas/Kylan_O-Danos.pl
+++ b/halas/Kylan_O-Danos.pl
@@ -25,7 +25,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 18760 - Tattered Note
-	if (plugin::takeItems(18760 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18760 => 1)) {
 		quest::say("Greetin's! We are the mighty Wolves o' the North, protectors o' Halas, and we must work hard t' keep it safe fer our citizens. Here is our tunic, it identifies ye as a proud warrior o' this great city. Once you are ready to begin your training please make sure that you see Lysbith, she can assist you in developing your hunting and gathering skills. Return to me when you have become more experienced in our art, I will be able to further instruct you on how to progress through your early ranks, as well as in some of the various [trades] you will have available to you.");
 		#:: Give a 13511 - Patched Fur Tunic*
 		quest::summonitem(13511);

--- a/halas/Lysbith_McNaff.pl
+++ b/halas/Lysbith_McNaff.pl
@@ -26,10 +26,10 @@ sub EVENT_SAY {
 	
 sub EVENT_ITEM {
 	#:: Match three 13915 - Gnoll Fang
-	if (plugin::takeItems(13915 => 3)) {
+	if (plugin::check_handin(\%itemcount, 13915 => 3)) {
 		quest::say("Fine work, fine work!  The gnoll threat must be extinguished before it can ever fully grow.  Ye've done yer part to aid our cause.  Please allow me to repay ye with a few provisions and a wee bit o' coin.  Then, continue with yer good deeds. Halas is surrounded by barren arctic tundra. We've many foes. Among them are the [orc troopers], [ice goblins] and the ever-present polar bears.");
 		#:: Choose a random reward from 13005 - Iron Ration, 13007 - Ration, 13002 - Torch, 13006 - Water Flask
-		quest::summonitem(1quest::ChooseRandom(13005, 13007, 13002, 13006));
+		quest::summonitem(quest::ChooseRandom(13005, 13007, 13002, 13006));
 		#:: Ding!
 		quest::ding();
 		#:: Set factions
@@ -45,7 +45,7 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Match four 12223 - Wrath Orc Wristbands
-	elsif (plugin::takeItems(12223 => 4)) {
+	elsif (plugin::check_handin(\%itemcount, 12223 => 4)) {
 		quest::say("Ye're becoming a fine champion o' Halas. Take th' Seax. May ye always defend Halas!");
 		#:: Give a 7322 - Seax
 		quest::summonitem(17322);
@@ -60,10 +60,10 @@ sub EVENT_ITEM {
 		quest::exp(800);
 	}
 	#:: Match a 13898 - Bag of Ice Necklaces
-	elsif (plugin::takeItems(13898 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13898 => 1)) {
 		quest::say("Ye've done well, me young $class.  We've gathered these to add to yer provisions.  While in the Everfrost Peaks, be on the watch fer any gnolls ye may find.  I declare there to be a [gnoll bounty].");
 		#:: Choose a random reward from 13005 - Iron Ration, 13007 - Ration, 13002 - Torch, 13006 - Water Flask, 13003 - Small Lantern
-		quest::summonitem(1quest::ChooseRandom(13005, 13007, 13002, 13006, 13003));
+		quest::summonitem(quest::ChooseRandom(13005, 13007, 13002, 13006, 13003));
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/halas/Margyn_McCann.pl
+++ b/halas/Margyn_McCann.pl
@@ -24,7 +24,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 13729 - Barbarian Head
-	if (plugin::takeItems(13729 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13729 => 1)) {
 		quest::say("We can now rest assured that justice has been served. Ye'll be a valuable asset to our court. Take and remember this spell, Spirit o' the Bear. I hope ye've attained the necessary skills to scribe it. If not, I'm sure ye soon will. Go now, and serve justice.");
 		#:: Give a 15279 - Spell: Spirit of Bear
 		quest::summonitem(15279);
@@ -44,7 +44,7 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Match a 18761 - Tattered Note
-	elsif (plugin::takeItems(18761 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 18761 => 1)) {
 		quest::say("Welcome t' the Church o' the Tribunal. Here, we practice the will o' the Six Hammers. This is our guild tunic - wear it with pride and represent us well.");
 		#:: Give a 13512 - Faded Blue Tunic*
 		quest::summonitem(13512);

--- a/halas/Renth_McLanis.pl
+++ b/halas/Renth_McLanis.pl
@@ -69,12 +69,12 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 13246 - Box of Remains
-	if (plugin::takeItems(13246 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13246 => 1)) {
 		#:: Match if faction is Indifferent or better
 		if ($faction <= 5) {
 			quest::say("Good work!! Kylan will never know o' me negligence. I owe ye one, young warrior. Let's call it even with this. Twas found by one of our foraging parties. It is still useful. And... I believe ye can assist with a more [dangerous matter] as well");
 			#:: Give a random reward: 17001 - Wrist Pouch, 17002 - Belt Pouch, 17003 - Small Bag, 17009 - Purse
-			quest::summonitem(1quest::ChooseRandom(17001, 17002, 17003, 17004, 17009));
+			quest::summonitem(quest::ChooseRandom(17001, 17002, 17003, 17004, 17009));
 			#:: Ding!
 			quest::ding();
 			#:: Set Factions
@@ -96,7 +96,7 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Match a 12227 - Barbarian head Identifies as Basil's Head
-	if (plugin::takeItems(12227 => 1)) {
+	if (plugin::check_handin(\%itemcount, 12227 => 1)) {
 		#:: Match if faction is Indifferent or better
 		if ($faction <= 5) {
 			quest::say("Fine work! We've avenged our fellow Northmen and ye've earned yer Langseax. Wield it in the name o' Halas!");
@@ -123,7 +123,7 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Match a 12225 - Barbarian head (Identifies as Paglan's Head)
-	elsif (plugin::takeItems(12225 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 12225 => 1)) {
 		#:: Match if faction is Indifferent or better
 		if ($faction <= 5) {
 			quest::say("Incredible! We’d heard Paglan was killed attempting to cross an ice floe! It appears his escape was for naught, Ye’ve earned something greater than a mere Langseax. Ye’ve earned the Langseax o’ the Wolves. Tis an enchanted weapon meant for a warrior’s skill only. The Tribunal will watch over ye.");

--- a/halas/Shamus_Felligan.pl
+++ b/halas/Shamus_Felligan.pl
@@ -12,10 +12,10 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 13968 - Shattered Caster Beads
-	if (plugin::takeItems(13968 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13968 => 1)) {
 		quest::say("Shattered! This has happened frequently! These beads are very delicate. They're useless to me now, however, I'll reward ye fer the execution of yet more goblin casters. Continue yer work. The Tribunal watches ye!");
 		#:: Give a random reward: 15270 - Spell: Drowsy, 15275 - Spell: Frost Rift, 15075 - Spell: Sicken, 15271 - Spell: Fleeting Fury, 15212 - Spell: Cure Blindness, 15079 - Spell: Spirit Sight
-		quest::summonitem(1quest::ChooseRandom(15270, 15275, 15075, 15271, 15212, 15079));
+		quest::summonitem(quest::ChooseRandom(15270, 15275, 15075, 15271, 15212, 15079));
 		#::Ding!
 		quest::ding();
 		#:: Set factions
@@ -32,7 +32,7 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Match a 13969 - Caster Beads
-	elsif (plugin::takeItems(13969 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13969 => 1)) {
 		quest::say("Finally! Intact! This IS good news! I can continue me investigation now. As fer yer loyal deed, I'll offer ye this, the Gavel of Justice. May ye employ it well in the service o' justice.");
 		#:: Give a 6028 - Gavel of Justice
 		quest::summonitem(16028);

--- a/halas/Teria_O-Danos.pl
+++ b/halas/Teria_O-Danos.pl
@@ -15,7 +15,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 13961 - Lion Meat Shipment
-	if (plugin::takeItems(13961 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13961 => 1)) {
 		quest::say("Ye've returned!! How wonderful! The people o' Halas thank ye! It isn't often we get to indulge ourselves in the delicacies o' warmer climates. Here ye go, me friend. Ye've completed the delivery in good time. I hope ye deliver more often. Here, try some of me new creation.. Lion Delight.");
 		#:: Give a 12221 - Lion Delight
 		quest::summonitem(12221);

--- a/halas/Thadres_Thyme.pl
+++ b/halas/Thadres_Thyme.pl
@@ -18,7 +18,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 18136 - Delius Thyme's Diary Pg. 74, 18137 - Delius Thyme's Diary Pg. 75, 18138 - Delius Thyme's Diary Pg. 76
-	if (plugin::takeItems(18136 => 1, 18137 => 1, 18138 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18136 => 1, 18137 => 1, 18138 => 1)) {
 		quest::say("Thank you, thank you. Let me read them. Oh! How could I want these brewing recipes after they made my brother insane? Where are they? I think this is all of them. Take them away from me! Delius can smile upon me now.");
 		#:: Give a 18139 - Garsen's Brewing List
 		quest::summonitem(18139);

--- a/halas/Waltor_Felligan.pl
+++ b/halas/Waltor_Felligan.pl
@@ -60,7 +60,7 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Match two 13967 - Wooly Fungus
-	elsif (plugin::takeItems(13967 => 2)) {
+	elsif (plugin::check_handin(\%itemcount, 13967 => 2)) {
 		#:: Match if faction is Indifferent or better
 		if ($faction <= 5) {
 			quest::say("The scales have been balanced and the Tribunal has spoken. Yer body shall be saved.");
@@ -77,7 +77,7 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Match a 13445 - Mammoth Steaks
-	elsif (plugin::takeItems(13445 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13445 => 1)) {
 		#:: Match if faction is Indifferent or better
 		if ($faction <= 5) {
 			quest::say("The scales have been balanced and the Tribunal has spoken. Yer body shall be saved.");
@@ -93,12 +93,12 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Match a 13966 - Jar of Fungus
-	elsif (plugin::takeItems(13966 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13966 => 1)) {
 		#:: Match if faction is Amiable or better
 		if ($faction <= 4) {
 			quest::say("Aye! Ye've filled the jar. I'll see to it that Holana locks this away. Tis difficult to obtain and we can only spare the talents of our young shamans. Allow me to give ye a reward. Thank ye kindly fer yer service.");
 			#:: Give a random reward: 15203 - Spell: Cure Poison, 15270 - Spell: Drowsy, 15271 - Spell: Fleeting Fury, 15275 - Spell: Frost Rift, 15036 - Spell: Gate, 15075 - Spell: Sicken
-			quest::summonitem(1quest::ChooseRandom(15203, 15270, 15271, 15275, 15036, 15075));
+			quest::summonitem(quest::ChooseRandom(15203, 15270, 15271, 15275, 15036, 15075));
 			#:: Ding!
 			quest::ding();
 			#:: Set factions

--- a/halas/Ysanna_MacGibbon.pl
+++ b/halas/Ysanna_MacGibbon.pl
@@ -20,7 +20,7 @@ sub EVENT_SIGNAL {
 
 sub EVENT_ITEM {
 	#:: Match a 1330 - Patched Gnoll Fur Bundle
-	if (plugin::takeItems(1330 => 1)) {
+	if (plugin::check_handin(\%itemcount, 1330 => 1)) {
 		quest::say("You have done well. Here is a small reward for your effort.");
 		#:: Give a 1349 - Fang of the Wolf
 		quest::summonitem(11349);

--- a/highpasshold/Bryan_McGee.pl
+++ b/highpasshold/Bryan_McGee.pl
@@ -21,7 +21,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 12366 - Never Stop Chopping
-	if (plugin::takeItems(12366 => 1)) {
+	if (plugin::check_handin(\%itemcount, 12366 => 1)) {
 		quest::say("On second thought.. You can do a little favor for me first. An associate of mine has asked me to acquire a case of spirits for him. Take this box and seek out what is needed to fill it. Inside you will combine the spirits of Lendel's Grand Lager, Gator Gulp Ale, Blackburrow Swig, Tunare's Finest, Underfoot Triple Bock, Frozen Toe Rum, Blood Spirit, Vasty Deep Ale, Clockwork Oil Stout and the legendary..[Oblong Bottle].");
 		#:: Give a 17984 - Bottle Crate
 		quest::summonitem(17984);
@@ -39,7 +39,7 @@ sub EVENT_ITEM {
 		quest::signalwith(5055, 2, 0);
 	}
 	#:: Match a 12365 - Case of Spirits
-	elsif (plugin::takeItems(12365 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 12365 => 1)) {
 		quest::say("I cannot believe you actually acquired all those drinks!! You do good work, kid. Here is the gem as I promised. And a few plat for good measure. Don't let it be said that the Axe doesn't treat his friends right.");
 		#:: Give a 12348 - Gem of Stamina
 		quest::summonitem(12348);

--- a/highpasshold/Captain_Ashlan.pl
+++ b/highpasshold/Captain_Ashlan.pl
@@ -24,7 +24,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match four 13791 - Orc Scalp
-	if (plugin::takeItems(13791 => 4)) {
+	if (plugin::check_handin(\%itemcount, 13791 => 4)) {
 		#:: Match if faction is Apprehensive or better
 		if ($faction <= 6) {
 			quest::say("Great work. Maybe you can help us out again sometime?");
@@ -46,7 +46,7 @@ sub EVENT_ITEM {
 		#:: Else eat the items
 	}
 	#:: Match three 13791 - Orc Scalp
-	elsif (plugin::takeItems(13791 => 3)) {
+	elsif (plugin::check_handin(\%itemcount, 13791 => 3)) {
 		#:: Match if faction is Apprehensive or better
 		if ($faction <= 6) {
 			quest::say("Great work. Maybe you can help us out again sometime?");
@@ -68,7 +68,7 @@ sub EVENT_ITEM {
 		#:: Else eat the items
 	}
 	#:: Match two 13791 - Orc Scalp
-	elsif (plugin::takeItems(13791 => 2)) {
+	elsif (plugin::check_handin(\%itemcount, 13791 => 2)) {
 		#:: Match if faction is Apprehensive or better
 		if ($faction <= 6) {
 			quest::say("Great work. Maybe you can help us out again sometime?");
@@ -90,7 +90,7 @@ sub EVENT_ITEM {
 		#:: Else eat the items
 	}
 	#:: Match a 13791 - Orc Scalp
-	elsif (plugin::takeItems(13791 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13791 => 1)) {
 		#:: Match if faction is Apprehensive or better
 		if ($faction <= 6) {
 			quest::say("Great work. Maybe you can help us out again sometime?");

--- a/highpasshold/Captain_Orben.pl
+++ b/highpasshold/Captain_Orben.pl
@@ -18,7 +18,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match four 13792 - Gnoll Scalp
-	if (plugin::takeItems(13792 => 4)) {
+	if (plugin::check_handin(\%itemcount, 13792 => 4)) {
 		#:: Match if faction is Dubious or better
 		if ($faction <= 7) {
 			#:: He says nothing.
@@ -38,7 +38,7 @@ sub EVENT_ITEM {
 		#:: Else eat items (cannot find text)
 	}
 	#:: Match three 13792 - Gnoll Scalp
-	elsif (plugin::takeItems(13792 => 3)) {
+	elsif (plugin::check_handin(\%itemcount, 13792 => 3)) {
 		#:: Match if faction is Dubious or better
 		if ($faction <= 7) {
 			#:: He says nothing.
@@ -57,7 +57,7 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Match two 13792 - Gnoll Scalp
-	elsif (plugin::takeItems(13792 => 2)) {
+	elsif (plugin::check_handin(\%itemcount, 13792 => 2)) {
 		#:: Match if faction is Dubious or better
 		if ($faction <= 7) {
 			#:: He says nothing.
@@ -76,7 +76,7 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Match one 13792 - Gnoll Scalp
-	elsif (plugin::takeItems(13792 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13792 => 1)) {
 		#:: Match if faction is Dubious or better
 		if ($faction <= 7) {
 			#:: He says nothing.

--- a/highpasshold/Jovan.pl
+++ b/highpasshold/Jovan.pl
@@ -9,7 +9,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 12114 - Tumpy Tonic
-	if (plugin::takeItems(12114 => 1)) {
+	if (plugin::check_handin(\%itemcount, 12114 => 1)) {
 		quest::say("<SLURP!!>  Ahh thhhhat'thh betterr. Take thithhh. <BURP!>");
 		#:: Give a 19006 - Icon of the Fervent
 		quest::summonitem(19006);

--- a/highpasshold/Marlin_Shirtov.pl
+++ b/highpasshold/Marlin_Shirtov.pl
@@ -12,7 +12,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Turn in for 13352 -  Silk Evening Tunic
-	if (plugin::takeItems(13352 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13352 => 1)) {
 		quest::say("Ahh!! The silk evening tunic. Mistress Anna will look stunning in this. Here is the key to Princess Lenya's cell. Good luck, hero!");
 		#:: Give item 20008 - Brass Key
 		quest::summonitem(20008);

--- a/highpasshold/Prak.pl
+++ b/highpasshold/Prak.pl
@@ -29,7 +29,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 18795 - Letter for Prak
-	if (plugin::takeItems(18795 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18795 => 1)) {
 		#:: Match if faction is Amiable or better
 		if ($faction <= 4) {
 			quest::say("I see. We think we've found out who the mole is in Carson's guards, some guy named Stald. We need to get rid of this guy as quickly, and as quietly, as possible. Carson doesn't want to cause a stink by eliminating one of his own men, so he asked us to do it. What about you? Do you think [you could get rid of Stald] for us?");
@@ -51,7 +51,7 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Match a 13793 - Stald's Badge
-	elsif (plugin::takeItems(13793 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13793 => 1)) {
 		#:: Match if faction is Amiable or better
 		if ($faction <= 4) {
 			quest::say("Ah, boy! Looks like I owe Kaden two plat... I thought you'd fumble it up for sure. Well, you've impressed me friend. Here, take this back to Zan... I'll make sure to note your fine work to Carson, too, next time we speak.");

--- a/kael/Svekk_Fangbinder.pl
+++ b/kael/Svekk_Fangbinder.pl
@@ -47,7 +47,7 @@ sub EVENT_ITEM {
 			quest::exp(250);
 			quest::summonitem(25266); # Giant Sack of Supplies
 		}
-		if(plugin::takeItems(25278=>1)) { # Velium Torque
+		if(plugin::check_handin(\%itemcount, 25278=>1)) { # Velium Torque
 			quest::say("Ahh, a Velium torque!  Here, I'll give you one hundred pieces of gold for that!'  Svekk places the torque in his pocket and drops some coins at his feet.");
 			quest::ding();
 			quest::faction(448,10); # Kromzek
@@ -57,7 +57,7 @@ sub EVENT_ITEM {
 			quest::exp(250);
 			quest::givecash(0,0,0,15);
 		}
-		if(plugin::takeItems(25267=>1)) { # Bekerak's Letter to Svekk
+		if(plugin::check_handin(\%itemcount, 25267=>1)) { # Bekerak's Letter to Svekk
 			quest::say("This is unbelievable!  The fool is asking for things I don't even have in stock!  Listen, $name, you're the one that wanted to help them out, I'm just here working for Wenglawks.  I can get most of these supplies ready but I have no source for Klezendian Crystals.  I will start bundling the more mundane items Bekerak wants.  If you find any Klezendian return to me with the crystal and this voucher.");
 			quest::ding();
 			quest::faction(448,10); # Kromzek
@@ -67,7 +67,7 @@ sub EVENT_ITEM {
 			quest::exp(250);
 			quest::summonitem(25270); # Supply Voucher
 		}
-		if(plugin::takeItems(25270=>1, 25271=>1)) { # Supply Voucher / Klezendian Crystal
+		if(plugin::check_handin(\%itemcount, 25270=>1, 25271=>1)) { # Supply Voucher / Klezendian Crystal
 			quest::say("Did you travel to the crystal caverns to get that crystal, $name?  You are quite brave for a $race.  I have the other supplies ready for your trip, they are quite heavy but I think you will get by.");
 			quest::ding();
 			quest::faction(448,10); # Kromzek

--- a/kerraridge/Feren.pl
+++ b/kerraridge/Feren.pl
@@ -12,7 +12,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 6348 - Razor Tooth
-	if (plugin::takeItems(6348 => 1)) {
+	if (plugin::check_handin(\%itemcount, 6348 => 1)) {
 		quest::say("Razortooth! You catch him! Truly, you be great fisher. Please take this from me. Feren is forever owing you.");
 		#:: Give a 1062 - Kerran Fishingpole
 		quest::summonitem(11062);

--- a/kerraridge/a_banished_kerran.pl
+++ b/kerraridge/a_banished_kerran.pl
@@ -12,13 +12,13 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 12369 - Puab's Token
-	if (plugin::takeItems(12369 => 1)) {
+	if (plugin::check_handin(\%itemcount, 12369 => 1)) {
 		quest::say("Ashen Order!!  Prrr.. My order.  I have been expecting one of us.  Prrr.. Help me rejoin my native land.  Take this box.  Combine all the [remains of Thipt] within the box and return it to me.  This shall aid me in my redemption.");
 		#:: Give a 17985 - Box With Pawprints
 		quest::summonitem(17985);
 	}
 	#:: Match a 12371 - Box of Cat Bones
-	elsif (plugin::takeItems(12371 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 12371 => 1)) {
 		quest::say("Prrr.. Thank you brother of Ashen. I can now spend my time upon this island in peace, until my penance is serrrved. He dabs his paw into the mud and places it upon a tattered parchment. Take this message to Puab. Farrrwell.");
 		#:: Give a 28055 - Tattered Parchment
 		quest::summonitem(28055);

--- a/kithicor/Leaf_Falldim.pl
+++ b/kithicor/Leaf_Falldim.pl
@@ -15,7 +15,7 @@ sub EVENT_SAY {
 }
 
 sub EVENT_ITEM {
-	if(plugin::takeItems(12321 => 1, 12320 => 1)) {
+	if(plugin::check_handin(\%itemcount, 12321 => 1, 12320 => 1)) {
 		quest::summonitem(3190); # Item: Ivy Etched Gauntlets
 		quest::say("Very good, you have brought justice to these lands.");
 		quest::faction(269,+30); # kithicor residence
@@ -34,7 +34,7 @@ sub EVENT_ITEM {
 		quest::faction(324,-60); # unkempt druids
 		quest::exp(10000);		
     }
-    elsif(plugin::takeItems(10059 => 1, 12328 => 1)) {
+    elsif(plugin::check_handin(\%itemcount, 10059 => 1, 12328 => 1)) {
 		quest::say("Here are your leggings.");
 		quest::summonitem(3191); # Item: Ivy Etched Leggings
 		quest::say("Very good, you have brought justice to these lands.");

--- a/neriaka/Uglan.pl
+++ b/neriaka/Uglan.pl
@@ -12,7 +12,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 13357 - Cracked Stein
-	if (plugin::takeItems(13357 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13357 => 1)) {
 		#:: Match if the player is an Ogre
 		if ($race eq "Ogre") {
 			quest::say("You from Oggok. Me waiting for you. Me know dark elves have dark plan for ogres. We must stop plan. You must go to Nektulos Forest. Wait for blue orc. He deliver message for dark elf king. Not good. You kill blue orc runners. If message on them then you take to Lork in Oggok. Ogres must know plan.");

--- a/neriakc/Lokar_To-Biath.pl
+++ b/neriakc/Lokar_To-Biath.pl
@@ -43,7 +43,7 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Match one 13030 - Red Wine
-	elsif (plugin::takeItems(13030 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13030 => 1)) {
 		#:: Match if faction is Indifferent or better
 		if ($faction <= 5) {
 			quest::say("Ah, yes, let me pray to our god.. Yes, Innoruuk has given me wisdom. A Scribe of Dal still exists, disguised as a barkeep in the Blind Fish. This information will not help you though, for she has sworn a [vow] of silence and will not speak of the Dal.");

--- a/neriakc/Mare_X-Lottl.pl
+++ b/neriakc/Mare_X-Lottl.pl
@@ -26,7 +26,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 10020 - Jasper
-	if (plugin::takeItems(10020 => 1)) {
+	if (plugin::check_handin(\%itemcount, 10020 => 1)) {
 		quest::say("Jasper! My one and only love! All right.. That Tayla creature was lost in a game of King's Court with a very important and secret merchant. Belyea will not speak of him but that he was some sort of Baron. He did give me this trinket from his new friend and owner of the half-elf scamp. You keep it. It is worth nothing compared to sweet, beautiful Jasper.");
 		#:: Give a 54026 - Klok's Seal
 		quest::summonitem(54026); # Item: Klok's Seal

--- a/oasis/Taldrik_Stumpystout.pl
+++ b/oasis/Taldrik_Stumpystout.pl
@@ -17,7 +17,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 13943 - Freeport Stout, 13036 - Dwarven Ale, 13035 - Elven Wine
-	if (plugin::takeItems(13943 => 1, 13036 => 1, 13035 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13943 => 1, 13036 => 1, 13035 => 1)) {
 		quest::say("Ah ha! So ye are Bronlor's chosen aye? Well den these fine brews can only mean one thing! Yep its dat youre a drinker like meh! Arg, if I only had me recipe.");
 		#:: Ding!
 		quest::ding();
@@ -25,7 +25,7 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Match a 2440 - Keg of Brells Blessed Stout, 13474 - Rat Sandwich, 1430 - Initiate Symbol of Brell Serilis
-	elsif (plugin::takeItems(2440 => 1, 13474 => 1, 1430 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 2440 => 1, 13474 => 1, 1430 => 1)) {
 		quest::say("Ye are a true Priest of Brell Serillis! And ye make me both proud and happy to have met ye so that I could enjoy this sweet drink once again! Please take this Initiate Symbol of Brell Serillis which will I have crafted to enable you to turn water into this blessed ale for you have truly earned it!");
 		#:: Give a 1431 - Disciple Symbol of Brell Serilis
 		quest::summonitem(11431);

--- a/oggok/Ambassador_K-Ryn.pl
+++ b/oggok/Ambassador_K-Ryn.pl
@@ -6,7 +6,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 18842 - Sealed Letter
-	if (plugin::takeItems(18842 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18842 => 1)) {
 		quest::say("Another young warrior. I pray you shall not meet the fate of the last twelve. Here then. Take this report to Mistress Seloxia at once. And stay clear of the Froglok lair called Gukk.");
 		#:: Give a 18843 - Sealed Letter
 		quest::summonitem(18843);

--- a/oot/#Marrey_McGrannel.pl
+++ b/oot/#Marrey_McGrannel.pl
@@ -56,7 +56,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 57008 - Letter from Muada
-	if (plugin::takeItems(57008 => 1)) {
+	if (plugin::check_handin(\%itemcount, 57008 => 1)) {
 		#:: Set by /sharvahl/#Elder_Animist_Muada.pl
 		if ($client->GetGlobal("beast_epic") == 1) {
 			quest::say("It is indeed authentic. I suppose I can tell ye that I've been studyin' the ways o' the sirens. We as beastlords use the strength of our warders, as well as bestow magic upon them. These sirens use mind tricks! I'm workin' on a [" . quest::saylink("way") . "] to use the magic these fair ocean maidens do to help our kin.");
@@ -66,7 +66,7 @@ sub EVENT_ITEM {
 		#:: Test handin with no epic in progress--eat item?
 	}
 	#:: Match three 13039 - Ale
-	if (plugin::takeItems(13039 =>3 )) {
+	if (plugin::check_handin(\%itemcount, 13039 =>3 )) {
 		#:: Set by /....someone!
 		if ($client->GetGlobal("beast_epic") == 9) {
 			quest::say("Thanks to ye. Ah! Now, let's get on with it. 'Tis a long story, so how about we have a wee chat. Take a seat if ye like, hm? Are ye [" . quest::saylink("ready") . "] to listen? Ye are going to need to pay attention -- even as I ramble on a bit.");

--- a/oot/Sentry_Xyrin.pl
+++ b/oot/Sentry_Xyrin.pl
@@ -61,7 +61,7 @@ sub EVENT_TIMER {
 
 sub EVENT_ITEM {
 	#:: Match a 12134 - Last of Potion of Marr
-	if (plugin::takeItems(12134 => 1)) {
+	if (plugin::check_handin(\%itemcount, 12134 => 1)) {
 		quest::say("Ahhhh! I am energized! Come! Let us show these undead the greatness of Erollisi Marr!");
 		#:: give a 12135 - Empty Potion of Marr
 		quest::summonitem(12135);

--- a/oot/Styria_Fearnon.pl
+++ b/oot/Styria_Fearnon.pl
@@ -17,10 +17,10 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 13337 - Bracers of Erollisi
-	if (plugin::takeItems(13337 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13337 => 1)) {
 		quest::say("Oh!! Thank you!! We are so grateful to you. I offer you this as reward. It is one of the dwarven smith's finest works.");
 		#:: Give a 5007 - Axe, 5008 - Broad Sword
-		quest::summonitem(1quest::ChooseRandom(5007,5008));
+		quest::summonitem(quest::ChooseRandom(5007,5008));
 		#:: Ding!
 		quest::ding();
 		#:: Set factions
@@ -37,10 +37,10 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Match a 13336 - Pirate's Earring
-	elsif (plugin::takeItems(13336 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13336 => 1)) {
 		quest::say("Good work. That is one less pirate to worry about. We do not have much, but take this as payment");
 		#:: Give a 13339 - Aviak Feather, 13342 - Conch Shell, 7017 - Fishing Spear, 13340 - Kiola Nut, 13075 - Shark Skin
-		quest::summonitem(1quest::ChooseRandom(13339, 13342, 7017, 13340, 13075));
+		quest::summonitem(quest::ChooseRandom(13339, 13342, 7017, 13340, 13075));
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/plugins/globals.pl
+++ b/plugins/globals.pl
@@ -222,7 +222,7 @@ sub takeItemsCoin
   
   if (plugin::givenCoin($c, $s, $g, $p))
   {
-    if (plugin::takeItems(@_))
+    if (plugin::check_handin(\%itemcount, @_))
     {
       plugin::takeCoin($c, $s, $g, $p);
       

--- a/qcat/Bait_Masterson.pl
+++ b/qcat/Bait_Masterson.pl
@@ -17,7 +17,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 13544 - Old Blue Tunic*
-  	if (plugin::takeItems(13544 => 1)) {
+  	if (plugin::check_handin(\%itemcount, 13544 => 1)) {
     		quest::say("Nice material!! I feel the ways of Prexus enlightening my soul. Unngh!! Enough of this fishing. Here take my broken fishing pole and toss it to the sea. All hail Prexus!!");
 		#:: Give a 13922 - Snapped Pole
 		quest::summonitem(13922); # Item: Snapped Pole

--- a/qcat/Garuc_Anehm.pl
+++ b/qcat/Garuc_Anehm.pl
@@ -25,7 +25,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 13287 - Order of Thunder
-	if (plugin::takeItems(13287 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13287 => 1)) {
 		#:: Match if faction is Indifferent or better
 		if ($faction <= 5) {
 			quest::say("Ha! You must have slain a member of the Knights of Thunder. These pitiful knights have been a thorn in our side for far too long. Take this reward and continue the work of Bertoxxulous.");
@@ -49,7 +49,7 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Match a 13296 - Prayer Beads
-	elsif (plugin::takeItems(13296 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13296 => 1)) {
 		#:: Match if faction is Indifferent or better
 		if ($faction <= 5) {
 			quest::say("Fine work! One less threat to our shrine. Take this. It shall help you become a great asset to our shrine. Go forth and spread the disease."); 
@@ -73,7 +73,7 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Match a 13908 - Busted Prayer Beads
-	elsif (plugin::takeItems(13908 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13908 => 1)) {
 		quest::say("You fool! Brother Trintle was our mole within the Priests of Life. Now you have killed him. For this you shall die!");
 		#:: Set factions
 		quest::faction(221, -50);			#:: - Bloodsabers
@@ -85,7 +85,7 @@ sub EVENT_ITEM {
 		quest::attack($name);
 	}
 	#:: Match a 13134 - Hurrieta's Bloody Dress
-	elsif (plugin::takeItems(13134 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13134 => 1)) {
 		#:: Match if faction is Indifferent or better
 		if ($faction <= 5) {
 			quest::say("Hahaha.. I see you actually killed a respected, well-known citizen of Qeynos. No loss for them, but you are certainly a gain for our shrine. Maybe this shall do you some good. If not now, then surely later. You may need it when the Qeynos Guards hunt you down.");

--- a/qcat/Kurne_Rextula.pl
+++ b/qcat/Kurne_Rextula.pl
@@ -43,7 +43,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 18805 - Sealed Letter
-	if (plugin::takeItems(18805 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18805 => 1)) {
 		quest::say("Good work! You shall rise quickly in our ranks of evil. Let no man stand in your way and never betray the shrine or you to will join our collection of undead. You can also assist me with a [new task].");
 		#:: Give a random reward: 17002 - Belt Pouch, 10018 - Hematite
 		quest::summonitem(quest::ChooseRandom(17002, 10018)); # Item(s): Belt Pouch (17002)
@@ -63,7 +63,7 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Match a 12136 - Dwarf Head
-	elsif (plugin::takeItems(12136 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 12136 => 1)) {
 		#:: Match if faction is Amiable or better
 		if ($faction <= 4) {
 			quest::say("Incredible!! You have slain one of the greatest warriors in Qeynos!! He must have been full of grog. No doubt he drank most of his skill away. Now I shall cast a spell and strip the flesh from his skull and.. Presto!! Take this skull to Lord Grimrot somewhere in the Plains of Karana. He will be in the center of a field of skeletons. If he is not there, wait for his return. He must return eventually.");

--- a/qey2hh1/Brother_Estle.pl
+++ b/qey2hh1/Brother_Estle.pl
@@ -39,7 +39,7 @@ sub EVENT_WAYPOINT_ARRIVE {
 
 sub EVENT_ITEM {
 	#:: Match a 13910 - Blessed Oil Flask
-	if (plugin::takeItems(13910 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13910 => 1)) {
 		quest::say("Thank you. Now I may cleanse the bodies of the new converts and help them enter into a new life. I also have this. It was given to me by a dying gnoll of all things. They belong to Brother Hayle. The gnoll's last words were 'Free him.' Make sure High Priestess Jahnda gets this. Be swift!");
 		#:: Give a 13911 - PrayerBeads
 		quest::summonitem(13911);

--- a/qey2hh1/Caninel.pl
+++ b/qey2hh1/Caninel.pl
@@ -23,7 +23,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 10019 - Bloodstone, a 10070 - Moonstone, and a 10021 - Star Rose Quartz
-	if (plugin::takeItems(10019 => 1, 10070 => 1, 10021 => 1)) {
+	if (plugin::check_handin(\%itemcount, 10019 => 1, 10070 => 1, 10021 => 1)) {
 		quest::say("Yes. Good. You have done well. Let's see, the Paw of Opolla was it? Yes.. Opolla was once a great shaman to the Gnolls of Blackburrow. It is said she wore four enchanted rings of power. She offered her hand in peace to the first hordes of humans pouring down from the Everfrost Peaks, only to have it lopped off at the wrist by a warror named Gynok Moltor. If you seek the Paw, seek out the [decendent of Gynok].");
 		#:: Key a data bucket
 		$key = $npc->GetNPCTypeID() . "-turned-in";

--- a/qey2hh1/Chrislin_Baker.pl
+++ b/qey2hh1/Chrislin_Baker.pl
@@ -12,7 +12,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 13063 - Piece of Parchment, and a 13051 - Quill
-	if (plugin::takeItems(13063 => 1, 13051 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13063 => 1, 13051 => 1)) {
 		quest::emote("gives you a hug. 'Thank you so much. I did some cleaning after you left and found this behind a barrel. It may have been left behind by the person who took my materials. You can have it.'");
 		#:: Give a 12100 - Bandit Sash
 		quest::summonitem(12100);

--- a/qey2hh1/Einhorst_McMannus.pl
+++ b/qey2hh1/Einhorst_McMannus.pl
@@ -28,7 +28,7 @@ sub EVENT_SAY {
 	
 sub EVENT_ITEM {
 	#:: Match a 18831 - Tattered Note
-	if (plugin::takeItems(18831 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18831 => 1)) {
 		quest::say("Yes. We almost forgot of the shipment of Karana clovers. Here you are, my friend. Back to the north with you. I am sure the Shamans of Justice will need this.");
 		#:: Give a 13962 - Karana Clover Shipment
 		quest::summonitem(13962);

--- a/qey2hh1/Frostbite.pl
+++ b/qey2hh1/Frostbite.pl
@@ -6,14 +6,14 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 12140 - Regurgitonic
-	if (plugin::takeItems(12140 => 1)) {
+	if (plugin::check_handin(\%itemcount, 12140 => 1)) {
 		#:: Give a 13383 - Koalindl Fish
 		quest::summonitem(13383);
 		#:: Ding!
 		quest::ding();
 	}
 	#:: Match a 12226 - Sweaty Shirt
-	elsif (plugin::takeItems(12226 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 12226 => 1)) {
 		quest::emote("takes a whiff of the sweaty shirt and barks.");
 		#:: Create a timer "follow" that loops every 15 seconds
 		quest::settimer("follow", 15);

--- a/qey2hh1/Henina_Miller.pl
+++ b/qey2hh1/Henina_Miller.pl
@@ -36,7 +36,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 13990 - Bale of Hay
-	if (plugin::takeItems(13990 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13990 => 1)) {
 		quest::say("Thank you so much. Tiny gets quite tired doing this by himself. Here you go.");
 		#:: Ding!
 		quest::ding();

--- a/qey2hh1/Innkeep_Rislarn.pl
+++ b/qey2hh1/Innkeep_Rislarn.pl
@@ -17,7 +17,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 1838 - Bag of Bread Loaves
-	if (plugin::takeItems(1838 => 1)) {
+	if (plugin::check_handin(\%itemcount, 1838 => 1)) {
 		quest::say("Thanks for running that errand for me, you are a life saver. I hate having to turn folks away like that. Here is your payment and you have my deepest thanks.");
 		#:: Ding!
 		quest::ding();
@@ -37,7 +37,7 @@ sub EVENT_ITEM {
 		quest::MerchantSetItem(12103, 13015, 20);
 	}
 	#:: Match a 1839 - Full Muffin Crate
-	elsif (plugin::takeItems(1839 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 1839 => 1)) {
 		#:: Made up
 		quest::say("Thanks for running that errand for me, you are a life saver. Here's some coin for your trouble.");
 		#:: Ding!

--- a/qey2hh1/Lempeck_Hargrin.pl
+++ b/qey2hh1/Lempeck_Hargrin.pl
@@ -26,7 +26,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 13954 - Prime Healer Potion
-	if (plugin::takeItems(13954 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13954 => 1)) {
 		quest::say("Thank you!! I felt the madness nearing my brain, but now I feel much better. Please take this as thanks - it is all I have to donate to Astaed Wemor. Be sure he gets it. I shall thank Rodcet Nife every day for sending help.");
 		#:: Give a 13970 - Rusty Scythe
 		quest::summonitem(13970);
@@ -42,7 +42,7 @@ sub EVENT_ITEM {
 		quest::exp(1000);
 	}
 	#:: Match a 13955 - Prime Healer Potion
-	elsif (plugin::takeItems(13955 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13955 => 1)) {
 		quest::say("Please let this help.. nnnnghhh!!!.. I fear it is too late.. Aaaarrrgh!!!!.. I.. I will.. KILL YOU!!!!!");
 		#:: Ding!
 		quest::ding();

--- a/qey2hh1/Linaya_Sowlin.pl
+++ b/qey2hh1/Linaya_Sowlin.pl
@@ -15,7 +15,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 13945 - Flask of Nitrates
-	if (plugin::takeItems(13945 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13945 => 1)) {
 		quest::say("Oh thank Tunare you showed up when you did. I was at a nearby merchant house when a fellow dropped a [note] and I picked it up and read it. It talked of the [Unkempt Druids] and before I could read on, the man swiped it from my hands. I ran for dear life, for surely he would kill me for reading the note. I think I lost him in the woods but I am not sure. Please stay with me a while to be sure.");
 		#:: Ding!
 		quest::ding();

--- a/qey2hh1/Minda.pl
+++ b/qey2hh1/Minda.pl
@@ -15,7 +15,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 12103 - Full Chalice
-	if (plugin::takeItems(12103 => 1)) {
+	if (plugin::check_handin(\%itemcount, 12103 => 1)) {
 		quest::say("May the Rainkeeper keep you safe. I thank you. Here is the empty chalice. By the way, inform your superior that the operations of the [Karana bandits] are getting closer to Qeynos.");
 		#:: Give a 12104 - Empty Chalice
 		quest::summonitem(12104);

--- a/qey2hh1/Rongol.pl
+++ b/qey2hh1/Rongol.pl
@@ -16,7 +16,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 12102 - Temple Blankets
-	if (plugin::takeItems(12102 => 1)) {
+	if (plugin::check_handin(\%itemcount, 12102 => 1)) {
 		quest::say("Thank you, protector of Karana. This will be handy when the cold rushes into the valley. Allow me to offer you some provisions for your journey. And, might I add, the [Karana bandits] have begun to operate much closer to Qeynos.");
 		#:: Ding
 		quest::ding();

--- a/qey2hh1/Tukk.pl
+++ b/qey2hh1/Tukk.pl
@@ -16,7 +16,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 12102 - Temple Blankets
-	if (plugin::takeItems(12102 => 1)) {
+	if (plugin::check_handin(\%itemcount, 12102 => 1)) {
 		quest::say("Thank you, protector of Karana. This will be handy when the cold rushes into the valley. Allow me to offer you some provisions for your journey. And, might I add, the [Karana bandits] have begun to operate much closer to Qeynos.");
 		#:: Ding!
 		quest::ding();

--- a/qeytoqrg/Axe_Broadsmith.pl
+++ b/qeytoqrg/Axe_Broadsmith.pl
@@ -9,7 +9,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 18893 - Sealed Letter
-	if (plugin::takeItems(18893 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18893 => 1)) {
 		quest::say("So you are the new warrior. Let us test your skill. Across the pond is a skeleton. See him? Engage him in combat. He awaits. Return his skull to me and I shall call you a Steel Warrior. Be quick. He will dissipate soon.");
 		#:: Ding
 		quest::ding();
@@ -23,7 +23,7 @@ sub EVENT_ITEM {
 		quest::unique_spawn(4192, 0, 0, 1055, 3858, -19);
 	}
 	#:: Match a 13397 - Skull
-	elsif (plugin::takeItems(13397 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13397 => 1)) {
 		quest::say("So you have returned. Victory is yours, young Steel Warrior. Take this letter of recommendation to Brin Stolunger at the arena in Qeynos. You have passed.");
 		#:: Give a 18895 - Letter of Recommendation
 		quest::summonitem(18895);

--- a/qeytoqrg/Gnasher_Furgutt.pl
+++ b/qeytoqrg/Gnasher_Furgutt.pl
@@ -6,7 +6,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 18800 - Tattered Note
-	if (plugin::takeItems(18800 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18800 => 1)) {
 		quest::say("Ah. Good for you! Here you are. Take this to McNeal, but next time there will be no stout if there are no weapons.");
 		#:: Give a 13131 - Case of Blackburrow Stout
 		quest::summonitem(13131);

--- a/qeytoqrg/Guard_Cheslin.pl
+++ b/qeytoqrg/Guard_Cheslin.pl
@@ -65,7 +65,7 @@ sub EVENT_ITEM {
 	#:: Let's Multi-Quest!
 	plugin::mq_process_items(\%itemcount);
 	#:: Match a 13904 - Ebon Lotus, a 13905 - Library of Erudin, a 13906 - Chrono Cyclone, and a 13907 - Diamond Vale
-	if (plugin::takeItems(13904 => 1, 13905 => 1, 13906 => 1, 13907 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13904 => 1, 13905 => 1, 13906 => 1, 13907 => 1)) {
 		quest::say("Oh great! I have all my cards back. Here is a little something for assisting a Qeynos guard. And any time you are in trouble, just call on Cheslin, master swordsman. Take it to my father, Master Chesgard of the Knights of Thunder in Qeynos. No doubt he sent you to follow me on my watch.");
 		#:: Give a 18839 - Sealed Letter
 		quest::summonitem(18839);
@@ -87,7 +87,7 @@ sub EVENT_ITEM {
 		$npc->ClearItemList();
 	}
 	#:: Match a 13904 - Ebon Lotus
-	elsif (plugin::takeItems(13904 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13904 => 1)) {
 		plugin::mq_process_items(13904 => 1);
 		if (plugin::check_mq_handin(13904 => 1, 13905 => 1, 13906 => 1, 13907 => 1)) {
 			quest::say("Oh great! I have all my cards back. Here is a little something for assisting a Qeynos guard. And any time you are in trouble, just call on Cheslin, master swordsman. Take it to my father, Master Chesgard of the Knights of Thunder in Qeynos. No doubt he sent you to follow me on my watch.");
@@ -115,7 +115,7 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Match a 13905 - Library of Erudin
-	elsif (plugin::takeItems(13905 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13905 => 1)) {
 		plugin::mq_process_items(13905 => 1);
 		if (plugin::check_mq_handin(13904 => 1, 13905 => 1, 13906 => 1, 13907 => 1)) {
 			quest::say("Oh great! I have all my cards back. Here is a little something for assisting a Qeynos guard. And any time you are in trouble, just call on Cheslin, master swordsman. Take it to my father, Master Chesgard of the Knights of Thunder in Qeynos. No doubt he sent you to follow me on my watch.");
@@ -143,7 +143,7 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Match a 13906 - Chrono Cyclone
-	elsif (plugin::takeItems(13906 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13906 => 1)) {
 		plugin::mq_process_items(13906 => 1);
 		if (plugin::check_mq_handin(13904 => 1, 13905 => 1, 13906 => 1, 13907 => 1)) {
 			quest::say("Oh great! I have all my cards back. Here is a little something for assisting a Qeynos guard. And any time you are in trouble, just call on Cheslin, master swordsman. Take it to my father, Master Chesgard of the Knights of Thunder in Qeynos. No doubt he sent you to follow me on my watch.");
@@ -171,7 +171,7 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Match a 13907 - Diamond Vale
-	elsif (plugin::takeItems(13907 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13907 => 1)) {
 		plugin::mq_process_items(13907 => 1);
 		if (plugin::check_mq_handin(13904 => 1, 13905 => 1, 13906 => 1, 13907 => 1)) {
 			quest::say("Oh great! I have all my cards back. Here is a little something for assisting a Qeynos guard. And any time you are in trouble, just call on Cheslin, master swordsman. Take it to my father, Master Chesgard of the Knights of Thunder in Qeynos. No doubt he sent you to follow me on my watch.");

--- a/qeytoqrg/Konem_Matse.pl
+++ b/qeytoqrg/Konem_Matse.pl
@@ -19,7 +19,7 @@ sub EVENT_WAYPOINT_ARRIVE {
 
 sub EVENT_ITEM {
 	#:: Match a 18921 - Message to Konem
-	if (plugin::takeItems(18921 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18921 => 1)) {
 		quest::say("Oh I see.. Phin's always after me about something. I mean, it's not my fault the order hasn't come in yet. Hey, since I'm so busy right now, why don't you be a friend and take this back to Phin for me, huh?");
 		#:: Give a 18922 - Grathin's Invoice
 		quest::summonitem(18922);

--- a/qeytoqrg/Marton_Sayer.pl
+++ b/qeytoqrg/Marton_Sayer.pl
@@ -24,7 +24,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 12204 - Baby Joseph Sayer
-	if (plugin::takeItems(12204 => 1)) {
+	if (plugin::check_handin(\%itemcount, 12204 => 1)) {
 		quest::say("Baby Joseph!! Look, Momma!! Baby Joseph has been rescued by this good adventurer!! That evil Lord Elgnub made good on his word and snatched my son from under our noses. You saved the day!! For this you shall wield 'Gnoll Slayer'!! Be aware of its [true potential].");
 		#:: Give a 5416 - Gnoll Slayer
 		quest::summonitem(15416);
@@ -40,7 +40,7 @@ sub EVENT_ITEM {
 		quest::exp(500);
 	}
 	#:: Match a 8357 - Gnoll's Eye, a 8356 - Journal of Greater Enchantment, and a 5416 - Gnoll Slayer
-	elsif (plugin::takeItems(8357 => 1, 8356 => 1, 5416 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 8357 => 1, 8356 => 1, 5416 => 1)) {
 		quest::say("The eye and the journal! What a great day! The Gnoll Slayer shall be returned to full strength because of you. Your service to Qeynos will not soon be forgotten.");
 		#:: Give a 5417 - Gnoll Slayer
 		quest::summonitem(15417);

--- a/qeytoqrg/Neclo_Rheslar.pl
+++ b/qeytoqrg/Neclo_Rheslar.pl
@@ -6,7 +6,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 18823 - Note to Neclo
-	if (plugin::takeItems(18823 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18823 => 1)) {
 		#:: Match if faction is Indifferent or better
 		if ($faction <= 5) {
 			quest::say("Ah.. Hello friend.. So, I see Daenor sent you.. Uh huh, ok.. Here's something that will be very useful for you. Practice this well, friend.. It will help protect you in this harsh world.");

--- a/qeytoqrg/Niclaus_Ressinn.pl
+++ b/qeytoqrg/Niclaus_Ressinn.pl
@@ -55,11 +55,11 @@ sub EVENT_WAYPOINT_ARRIVE {
 
 sub EVENT_ITEM {
 	#:: Match a 18970 - Note to Niclaus
-	if (plugin::takeItems(18970 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18970 => 1)) {
 		quest::say("Oh, things are becoming dire here in Norrath. May Rodcet protect us! I have gathered most of the evidence I will need to present to Jahnda, but I could still use your assistance with one final piece. I need to recover a rib bone from of the undead beasts that wander these hills. Be sure the rib bone comes from one of the putrid skeletons. They are the spawn of Bertoxxulous.");
 	}
 	#:: Match a 13722 - Putrid Rib Bone
-	elsif (plugin::takeItems(13722 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13722 => 1)) {
 		quest::say("Excellent! Rodcet smiles upon us this day! Here, please take this pouch of evidence to Jahnda in the Temple of Life. She will know what we must do. I will remain here to keep an eye out for the minions of Bertoxxlous. Also, accept this small reward as a token of my appreciation of your efforts to rid Norrath of the influence of the Plaguebringer.");
 		#:: Give a 13724 - Pouch of Evidence
 		quest::summonitem(13724);

--- a/qeytoqrg/Rephas.pl
+++ b/qeytoqrg/Rephas.pl
@@ -12,7 +12,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 13072 - Rat Ears
-	if (plugin::takeItems(13072 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13072 => 1)) {
 		quest::say("Ahh yes..  These are a little small, but still some good eating, if you know how to cook 'em of course..   Here ya go, enjoy and may Karana keep your fields lush and green.");
 		#:: Give a 13719 - Grilled Rat Ears
 		quest::summonitem(13719);
@@ -27,7 +27,7 @@ sub EVENT_ITEM {
 		quest::exp(200);
 	}
 	#:: Match a 13719 - Grilled Rat Ears
-	elsif (plugin::takeItems(13719 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13719 => 1)) {
 		quest::say("Wha?..   Ah, I guess it's a bit of an acquired taste..  Oh well, your loss..  Here, take this..  They ain't no ears, but it's the least I could do..   And if ya find any more rat ears, good ol' Rephas here will be glad to take 'em off your hands for ya!");
 		#:: Give a 13076 - Fish Scales
 		quest::summonitem(13076);
@@ -42,7 +42,7 @@ sub EVENT_ITEM {
 		quest::exp(200);
 	}
 	#:: Match three 13050 - Giant Rat Ear
-	elsif (plugin::takeItems(13050 => 3)) {
+	elsif (plugin::check_handin(\%itemcount, 13050 => 3)) {
 		quest::say("Wow!..  How big was the dang varmint that these come off of?!  Bigger'n a ol' grizzly, I bet!  You've earned this, my friend!  It's my own secret recipe for rat ear pie..  sure is tasty, easy to make, and keeps your belly full while you're running about in the hills and such.  Take care, and may Karana keep your path clear and our lakes full.");
 		#:: Give a 18103 - Rat Ear Pie
 		quest::summonitem(18103);
@@ -57,7 +57,7 @@ sub EVENT_ITEM {
 		quest::exp(200);
 	}
 	#:: Match one 13050 - Giant Rat Ear
-	elsif (plugin::takeItems(13050 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13050 => 1)) {
 		quest::say("Hey... wow... Now THESE are some good, meaty ears... These will make one great rat ear pie... Tell ya what, kid... bring me a few more o' these beauties, and I'll give you my secret recipe for cooking 'em.");
 		#:: Ding!
 		quest::ding();

--- a/rathemtn/Hasten_Bootstrutter.pl
+++ b/rathemtn/Hasten_Bootstrutter.pl
@@ -93,7 +93,7 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Match a 7100 - Shadowed Rapier
-	elsif (plugin::takeItems(7100 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 7100 => 1)) {
 		#:: Match a 7100 - Shadowed Rapier and 12268 - Ring of the Ancients
 		if (plugin::check_mq_handin(12268 => 1, 7100 => 1)) {
 			quest::say("The time to trade has come!! I am now rich and you are now fast. Take the Journeyman Boots and run like the wind.");
@@ -113,7 +113,7 @@ sub EVENT_ITEM {
 
 	}
 	#:: Match a 12268 - Ring of the Ancients
-	elsif (plugin::takeItems(12268 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 12268 => 1)) {
 		#:: Match a 7100 - Shadowed Rapier and 12268 - Ring of the Ancients
 		if (plugin::check_mq_handin(12268 => 1, 7100 => 1)) {
 			quest::say("The time to trade has come!! I am now rich and you are now fast. Take the Journeyman Boots and run like the wind.");

--- a/rivervale/Ace_Slighthand.pl
+++ b/rivervale/Ace_Slighthand.pl
@@ -12,7 +12,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 13182 - Kevlin's Debt
-	if (plugin::takeItems(13182 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13182 => 1)) {
 		quest::say("Heh heh! You got a career ahead of ya kid! Good work. Here is your cut.");
 		#:: Ding!
 		quest::ding();

--- a/rivervale/Beek_Guinders.pl
+++ b/rivervale/Beek_Guinders.pl
@@ -38,7 +38,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 18731 - Tattered Note
-	if (plugin::takeItems(18731 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18731 => 1)) {
 		quest::say("Aye. Welcome, my fur-footed friend. My name is Beek Guinders, and I am guildmaster here at the Chapel of Mischief. Here is our guild tunic. Wear it with pride, as it will set you apart from the crowd. Once you are ready to begin your training please make sure that you see Thekela Meepup, she can assist you in experienced in our art, I will be able to further instruct you on how to progress through your early ranks, as well as in some of the various [trades] you will have available to you.");
 		#:: Give a 13538 - Faded Gold Felt Tunic*
 		quest::summonitem(13538);
@@ -52,10 +52,10 @@ sub EVENT_ITEM {
 		quest::faction(263, 15);	#:: + Guardians of the Vale
 	}
 	#:: Match a 13045 - Berries, two 13782 - Ruined Wolf Pelt, and a 13758 - Black Wolf Skin
-	elsif (plugin::takeItems(13045 => 1, 13782 => 2, 13758 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13045 => 1, 13782 => 2, 13758 => 1)) {
 		quest::say("Hey, great! You found the materials! We'll get to work right away. If you find any more, please come by again. Here's a little something for your troubles, friend.");
 		#:: Give a random reward: 15014 - Spell: Strike, 15201 - Spell: Flash of Light, 15207 - Spell: Divine Aura, 15208 - Spell: Lull, 16303 - Spell: Gate
-		quest::summonitem(1quest::ChooseRandom(15014,15201,15207,15208,16303));
+		quest::summonitem(quest::ChooseRandom(15014,15201,15207,15208,16303));
 		#:: Ding!
 		quest::ding();
 		#:: Grant a small amount of experience

--- a/rivervale/Blinza_Toepopal.pl
+++ b/rivervale/Blinza_Toepopal.pl
@@ -30,7 +30,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 13958 - Crate of Carrots
-	if (plugin::takeItems(13958 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13958 => 1)) {
 		quest::say("Well it is about time!  The mayor gets very upset if he does not have the freshest of carrots in his stew.  Here is the money for the carrots.  Be off with you.  Now, where the heck did [Jillin] go?");
 		#:: Ding!
 		quest::ding();
@@ -48,7 +48,7 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Match a 13957 - Crate of Fine Carrots
-	elsif (plugin::takeItems(13957 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13957 => 1)) {
 		quest::say("Oh excellent! These carrots are perfect! The finest Reebo has ever sent us. The mayor will be so pleased. Here is the payment for the carrots. Excuse me, but I must finish preparing the stew. Hmm. Where the heck did [Jillin] go?");
 		#:: Ding!
 		quest::ding();
@@ -66,7 +66,7 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Match a 13971 - Crate of Rotten Carrots
-	elsif (plugin::takeItems(13971 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13971 => 1)) {
 		quest::say("What are these?!  I am trying to make stew for the mayor and you bring me ROTTEN CARROTS?!  Have you no sense??  Take these back to Reebo.");
 		#:: Give a 13972 - Crate of Rotten Carrots
 		quest::summonitem(13972);

--- a/rivervale/Deputy_Lowmot.pl
+++ b/rivervale/Deputy_Lowmot.pl
@@ -6,7 +6,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 13959 - Carrot Stew
-	if (plugin::takeItems(13959 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13959 => 1)) {
 		quest::say("Oh good!  Hey.  You are not Jillin..  Helping out Blinza huh?  She is quite a woman..  Yes indeed.  Quite a woman..  ah..  Oh sorry.  Here you go.  Thanks again.  Mayor Gubbin will be pleased.");
 		#:: Ding!
 		quest::ding();

--- a/rivervale/Fiddy_Bobick.pl
+++ b/rivervale/Fiddy_Bobick.pl
@@ -15,7 +15,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 13870 - Piranha Tooth
-	if (plugin::takeItems(13870 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13870 => 1)) {
 		quest::say("Whew!! We are sure on the way to saving this village, pal! They're gonna erect a statue in our names.  Fishslayers is what we are!  Let's keep up the good work!");
 		#:: Ding!
 		quest::ding();

--- a/rivervale/Gapeers_Johhanis.pl
+++ b/rivervale/Gapeers_Johhanis.pl
@@ -21,7 +21,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 1736 - Algae Covered Flesh, a 1737 - Swollen Flesh, and a 1735 - Waterlogged Flesh
-	if (plugin::takeItems(1736 => 1, 1737 => 1, 1735 => 1)) {
+	if (plugin::check_handin(\%itemcount, 1736 => 1, 1737 => 1, 1735 => 1)) {
 		quest::emote("cheers as you hand him the samples of zombie flesh. He says, 'You have them! Excellent! Thank you very much, $name! Now I have much work to do so shoo before you break something else. Oh and here is your reward. It's an anklet that all our acolytes wear. Not only is it functional, but we can show off our beautiful foot hairs at the same time. Us halflings are pretty smart really.");
 		#:: Give a 1731 - Acolyte's Anklet
 		quest::summonitem(11731);

--- a/rivervale/Hendi_Mrubble.pl
+++ b/rivervale/Hendi_Mrubble.pl
@@ -21,19 +21,19 @@ sub EVENT_ITEM {
 		$npc->CastSpell(213,$userid);
 	}
 	#:: Match three 14029 - Bixie Stinger, 
-	if (plugin::takeItems(14029 => 3)) { 
+	if (plugin::check_handin(\%itemcount, 14029 => 3)) { 
 		quest::say("May the swift and silent spirit of Fizzlethorpe Bristlebane smile upon your frail soul.");
 		#:: Cast 203 - Cure Poison
 		$npc->CastSpell(203,$userid);
 	}
 	#:: Match one 13870 - Piranha Tooth
-	if (plugin::takeItems(13870 => 1)) { 
+	if (plugin::check_handin(\%itemcount, 13870 => 1)) { 
 		quest::say("May the swift and silent spirit of Fizzlethorpe Bristlebane smile upon your frail soul.");
 		#:: Cast 12 - Healing
 		$npc->CastSpell(12,$userid);
 	}
 	#:: Match 13936 - Squad Ring
-	if (plugin::takeItems(13936 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13936 => 1)) {
 		#:: Match if faction is better than indifferent
 		if ($faction < 5) {
 			quest::say("May the swift and silent spirit of Fizzlethorpe Bristlebane smile upon your frail soul.");

--- a/rivervale/Hibbs_Rootenpaw.pl
+++ b/rivervale/Hibbs_Rootenpaw.pl
@@ -41,7 +41,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 18734 - Tattered Note
-	if (plugin::takeItems(18734 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18734 => 1)) {
 		quest::say("Hello, friend! I am Hibbs Rootenpaw, leader of the Storm Reapers. Our guild works together with Will Tagglefoot and his family on their farm, to produce the food supply for all of Rivervale. With Karana's help, we have a bountiful harvest every season. We're glad you could help us out. Here's your guild tunic, it'll help keep you dry during the wet months. Go find Reebo out in the fields. He'll help get you started. Return to me when you have become more experienced in our art, I will be able to further instruct you on how to progress through your early ranks, as well as in some of the various [trades] you will have available to you.");
 		#:: Give a 13541 - Jumjum Sack Tunic*
 		quest::summonitem(13541);
@@ -56,7 +56,7 @@ sub EVENT_ITEM {
 		quest::faction(324, -15);	#:: - Unkempt Druids
 	}
 #POP	#:: Match a 19689 - Rusbek's Head
-#POP	elsif (plugin::takeItems(19689 => 1)) {
+#POP	elsif (plugin::check_handin(\%itemcount, 19689 => 1)) {
 #POP		quest::say("Excellent work young Storm Reaper. It is sad that one of our own would resort to such vile acts; his mind must have been twisted by evil desires. Such behavior is practically unheard of among the kind people of Rivervale. Take this dull scimitar and sharpen it in the forge here at the Tagglefoots Farm with a sharpening stone. It may take several attempts if you are unfamiliar with the process. Once that is done give the sharpened scimitar and a large fruit bat wing to Bodbin Gimple and he will put the finishing touches on what will be a fitting scimitar for a Druid of the Storm Reapers.");
 #POP		#:: Give a 19626 - Dull Storm Reaper Scimitar
 #POP		quest::summonitem(19626);

--- a/rivervale/Kaya_Cloudfoot.pl
+++ b/rivervale/Kaya_Cloudfoot.pl
@@ -31,7 +31,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 18431 - Halfling Paladin Note
-	if (plugin::takeItems(18431 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18431 => 1)) {
 		quest::say("Karana smiles upon you young $name! Take this tunic to keep you warm through the storms you must face. There is evil encroaching upon the lands of Karana's faithful. The wicked minions of Bertoxxulous and the Teir'Dal children of Hate corrupt the lands to the west and east, and the Deathfist Clan of Orcs are waging war on this region while destoying the wilderness for lumber and stone. It is Karana's will that we defend our lands and way of life from these evil threats. When you are ready to begin adventuring, I will be happy to advise you on how to help us deal with the [evil forces]. I also posses knowledge of various [trades], seek me out when you wish to learn about them.");
 		#:: Give a 13541 - Jumjum Sack Tunic*
 		quest::summonitem(13541);

--- a/rivervale/Lendel_Deeppockets.pl
+++ b/rivervale/Lendel_Deeppockets.pl
@@ -36,7 +36,7 @@ sub EVENT_SIGNAL {
 
 sub EVENT_ITEM {
 	#:: Turn in for 18732 - Tattered Note
-	if (plugin::takeItems(18732 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18732 => 1)) {
 		quest::say("HA! I asked that fool Denry to send me a professional, and this is what I get?!? Oh diddlepicks! That crotchety old coot never liked me anyway. And after all I've done for him! Hrrmf! Ah well, let's get you started and see what ya got, huh, kid? Here, wear this. Maybe I'll have Toelia break you in, huh? Yeah, that'll work! Go find her, and she'll put you to work. Just remember, we all earn our keep around here, or else it's back to hay farm for you! Oh yeah, tell her you're the new dishwasher so she knows you are on the level. Return to me when you have become more experienced in our art, I will be able to further instruct you on how to progress through your early ranks, as well as in some of the various [trades] you will have available to you.");
 		#:: Give item 13539 - Old Brown Vest*
 		quest::summonitem(13539);

--- a/rivervale/Marshal_Anrey.pl
+++ b/rivervale/Marshal_Anrey.pl
@@ -24,7 +24,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 13749 - Alligator Skin, a 13761 - Polar Bear Skin, a 13075 - Shark Skin, and a 13756 - Thick Grizzly Bear Skin
-	if (plugin::takeItems(13749 => 1, 13761 => 1, 13075 => 1, 13756 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13749 => 1, 13761 => 1, 13075 => 1, 13756 => 1)) {
 		quest::say("Good work, $name. You passed the first test. If you think you are one of us, return this cap to me along with a dagger from a Dark Elf for your true reward.");
 		#:: Give a 13941 - Leatherfoot Skullcap
 		quest::summonitem(13941);
@@ -38,7 +38,7 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}		
 	#:: Match a 13942 - Dragoon Dirk and 13941 = Leatherfoot Skullcap
-	elsif (plugin::takeItems(13942 => 1, 13941 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13942 => 1, 13941 => 1)) {
 		quest::say("Wonderful, $name. You have proven yourself to the Leatherfoot Squad. Take this and wear it with honor.");
 		#:: Give item 12259 - Leatherfoot Raider Skullcap
 		quest::summonitem(12259);

--- a/rivervale/Marshal_Lanena.pl
+++ b/rivervale/Marshal_Lanena.pl
@@ -36,7 +36,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 13870 - Piranha Tooth
-	if (plugin::takeItems(13870 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13870 => 1)) {
 		#:: Match if faction is better than indifferent
 		if ($faction < 5) {
 			quest::say("What was I thinking?!! Piranha are coming downstream and eating our supply of fish! We have never had a problem like this!!  Where are these little beasts coming from?  For now we must collect more. Take this bag. Collect enough teeth to fill the bag. Don't worry, if it takes a while I shall reward you with the [Rantho Rapier].  We will need to examine the teeth.");
@@ -64,7 +64,7 @@ sub EVENT_ITEM {
 		}
 	}		
 	#:: Match a 12155 - Bag of Piranha Teeth
-	if (plugin::takeItems(12155 => 1)) {
+	if (plugin::check_handin(\%itemcount, 12155 => 1)) {
 		#:: Match if faction is better than indifferent
 		if ($faction < 5) {
 			quest::say("Fine work. We shall continue to study these and shall determine if we need to seek the source.");

--- a/rivervale/Megosh_Thistlethorn.pl
+++ b/rivervale/Megosh_Thistlethorn.pl
@@ -28,7 +28,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 18432 - Halfling Ranger Note
-	if (plugin::takeItems(18432 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18432 => 1)) {
 		quest::say("Welcome to the Storm Reapers $name! Here is a tunic to keep you warm in your travels. Rivervale, our lovely home is facing dangerous times. From both the east and west forces devoted to the evil Gods Bertoxxulous adn Innoruuk are corrupting and destroying the wilds of Norrath. Also, the Orcs of Clan Deathfist are waging war on this entire region and gathering lumber and stone for some unknown purpose. We must do our best to preserve the lands and way of life of all Karanas people. Once you are ready to begin defending the vale against the evil forces, please return to me. I also posses knowledge of various [trades], seek me out when you wish to learn about them.");
 		#:: Give a 13541 - Jumjum Sack Tunic*
 		quest::summonitem(13541);

--- a/rivervale/Reebo_Leafsway.pl
+++ b/rivervale/Reebo_Leafsway.pl
@@ -43,7 +43,7 @@ sub EVENT_PROXIMITY_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 13971 - Crate of Rotten Carrots
-	if (plugin::takeItems(13971 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13971 => 1)) {
 		quest::say("Very good. Very good indeed. Karana does not need the blind obedience that so many deities require. Trust your instincts, they are more often right than not. Here, take this to Blinza. Hurry, she is expecting them. You may keep the donation she gives you in return.");
 		#:: Give a 13957 - Crate of Fine Carrots
 		quest::summonitem(13957);
@@ -53,7 +53,7 @@ sub EVENT_ITEM {
 		quest::exp(5);
 	}
 	#:: Match a 13972 - Crate of Rotten Carrots
-	elsif (plugin::takeItems(13972 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13972 => 1)) {
 		quest::say("These carrots are rotten. They were rotten when I gave them to you. Why would you waste time and energy on such a fool's errand? Because I asked you to? Many, even those you trust will ask you to do things which you should not. Use the common sense that Karana has blessed you with to know which tasks can benefit our people and which could harm them. Learn this lesson well. You will need it if you plan to adventure beyond the vale. Now take these fresh carrots to Blinza and apologize for your error. You may keep the donation she gives you as payment.");
 		#:: Give a 13958 - Crate of Carrots
 		quest::summonitem(13958);
@@ -61,11 +61,11 @@ sub EVENT_ITEM {
 		quest::ding();
 	}
 	#:: Match four 13974 - Jumjum Stalk
-	elsif (plugin::takeItems(13974 => 4)) {
+	elsif (plugin::check_handin(\%itemcount, 13974 => 4)) {
 		quest::say("Excellent!!  You must have taught ol' Nillipuss a great deal!  But he never seems to learn..  Oh well.  The Stormreapers and all of Rivervale owe you a debt of gratitude.  Please accept this token of our appreciation.");
 		#:: Give a random reward:  10308 - Anti-Poison Amulet, 8303 - Arrow of Contagion, 8304 - Arrow of Frost, 10302 - Earring of Disease Reflection, 10303 - Earring of Fire Reflection, 10304 - Earring of Frost Reflection, 10305 - Earring of Magic Reflection
 		#:: 10306 - Earring of Poison Reflection, 10309 - Eye of Disvan, 17302 - Pierce's Pouch of Storing, 12001 - Rod of Identification, 10301 - Runners Ring, 17301 - Travelers Pack, 17300 - Travelers Pouch, 12002 - Wand of Frost Bolts
-		quest::summonitem(1quest::ChooseRandom(10308,8303,8304,10302,10303,10304,10305,10306,10309,17302,12001,10301,17301,17300,12002));
+		quest::summonitem(quest::ChooseRandom(10308,8303,8304,10302,10303,10304,10305,10306,10309,17302,12001,10301,17301,17300,12002));
 		#:: Ding!
 		quest::ding();
 		#:: Grant a large amount of experience
@@ -81,7 +81,7 @@ sub EVENT_ITEM {
 		quest::faction(324, -1);	#:: - Unkempt Druids
 	}
 	#:: Match three 13974 - Jumjum Stalk
-	elsif (plugin::takeItems(13974 => 3)) {
+	elsif (plugin::check_handin(\%itemcount, 13974 => 3)) {
 		quest::say("Oh good! I see you have taugh that nasty Nillipuss a thing or two! Good. But it seems to me that he has stolen more jumjum than this. Perhaps he needs another lesson?");
 		#:: Give a 13974 - Jumjum Stalk
 		quest::summonitem(13974);
@@ -91,7 +91,7 @@ sub EVENT_ITEM {
 		quest::summonitem(13974);
 	}
 	#:: Match two 13974 - Jumjum Stalk
-	elsif (plugin::takeItems(13974 => 2)) {
+	elsif (plugin::check_handin(\%itemcount, 13974 => 2)) {
 		quest::say("Oh good! I see you have taugh that nasty Nillipuss a thing or two! Good. But it seems to me that he has stolen more jumjum than this. Perhaps he needs another lesson?");
 		#:: Give a 13974 - Jumjum Stalk
 		quest::summonitem(13974);
@@ -99,7 +99,7 @@ sub EVENT_ITEM {
 		quest::summonitem(13974);
 	}
 	#:: Match two 13974 - Jumjum Stalk
-	elsif (plugin::takeItems(13974 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13974 => 1)) {
 		quest::say("Oh good! I see you have taugh that nasty Nillipuss a thing or two! Good. But it seems to me that he has stolen more jumjum than this. Perhaps he needs another lesson?");
 		#:: Give a 13974 - Jumjum Stalk
 		quest::summonitem(13974);

--- a/rivervale/Rueppy_Kutpurse.pl
+++ b/rivervale/Rueppy_Kutpurse.pl
@@ -18,7 +18,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Turn in for 13032 - Short Beer
-	if (plugin::takeItems(13032 => 1 )) {
+	if (plugin::check_handin(\%itemcount, 13032 => 1 )) {
 		quest::say("Mmm. It's good, but not as good as [Blackburrow Stout].");
 		#:: Ding!
 		quest::ding();
@@ -30,7 +30,7 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Turn in for 13131 - Case of Blackburrow Stout
-	elsif (plugin::takeItems(13131 => 1 )) {
+	elsif (plugin::check_handin(\%itemcount, 13131 => 1 )) {
 		quest::say("Heh heh! You did it! I thought the deputies would get you for sure! I mean... You did it! Heh! Here buy yourself a drink on me.");
 		#:: Ding!
 		quest::ding();

--- a/rivervale/Shakey_Scarecrow.pl
+++ b/rivervale/Shakey_Scarecrow.pl
@@ -8,10 +8,10 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Turn in for 14321 - Sack of Writhing Hay
-	if (plugin::takeItems(14321 => 1 )) {
+	if (plugin::check_handin(\%itemcount, 14321 => 1 )) {
 		quest::emote("shakes his head around and beams a smile at you");
 		#:: Give item 13980 - Wee Harvester or 14031 - Belt of the River
-		quest::summonitem(1quest::ChooseRandom(13980, 13980, 14031));
+		quest::summonitem(quest::ChooseRandom(13980, 13980, 14031));
 		#:: Ding!
 		quest::ding();
 		#:: Give a small amount of xp

--- a/rivervale/Sheriff_Roglio.pl
+++ b/rivervale/Sheriff_Roglio.pl
@@ -33,7 +33,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 18733 - Warrior Recruitment Letter
-	if (plugin::takeItems(18733 => 1 )) {
+	if (plugin::check_handin(\%itemcount, 18733 => 1 )) {
 		quest::say("Welcome to the Guardians of the Vale. I'm Roglio Bruth, and I run this proud little outfit. You seem to be of hearty stock, let's put you to work. Here's your guild tunic - hope it fits. Start your training right away. Once you are ready to begin please make sure that you see Dalario Blistbobble, he can assist you in developing your hunting and gathering skills. Return to me when you have become more experienced in our art, I will be able to further instruct you on how to progress through your early ranks, as well as in some of the various [trades] you will have available to you.");
 		#:: Give item 13540 - *Old Tan Tunic
 		quest::summonitem(13540);
@@ -49,7 +49,7 @@ sub EVENT_ITEM {
 		quest::faction(334, -15); 	#:: - Dreadguard Outer
 	}
 	#:: Match four 13931 - Runnyeye Warbeads
-	if (plugin::takeItems(13931 => 4 )) {
+	if (plugin::check_handin(\%itemcount, 13931 => 4 )) {
 		quest::say("Good work, Deputy $name! We shall soon rid our countryside of the goblin threat. Here are your wages. Eat well tonight!");
 		#:: Give item 13023 - Bixie Berry Buns
 		quest::summonitem(13023);

--- a/rivervale/Toelia_Snuckery.pl
+++ b/rivervale/Toelia_Snuckery.pl
@@ -32,7 +32,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 13785 - Torn Old Pouch
-	if (plugin::takeItems(13785 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13785 => 1)) {
 		#:: Match if faction is Indifferent or better
 		if ($faction <= 5) {		
 			quest::say("What is this?  The pouch is empty!  Where is the Ruby?!  What do you mean you don't have it?  Oh no.  I bet [Chomper] swallowed it!  Get it back and bring it to me.");
@@ -58,7 +58,7 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Match a 13786 - Large Ruby
-	if (plugin::takeItems(13786 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13786 => 1)) {
 		#:: Match if faction is Indifferent or better
 		if ($faction <= 5) {		
 			quest::say("You found it!  Heh.  Good thing you brought it back bub.  This thing isn't priceless, its worthless but at least you proved you are loyal.  Poor ol' Chomper..");

--- a/rivervale/Uner_Gnarltrunk.pl
+++ b/rivervale/Uner_Gnarltrunk.pl
@@ -11,10 +11,10 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 13240 - Deputy Tagil's Payment
-	if (plugin::takeItems(13240 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13240 => 1)) {
 		quest::say("I knew that Deputy Tagil had simply forgotten. He really is a good young halfling. Here, take this as a small payment for your time.");
 		#:: Give a random reward: 13977 - Carrot, 13100 - Fishing Pole, 14014 - Potion of Wisdom, 13083 - Pine Needles
-		quest::summonitem(1quest::ChooseRandom(13977,13100,14014,13083));
+		quest::summonitem(quest::ChooseRandom(13977,13100,14014,13083));
 		#:: Ding!
 		quest::ding();
 		#:: Grant a small amount of experience

--- a/southkarana/#Brother_Hayle.pl
+++ b/southkarana/#Brother_Hayle.pl
@@ -12,7 +12,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 18927 - Temple Summons
-	if (plugin::takeItems(18927 => 1)) {
+	if (plugin::check_handin(\%itemcount, 18927 => 1)) {
 		quest::say("I am needed!! What am I doing here? I must return to the Temple of Life to commune with the Prime Healer. Rodcet Nife will give me more strength to finish this job. Thank you, young one! Take this key as a reward. Turn it into Tyokan in the temple shop. Safe journey to you!");
 		#:: Give a 13306 - T.O.L. 2020
 		quest::summonitem(13306);
@@ -28,7 +28,7 @@ sub EVENT_ITEM {
 		quest::exp(200);
 	}
 	#:: Match a 18936 - Sealed Note
-	elsif (plugin::takeItems(18936 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 18936 => 1)) {
 		quest::say("Finally!! I see that Ariska has found a noble knight to retrieve Soulfire. Per Ariska's orders I am not to give Soulfire to you until you can show me [proof of nobility]. You must honor both the Temple of Life as well as the Hall of Truth and to a high degree. Only then shall you hold Soulfire.");
 		#:: Give a 18937 - Note
 		quest::summonitem(18937);
@@ -44,7 +44,7 @@ sub EVENT_ITEM {
 		quest::exp(200);
 	}
 	#:: Match a 18937 - Note, a 13947 - Brilliant Sword of Faith, a 18828 - Testimony, and a 12197 - Glowing Sword Hilt
-	elsif (plugin::takeItems(18937 => 1, 13947 => 1, 18828 => 1, 12197 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 18937 => 1, 13947 => 1, 18828 => 1, 12197 => 1)) {
 		#:: Match if faction is Kindly or better
 		if ($faction <= 2) {
 			quest::say("You have proven yourself worthy to hold Soulfire. Do not let her slip into the hands of evil. There are many who wish to free the many trapped souls of shadowknights and necromancers trapped inside the blade. The power of the blade can be called upon to heal you if need be. May Rodcet Nife and the twins of Marr hold you in their glory.");

--- a/southkarana/Shakrn_Meadowgreen.pl
+++ b/southkarana/Shakrn_Meadowgreen.pl
@@ -39,7 +39,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 13743 - Goblin Fire Totem, and a 10035 - Ruby
-	if (plugin::takeItems(13743 => 1,10035 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13743 => 1,10035 => 1)) {
 		quest::say("By the gods, a Fire Goblin Totem - Well done warrior! Here is your Crafted Helm. Wear it with pride, for it is a true warriors Helmet.");
 		#:: Give a 4173 - Crafted Helm
 		quest::summonitem(14173);
@@ -49,7 +49,7 @@ sub EVENT_ITEM {
 		quest::exp(25000);
 	}
 	#:: Match a 13737 - Aviak Charm, and two 10032 - Star Ruby
-	elsif (plugin::takeItems(13737 => 1, 10032 => 2)) {
+	elsif (plugin::check_handin(\%itemcount, 13737 => 1, 10032 => 2)) {
 		quest::say("Ho ho! An aviak charm. These are not easy to come by. You have proven yourself a mighty warrior, and therefore deserve to wear these crafted warrior gauntlets.");
 		#:: Give a 4178 - Crafted Gauntlets
 		quest::summonitem(14178);
@@ -59,7 +59,7 @@ sub EVENT_ITEM {
 		quest::exp(25000);
 	}
 	#:: Match a 13744 - Goblin Frost Totem, and two 10034 - Sapphire
-	elsif (plugin::takeItems(13744 => 1, 10034 => 2)) {
+	elsif (plugin::check_handin(\%itemcount, 13744 => 1, 10034 => 2)) {
 		quest::say("What strength you must have to return with a frost goblin totem. You have surprised me - I did not think you up to the task. Take these crafted boots - you have indeed earned them.");
 		#:: Give a 4180 - Crafted Plate Boots
 		quest::summonitem(14180);
@@ -69,7 +69,7 @@ sub EVENT_ITEM {
 		quest::exp(25000);
 	}
 	#:: Match a 13739 - Griffon Eye, and two 10033 - Fire Emerald
-	elsif (plugin::takeItems(13739 => 1, 10033 => 2)) {
+	elsif (plugin::check_handin(\%itemcount, 13739 => 1, 10033 => 2)) {
 		quest::say("A griffon eye - I shall eat well tonight, and toast you in the manner of my ancestors. Take these crafted vambraces - they will serve you well.");
 		#:: Give a 4176 - Crafted Vambraces
 		quest::summonitem(14176);

--- a/southkarana/Ulan_Meadowgreen.pl
+++ b/southkarana/Ulan_Meadowgreen.pl
@@ -45,7 +45,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 14019 - Bunch of Optic Nerves, and a 10034 - Sapphire
-	if (plugin::takeItems(14019 => 1, 10034 => 1)) {
+	if (plugin::check_handin(\%itemcount, 14019 => 1, 10034 => 1)) {
 		quest::say("Very good. I am always in need of more optic nerves. Take this crafted bracer with my thanks.");
 		#:: Give a 4177 - Crafted Bracers
 		quest::summonitem(14177);
@@ -55,7 +55,7 @@ sub EVENT_ITEM {
 		quest::exp(25000);
 	}
 	#:: Match a 13742 - Dark Circlet, and two 10032 - Star Ruby
-	elsif (plugin::takeItems(13742 => 1, 10032 => 2)) {
+	elsif (plugin::check_handin(\%itemcount, 13742 => 1, 10032 => 2)) {
 		quest::say("Is this.. it is! I did not recognize it at first, but this is indeed the circlet my father once crafted. It seems to have been enchanted since. Take these crafted greaves with my thanks for a job well done.");
 		#:: Give a 4179 - Crafted Greaves
 		quest::summonitem(14179);
@@ -65,7 +65,7 @@ sub EVENT_ITEM {
 		quest::exp(25000);
 	}
 	#:: Match a 13698 - Bottom of a Fractured Rune, a 13699 - Middle of a Fractured Rune, 13738 - Top of a Fractured Rune, and a 10033 - Fire Emerald
-	elsif (plugin::takeItems(13698 =>1, 13699 => 1, 13738 => 1, 10033 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13698 =>1, 13699 => 1, 13738 => 1, 10033 => 1)) {
 		quest::say("Most impressive - all three pieces of the dwarven rune. When joined, this shall serve me well. Take this crafted pauldron with my gratitude.");
 		#:: Give a 4175 - Crafted Pauldron
 		quest::summonitem(14175);
@@ -75,7 +75,7 @@ sub EVENT_ITEM {
 		quest::exp(25000);
 	}
 	#:: Match a 13746 - Werewolf Talon, and three 10035 - Ruby
-	elsif (plugin::takeItems(13746 => 1, 10035 => 3)) {
+	elsif (plugin::check_handin(\%itemcount, 13746 => 1, 10035 => 3)) {
 		quest::say("'I am most impressed that you have returned from Castle Mistmoore with a Werewolf Talon. You have justly earned your Crafted Breastplate.");
 		#:: Give a 4174 - Crafted Breastplate
 		quest::summonitem(14174);

--- a/southkarana/Vhalen_Nostrolo.pl
+++ b/southkarana/Vhalen_Nostrolo.pl
@@ -18,7 +18,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 13114 - Lisera Lute
-	if (plugin::takeItems(13114 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13114 => 1)) {
 		quest::say("Oh, dear! I forgot to repair Cassius' lute. I shall fix and return it to him myself. Thank you for bringing this to me. Here, please return this note to Cassius. He shall be most happy. Thank you again, good citizen!");
 		#:: Give a 18803 - Note To Cassius
 		quest::summonitem(18803);
@@ -34,10 +34,10 @@ sub EVENT_ITEM {
 		quest::exp(5000);
 	}
 	#:: Match a 13116 - Winds of Karana sheet 1 and a 13119 - Winds of Karana sheet 2
-	elsif (plugin::takeItems(13116 =>1, 13119 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13116 =>1, 13119 => 1)) {
 		quest::say("Thank you, my friend. I have just completed the composition. It is a work of art. Here. Have a copy. I hope you have the musical talent to play it. If not... Practice, practice, practice!");
 		#:: Give a random reward:  15722 - Song: Jaxan's Jig o' Vigor, 15717 - Song: Selo's Accelerando, or 15703 - Song: Chords of Dissonance
-		quest::summonitem(1quest::ChooseRandom(15722, 15717, 15703));
+		quest::summonitem(quest::ChooseRandom(15722, 15717, 15703));
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/southkarana/a_hermit.pl
+++ b/southkarana/a_hermit.pl
@@ -30,7 +30,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 13854 - Human Heart
-	if (plugin::takeItems(13854 => 1)) {
+	if (plugin::check_handin(\%itemcount, 13854 => 1)) {
 		quest::say("Good work, my friend! I thank you and the Unkempt Druids thank you. Unfortunately I have sold the other song sheet to a traveling bard of the plains. I believe her name was Cordelia. Now be on your way. Unless you plan to [join the Unkempt Druids]..?");
 		#:: Give a 13116 - Winds of Karana sheet 1
 		quest::summonitem(13116);
@@ -45,7 +45,7 @@ sub EVENT_ITEM {
 		quest::exp(1000);
 	}
 	#:: Match a 13913 - Barbarian Head
-	elsif (plugin::takeItems(13913 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 13913 => 1)) {
 		quest::say("What fine work you do! In the name of all Norrath's beasts and of the Unkempt Druids, I thank you. No longer will there be senseless slaughter. Here is the flute.");
 		#:: Give a 13310 - Cracked Flute
 		quest::summonitem(13310);

--- a/sro/Ortallius.pl
+++ b/sro/Ortallius.pl
@@ -12,10 +12,10 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match three 1903 - Cutthroat Insignia Ring
-	if (plugin::takeItems(1903 => 3)) {
+	if (plugin::check_handin(\%itemcount, 1903 => 3)) {
 		quest::say("You will make a fine addition to the crusade. Continue the cleansing of the desert. Let it be known that the Defenders of Ro are here to challenge the evils of the desert. I call upon the righteousness of all paladins to assist me.");
 		#:: Give a random reward:  7012 - Bronze Dagger, 5026 - Bronze Short Sword, 5015 - Rusty Scythe, or 6017 - Splintering Club
-		quest::summonitem(1quest::ChooseRandom(7012, 5026, 5015, 6017));
+		quest::summonitem(quest::ChooseRandom(7012, 5026, 5015, 6017));
 		#:: Ding!
 		quest::ding();
 		#:: Set factions
@@ -29,7 +29,7 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Match a 12348 - Gem of Stamina and a 12349 - Sparkling Sapphire
-	elsif (plugin::takeItems(12348 => 1, 12349 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 12348 => 1, 12349 => 1)) {
 		quest::say("You serve the Burning Prince as I do. The Redeemed has instructed me to give you this reward upon completion of your test. Practice your arts and prepare yourself. Evil approaches our realm. Long live Ro!!");
 		#:: Give a 7041 - Burning Rapier
 		quest::summonitem(17041);

--- a/sro/Rathmana_Allin.pl
+++ b/sro/Rathmana_Allin.pl
@@ -21,7 +21,7 @@ sub EVENT_ITEM {
 	if (plugin::takeCoin(0, 0, 30, 0)) {
 		quest::say("Good luck, my friend. May Solusek Ro guide your hand.");
 		#:: Give a random reward: 15022 - Spell: Force Snap, 15035 - Spell: Bind Affinity, 15038 - Spell: Lightning Bolt, 15039 - Spell: Quickness, 15303 - Spell: Whirl till you hurl, 15328 - Spell: Column of Fire, 15355 - Spell: Engulfing Darkness, 15364 - Spell: Banshee Aura, 15445 - Spell: Lifedraw, 16425 - Spell: Charm, 13360 - Rotted Illegible Scroll
-		quest::summonitem(1quest::ChooseRandom(15022, 15035, 15038, 15039, 15303, 15328, 15355, 15364, 15445, 16425, 13360, 13360, 13360, 13360, 13360, 13360, 13360, 13360, 13360, 13360, 13360, 13360, 13360, 13360, 13360, 13360, 13360, 13360, 13360, 13360));
+		quest::summonitem(quest::ChooseRandom(15022, 15035, 15038, 15039, 15303, 15328, 15355, 15364, 15445, 16425, 13360, 13360, 13360, 13360, 13360, 13360, 13360, 13360, 13360, 13360, 13360, 13360, 13360, 13360, 13360, 13360, 13360, 13360, 13360, 13360));
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/sro/Smith_Tv-ysa.pl
+++ b/sro/Smith_Tv-ysa.pl
@@ -30,12 +30,12 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Match a 10300 - Lightstone
-	if (plugin::takeItems(10300 => 1)) {
+	if (plugin::check_handin(\%itemcount, 10300 => 1)) {
 		#:: Match if faction is indifferent or better
 		if ($faction <= 5) {
 			quest::say("A lightstone? Thank you very much. Here is a copy of 'Runes and Research' for you.");
 			#:: Give a random reward: 18175 - Runes and Research Volume I, or 18176 - Runes and Research Volume II
-			quest::summonitem(1quest::ChooseRandom(18175, 18176));
+			quest::summonitem(quest::ChooseRandom(18175, 18176));
 			#:: Ding!
 			quest::ding();
 			#:: Set factions
@@ -52,7 +52,7 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Match a 10400 - Greater Lightstone
-	elsif (plugin::takeItems(10400 => 1)) {
+	elsif (plugin::check_handin(\%itemcount, 10400 => 1)) {
 		#:: Match if faction is indifferent or better
 		if ($faction <= 5) {
 			quest::say("A greater lightstone? Thank you very much. Here is a 'Concordance of Research' for you.");


### PR DESCRIPTION
This globally fixes the issue we identified here https://github.com/The-Heroes-Journey-EQEMU/quests/pull/11

While I was looking through the changes I also found another weird bug where a bunch of scripts had a random `1` prefixing `quest` causing them to fail with `Missing operator before quest::ChooseRandom` so I fixed all of those also even though probably no one will or ever has done any of these quests.

https://github.com/search?q=repo%3AThe-Heroes-Journey-EQEMU%2Fquests%201quest%3A%3AChooseRandom&type=code

I made these changes in the GitHub web editor and it was a very fucky and started choking when I tried to commit all of them at once for some reason so I split it into two commits.