### PR TITLE
More quest plugin fixes

### DIFF
--- a/airplane/a_thunder_spirit_princess.pl
+++ b/airplane/a_thunder_spirit_princess.pl
@@ -16,7 +16,7 @@ sub EVENT_ITEM {
 #::		quest::depop();
 #::	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/bazaar/Santug_Claugg.pl
+++ b/bazaar/Santug_Claugg.pl
@@ -54,7 +54,7 @@ sub EVENT_ITEM {
 	quest::summonitem(995);
   quest::say("This can't be... Well, I always reward a good deed. Here you go. Merry Christmas $name");
    }
-   plugin::returnUnusedItems();
+   plugin::return_items(\%itemcount);
 }
 
 

--- a/befallen/Priest_Amiaz.pl
+++ b/befallen/Priest_Amiaz.pl
@@ -4,5 +4,5 @@ sub EVENT_DEATH_COMPLETE {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/befallen/an_elf_skeleton.pl
+++ b/befallen/an_elf_skeleton.pl
@@ -7,5 +7,5 @@ sub EVENT_COMBAT {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/befallen/ice_boned_skeleton.pl
+++ b/befallen/ice_boned_skeleton.pl
@@ -7,5 +7,5 @@ sub EVENT_COMBAT {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/butcher/Glorin_Binfurr.pl
+++ b/butcher/Glorin_Binfurr.pl
@@ -18,5 +18,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/butcher/Margyl_Darklin.pl
+++ b/butcher/Margyl_Darklin.pl
@@ -11,5 +11,5 @@ sub EVENT_WAYPOINT_ARRIVE {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/commons/Guard_Colin.pl
+++ b/commons/Guard_Colin.pl
@@ -10,5 +10,5 @@ sub EVENT_ITEM {
 		quest::say("It is best you donate to the Freeport Militia. I would hate to see something happen to you.");
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/crushbone/Rondo_Dunfire.pl
+++ b/crushbone/Rondo_Dunfire.pl
@@ -11,5 +11,5 @@ sub EVENT_DEATH_COMPLETE {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/cshome/Santug_Claugg.pl
+++ b/cshome/Santug_Claugg.pl
@@ -54,7 +54,7 @@ sub EVENT_ITEM {
 	quest::summonitem(995);
   quest::say("This can't be... Well, I always reward a good deed. Here you go. Merry Christmas $name");
    }
-   plugin::returnUnusedItems();
+   plugin::return_items(\%itemcount);
 }
 
 

--- a/eastkarana/#Guard_Elias.pl
+++ b/eastkarana/#Guard_Elias.pl
@@ -18,5 +18,5 @@ sub EVENT_SIGNAL {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/eastkarana/Guard_Alonso.pl
+++ b/eastkarana/Guard_Alonso.pl
@@ -14,7 +14,7 @@ sub EVENT_COMBAT {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/eastkarana/Guard_Angus.pl
+++ b/eastkarana/Guard_Angus.pl
@@ -14,7 +14,7 @@ sub EVENT_COMBAT {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/eastkarana/Guard_Beatrice.pl
+++ b/eastkarana/Guard_Beatrice.pl
@@ -14,7 +14,7 @@ sub EVENT_COMBAT {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/eastkarana/Guard_Boyet.pl
+++ b/eastkarana/Guard_Boyet.pl
@@ -14,7 +14,7 @@ sub EVENT_COMBAT {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/eastkarana/Guard_Calin.pl
+++ b/eastkarana/Guard_Calin.pl
@@ -14,7 +14,7 @@ sub EVENT_COMBAT {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/eastkarana/Guard_Celia.pl
+++ b/eastkarana/Guard_Celia.pl
@@ -14,7 +14,7 @@ sub EVENT_COMBAT {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/eastkarana/Guard_Cloten.pl
+++ b/eastkarana/Guard_Cloten.pl
@@ -14,7 +14,7 @@ sub EVENT_COMBAT {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/eastkarana/Guard_Diana.pl
+++ b/eastkarana/Guard_Diana.pl
@@ -14,7 +14,7 @@ sub EVENT_COMBAT {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/eastkarana/Guard_Gonlo.pl
+++ b/eastkarana/Guard_Gonlo.pl
@@ -14,7 +14,7 @@ sub EVENT_COMBAT {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/eastkarana/Guard_Iris.pl
+++ b/eastkarana/Guard_Iris.pl
@@ -14,7 +14,7 @@ sub EVENT_COMBAT {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/eastkarana/Guard_Juno.pl
+++ b/eastkarana/Guard_Juno.pl
@@ -14,7 +14,7 @@ sub EVENT_COMBAT {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/eastkarana/Guard_Mercyl.pl
+++ b/eastkarana/Guard_Mercyl.pl
@@ -14,7 +14,7 @@ sub EVENT_COMBAT {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/eastkarana/Guard_Miranda.pl
+++ b/eastkarana/Guard_Miranda.pl
@@ -14,7 +14,7 @@ sub EVENT_COMBAT {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/eastkarana/Guard_Peter.pl
+++ b/eastkarana/Guard_Peter.pl
@@ -14,7 +14,7 @@ sub EVENT_COMBAT {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/eastkarana/Guard_Philip.pl
+++ b/eastkarana/Guard_Philip.pl
@@ -14,7 +14,7 @@ sub EVENT_COMBAT {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/eastkarana/Guard_Sara.pl
+++ b/eastkarana/Guard_Sara.pl
@@ -14,7 +14,7 @@ sub EVENT_COMBAT {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/eastkarana/Guard_Sebastian.pl
+++ b/eastkarana/Guard_Sebastian.pl
@@ -14,7 +14,7 @@ sub EVENT_COMBAT {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/eastkarana/Guard_Silvia.pl
+++ b/eastkarana/Guard_Silvia.pl
@@ -14,7 +14,7 @@ sub EVENT_COMBAT {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/eastkarana/Guard_Titan.pl
+++ b/eastkarana/Guard_Titan.pl
@@ -14,7 +14,7 @@ sub EVENT_COMBAT {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/eastkarana/Guard_Tubal.pl
+++ b/eastkarana/Guard_Tubal.pl
@@ -14,7 +14,7 @@ sub EVENT_COMBAT {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/eastkarana/Guard_Viola.pl
+++ b/eastkarana/Guard_Viola.pl
@@ -14,7 +14,7 @@ sub EVENT_COMBAT {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/eastkarana/Sir_Morgan.pl
+++ b/eastkarana/Sir_Morgan.pl
@@ -47,5 +47,5 @@ sub EVENT_ITEM {
 		quest::exp(500);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/eastkarana/Tallus_Holton.pl
+++ b/eastkarana/Tallus_Holton.pl
@@ -11,5 +11,5 @@ sub EVENT_DEATH_COMPLETE {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/erudnext/Breya_Nostulia.pl
+++ b/erudnext/Breya_Nostulia.pl
@@ -29,5 +29,5 @@ sub EVENT_ITEM {
 		quest::exp(1000);	
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/erudnext/Cipse_Tospyr.pl
+++ b/erudnext/Cipse_Tospyr.pl
@@ -30,5 +30,5 @@ sub EVENT_ITEM {
 		$npc->CastSpell(213,$userid);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/erudnext/Depnar_Bulrious.pl
+++ b/erudnext/Depnar_Bulrious.pl
@@ -35,5 +35,5 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/erudnext/Dleria_Mausrel.pl
+++ b/erudnext/Dleria_Mausrel.pl
@@ -110,5 +110,5 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/erudnext/Gans_Paust.pl
+++ b/erudnext/Gans_Paust.pl
@@ -64,5 +64,5 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/erudnext/Geoard_BlueHawk.pl
+++ b/erudnext/Geoard_BlueHawk.pl
@@ -20,5 +20,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/erudnext/Grendin_Maze.pl
+++ b/erudnext/Grendin_Maze.pl
@@ -4,7 +4,7 @@ sub EVENT_AGGRO {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/erudnext/Helia_BlueHawk.pl
+++ b/erudnext/Helia_BlueHawk.pl
@@ -24,5 +24,5 @@ sub EVENT_SIGNAL {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/erudnext/Illithi_Nollith.pl
+++ b/erudnext/Illithi_Nollith.pl
@@ -9,5 +9,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/erudnext/Jras_Solsier.pl
+++ b/erudnext/Jras_Solsier.pl
@@ -109,5 +109,5 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/erudnext/Laoni_Reista.pl
+++ b/erudnext/Laoni_Reista.pl
@@ -63,5 +63,5 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/erudnext/Leraena_Shelyrak.pl
+++ b/erudnext/Leraena_Shelyrak.pl
@@ -200,5 +200,5 @@ sub EVENT_ITEM {
 		#quest::faction(265,-20); 	#:: - Heretics
 	#}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/erudnext/Lumi_Stergnon.pl
+++ b/erudnext/Lumi_Stergnon.pl
@@ -132,5 +132,5 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/erudnext/Nolusia_Finharn.pl
+++ b/erudnext/Nolusia_Finharn.pl
@@ -58,5 +58,5 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/erudnext/Phloatin_Highbrow.pl
+++ b/erudnext/Phloatin_Highbrow.pl
@@ -27,5 +27,5 @@ sub EVENT_SIGNAL {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/erudnext/Raine_Beteria.pl
+++ b/erudnext/Raine_Beteria.pl
@@ -56,5 +56,5 @@ sub EVENT_ITEM {
 		quest::exp(1000);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/erudnext/Rarnan_Lapice.pl
+++ b/erudnext/Rarnan_Lapice.pl
@@ -33,5 +33,5 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/erudnext/Sentinel_Adrial.pl
+++ b/erudnext/Sentinel_Adrial.pl
@@ -13,5 +13,5 @@ sub EVENT_DEATH_COMPLETE {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/erudnext/Sentinel_Aegeo.pl
+++ b/erudnext/Sentinel_Aegeo.pl
@@ -13,5 +13,5 @@ sub EVENT_DEATH_COMPLETE {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/erudnext/Sentinel_Belario.pl
+++ b/erudnext/Sentinel_Belario.pl
@@ -13,5 +13,5 @@ sub EVENT_DEATH_COMPLETE {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/erudnext/Sentinel_Cymbelin.pl
+++ b/erudnext/Sentinel_Cymbelin.pl
@@ -13,5 +13,5 @@ sub EVENT_DEATH_COMPLETE {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/erudnext/Sentinel_Demitri.pl
+++ b/erudnext/Sentinel_Demitri.pl
@@ -13,5 +13,5 @@ sub EVENT_DEATH_COMPLETE {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/everfrost/Karg_IceBear.pl
+++ b/everfrost/Karg_IceBear.pl
@@ -60,5 +60,5 @@ sub EVENT_ITEM {
 		quest::ding();
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/everfrost/Megan_OReilly.pl
+++ b/everfrost/Megan_OReilly.pl
@@ -38,5 +38,5 @@ sub EVENT_ITEM {
 		quest::exp(150);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/everfrost/Sulgar.pl
+++ b/everfrost/Sulgar.pl
@@ -34,5 +34,5 @@ sub EVENT_ITEM {
 		quest::exp(100000);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/everfrost/Tundra_Jack.pl
+++ b/everfrost/Tundra_Jack.pl
@@ -71,7 +71,7 @@ sub WAYPOINT_ARRIVE {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 # Converted to Perl by SS

--- a/fearplane/Cazic_Thule.pl
+++ b/fearplane/Cazic_Thule.pl
@@ -25,7 +25,7 @@ sub EVENT_ITEM {
 		quest::exp(100000);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_TIMER {

--- a/feerrott/#Roror.pl
+++ b/feerrott/#Roror.pl
@@ -42,5 +42,5 @@ sub EVENT_ITEM {
 		quest::faction(344, 10);		#:: +Beta Neutral
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/feerrott/Innkeep_Gub.pl
+++ b/feerrott/Innkeep_Gub.pl
@@ -51,5 +51,5 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/feerrott/Innkeep_Morpa.pl
+++ b/feerrott/Innkeep_Morpa.pl
@@ -51,5 +51,5 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/felwithea/Guard_Settine.pl
+++ b/felwithea/Guard_Settine.pl
@@ -10,5 +10,5 @@ sub EVENT_ITEM {
 		quest::summonitem(14640);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/felwithea/Tolkar_Parlone.pl
+++ b/felwithea/Tolkar_Parlone.pl
@@ -30,5 +30,5 @@ sub EVENT_ITEM {
 		quest::exp(1000);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/felwithea/Tolon_Nurbyte.pl
+++ b/felwithea/Tolon_Nurbyte.pl
@@ -76,5 +76,5 @@ sub EVENT_ITEM {
 		quest::exp(2000);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/felwitheb/Kinool_Goldsinger.pl
+++ b/felwitheb/Kinool_Goldsinger.pl
@@ -76,5 +76,5 @@ sub EVENT_ITEM {
 		quest::exp(5000);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/felwitheb/Niola_Impholder.pl
+++ b/felwitheb/Niola_Impholder.pl
@@ -71,5 +71,5 @@ sub EVENT_ITEM {
 		quest::exp(30000);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/felwitheb/Tarker_Blazetoss.pl
+++ b/felwitheb/Tarker_Blazetoss.pl
@@ -61,5 +61,5 @@ sub EVENT_ITEM {
 		quest::exp(350);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freporte/10000.pl
+++ b/freporte/10000.pl
@@ -10,7 +10,7 @@ sub EVENT_ITEM {
 		quest::settimer("depop", 5);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_TIMER {

--- a/freporte/Beur_Tenlah.pl
+++ b/freporte/Beur_Tenlah.pl
@@ -26,5 +26,5 @@ sub EVENT_ITEM {
 		quest::signalwith(10107,1,0);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freporte/Branis_Noolright.pl
+++ b/freporte/Branis_Noolright.pl
@@ -52,5 +52,5 @@ sub EVENT_SIGNAL {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freporte/Bronto_Thudfoot.pl
+++ b/freporte/Bronto_Thudfoot.pl
@@ -19,5 +19,5 @@ sub EVENT_SIGNAL {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freporte/Brunar_Rankin.pl
+++ b/freporte/Brunar_Rankin.pl
@@ -39,5 +39,5 @@ sub EVENT_WAYPOINT_ARRIVE {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freporte/Brutol_Rhaksen.pl
+++ b/freporte/Brutol_Rhaksen.pl
@@ -30,5 +30,5 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freporte/Elisi_Nasin.pl
+++ b/freporte/Elisi_Nasin.pl
@@ -27,5 +27,5 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freporte/Fabian.pl
+++ b/freporte/Fabian.pl
@@ -62,5 +62,5 @@ sub EVENT_ITEM {
 #::		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum}); 
 #::	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freporte/Giz_Dinree.pl
+++ b/freporte/Giz_Dinree.pl
@@ -13,5 +13,5 @@ sub EVENT_ITEM {
 		quest::say("I am glad to see you. We have a problem. The last runner and I attempted to carry the chest from a boat. It fell overboard! He went in after it, but the sharks made a meal of him. If you want to try and get it, it is down below in the water in the harbor. Be careful.");
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freporte/Gregor_Nasin.pl
+++ b/freporte/Gregor_Nasin.pl
@@ -50,7 +50,7 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_SIGNAL {

--- a/freporte/Gren_Frikniller.pl
+++ b/freporte/Gren_Frikniller.pl
@@ -35,7 +35,7 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_SIGNAL {

--- a/freporte/Groflah_Steadirt.pl
+++ b/freporte/Groflah_Steadirt.pl
@@ -101,7 +101,7 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/freporte/Guard_Zeph.pl
+++ b/freporte/Guard_Zeph.pl
@@ -1,6 +1,6 @@
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/freporte/Harkin_Duskfoot.pl
+++ b/freporte/Harkin_Duskfoot.pl
@@ -50,5 +50,5 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freporte/Heneva_Jexsped.pl
+++ b/freporte/Heneva_Jexsped.pl
@@ -30,5 +30,5 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freporte/Ikthar_Fireheart.pl
+++ b/freporte/Ikthar_Fireheart.pl
@@ -15,5 +15,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freporte/Imxil_T-brow.pl
+++ b/freporte/Imxil_T-brow.pl
@@ -20,5 +20,5 @@ sub EVENT_SIGNAL {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freporte/Innkeep_Paggie.pl
+++ b/freporte/Innkeep_Paggie.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freporte/Innkeep_Rastle.pl
+++ b/freporte/Innkeep_Rastle.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freporte/Jheron_Felkis.pl
+++ b/freporte/Jheron_Felkis.pl
@@ -19,5 +19,5 @@ sub EVENT_ITEM {
 		quest::exp(8000);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freporte/Jyle_Windshot.pl
+++ b/freporte/Jyle_Windshot.pl
@@ -25,5 +25,5 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freporte/Konious_Eranon.pl
+++ b/freporte/Konious_Eranon.pl
@@ -20,5 +20,5 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freporte/Lenka_Stoutheart.pl
+++ b/freporte/Lenka_Stoutheart.pl
@@ -120,5 +120,5 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freporte/Lunce_Nasin.pl
+++ b/freporte/Lunce_Nasin.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freporte/Nesin_Tapper.pl
+++ b/freporte/Nesin_Tapper.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freporte/Nestral_TGaza.pl
+++ b/freporte/Nestral_TGaza.pl
@@ -32,5 +32,5 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freporte/Netuk_Phenzon.pl
+++ b/freporte/Netuk_Phenzon.pl
@@ -27,5 +27,5 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freporte/Nexvok_Thirod.pl
+++ b/freporte/Nexvok_Thirod.pl
@@ -20,5 +20,5 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freporte/Olunea_Miltin.pl
+++ b/freporte/Olunea_Miltin.pl
@@ -26,5 +26,5 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freporte/Opal_Darkbriar.pl
+++ b/freporte/Opal_Darkbriar.pl
@@ -23,5 +23,5 @@ sub EVENT_ITEM {
 		
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freporte/Palana_Willin.pl
+++ b/freporte/Palana_Willin.pl
@@ -55,5 +55,5 @@ sub EVENT_SIGNAL {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freporte/Palatos_Kynarn.pl
+++ b/freporte/Palatos_Kynarn.pl
@@ -64,7 +64,7 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/freporte/Pietro_Zarn.pl
+++ b/freporte/Pietro_Zarn.pl
@@ -44,5 +44,5 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freporte/Plnorrick_Spinecracker.pl
+++ b/freporte/Plnorrick_Spinecracker.pl
@@ -13,5 +13,5 @@ sub EVENT_SIGNAL {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freporte/Raltur_Caliskon.pl
+++ b/freporte/Raltur_Caliskon.pl
@@ -51,5 +51,5 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freporte/Runthar.pl
+++ b/freporte/Runthar.pl
@@ -7,7 +7,7 @@ sub EVENT_COMBAT {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/freporte/Sir_Edwin_Motte.pl
+++ b/freporte/Sir_Edwin_Motte.pl
@@ -25,5 +25,5 @@ sub EVENT_SIGNAL {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freporte/Swiftfingers.pl
+++ b/freporte/Swiftfingers.pl
@@ -7,5 +7,5 @@ sub EVENT_COMBAT {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freporte/Talym_Shoontar.pl
+++ b/freporte/Talym_Shoontar.pl
@@ -36,5 +36,5 @@ sub EVENT_SIGNAL {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freporte/Tlin_Bowfright.pl
+++ b/freporte/Tlin_Bowfright.pl
@@ -21,5 +21,5 @@ sub EVENT_SIGNAL {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freporte/Tohsan_Hallard.pl
+++ b/freporte/Tohsan_Hallard.pl
@@ -28,5 +28,5 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freporte/Trolon_Lightleer.pl
+++ b/freporte/Trolon_Lightleer.pl
@@ -47,5 +47,5 @@ sub EVENT_SIGNAL {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freporte/Tykar_Renlin.pl
+++ b/freporte/Tykar_Renlin.pl
@@ -99,5 +99,5 @@ sub EVENT_ITEM {
 		}
 	}		
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freporte/Venox_Tarkog.pl
+++ b/freporte/Venox_Tarkog.pl
@@ -29,5 +29,5 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freporte/Vesagar_Nekio.pl
+++ b/freporte/Vesagar_Nekio.pl
@@ -51,5 +51,5 @@ sub EVENT_ITEM {
 		$npc->CastSpell(203,$client);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freporte/Winda_Lylil.pl
+++ b/freporte/Winda_Lylil.pl
@@ -50,5 +50,5 @@ sub EVENT_ITEM {
 		$client->AddLevelBasedExp(4, 14);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freporte/Xelha_Nevagon.pl
+++ b/freporte/Xelha_Nevagon.pl
@@ -127,5 +127,5 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freporte/Zenita_D-Rin.pl
+++ b/freporte/Zenita_D-Rin.pl
@@ -40,5 +40,5 @@ sub EVENT_ITEM {
 		quest::say("I see you have drawn the card that best represents a $class such as yourself. You lose! $name");
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freportn/Caskin_Marsheart.pl
+++ b/freportn/Caskin_Marsheart.pl
@@ -41,5 +41,5 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freportn/Celsar_Vestagon.pl
+++ b/freportn/Celsar_Vestagon.pl
@@ -34,5 +34,5 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freportn/Eestyana_Naestra.pl
+++ b/freportn/Eestyana_Naestra.pl
@@ -65,5 +65,5 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freportn/Falia_Frikniller.pl
+++ b/freportn/Falia_Frikniller.pl
@@ -16,5 +16,5 @@ sub EVENT_ITEM {
 		quest::exp(500);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freportn/Felisity_Starbright.pl
+++ b/freportn/Felisity_Starbright.pl
@@ -96,5 +96,5 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freportn/Gern_Tassel.pl
+++ b/freportn/Gern_Tassel.pl
@@ -53,5 +53,5 @@ sub EVENT_ITEM {
 		$client->AddLevelBasedExp(4, 14);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freportn/Ghonic_Erharn.pl
+++ b/freportn/Ghonic_Erharn.pl
@@ -9,5 +9,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freportn/Groflah_Steadirt.pl
+++ b/freportn/Groflah_Steadirt.pl
@@ -30,7 +30,7 @@ sub EVENT_ITEM {
 		quest::exp(500);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }	
 
 sub EVENT_DEATH_COMPLETE {

--- a/freportn/Gygus_Remnara.pl
+++ b/freportn/Gygus_Remnara.pl
@@ -20,5 +20,5 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freportn/Jemoz_Lerkarson.pl
+++ b/freportn/Jemoz_Lerkarson.pl
@@ -65,5 +65,5 @@ sub EVENT_ITEM {
 		quest::faction(330, -10); 		#:: - Freeport Militia
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freportn/Kalatrina_Plossen.pl
+++ b/freportn/Kalatrina_Plossen.pl
@@ -45,5 +45,5 @@ sub EVENT_ITEM {
 		quest::exp(500);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }	

--- a/freportn/Lanis_Herion.pl
+++ b/freportn/Lanis_Herion.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }	

--- a/freportn/Marus_Kemson.pl
+++ b/freportn/Marus_Kemson.pl
@@ -1,4 +1,4 @@
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }	

--- a/freportn/Merko_Quetalis.pl
+++ b/freportn/Merko_Quetalis.pl
@@ -78,5 +78,5 @@ sub EVENT_ITEM {
 			quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }	

--- a/freportn/Nashia_Lanseb.pl
+++ b/freportn/Nashia_Lanseb.pl
@@ -1,4 +1,4 @@
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }	

--- a/freportn/Palious_Jarten.pl
+++ b/freportn/Palious_Jarten.pl
@@ -17,5 +17,5 @@ sub EVENT_ITEM {
 		$npc->CastSpell(213,$userid);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }	

--- a/freportn/Plur_Etinu.pl
+++ b/freportn/Plur_Etinu.pl
@@ -39,5 +39,5 @@ sub EVENT_ITEM {
 		quest::ding();
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }	

--- a/freportn/Sentry_Andlin.pl
+++ b/freportn/Sentry_Andlin.pl
@@ -20,5 +20,5 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freportn/Sentry_Boris.pl
+++ b/freportn/Sentry_Boris.pl
@@ -20,5 +20,5 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freportn/Sentry_Gallius.pl
+++ b/freportn/Sentry_Gallius.pl
@@ -20,5 +20,5 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freportn/Sentry_Janeal.pl
+++ b/freportn/Sentry_Janeal.pl
@@ -20,5 +20,5 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freportn/Sentry_Meighan.pl
+++ b/freportn/Sentry_Meighan.pl
@@ -20,5 +20,5 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freportn/Sentry_Theo.pl
+++ b/freportn/Sentry_Theo.pl
@@ -20,5 +20,5 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freportn/Sentry_Warren.pl
+++ b/freportn/Sentry_Warren.pl
@@ -23,5 +23,5 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freportn/Serna_Tasknon.pl
+++ b/freportn/Serna_Tasknon.pl
@@ -60,5 +60,5 @@ sub EVENT_ITEM {
 		quest::exp(1000);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freportn/Svinal_Wyspin.pl
+++ b/freportn/Svinal_Wyspin.pl
@@ -9,5 +9,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freportn/Theron_Rolius.pl
+++ b/freportn/Theron_Rolius.pl
@@ -58,5 +58,5 @@ sub EVENT_ITEM {
 		quest::exp(500);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freportn/Tholius_Quey.pl
+++ b/freportn/Tholius_Quey.pl
@@ -26,7 +26,7 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_ITEM {
@@ -45,5 +45,5 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freportn/Thurion_Desius.pl
+++ b/freportn/Thurion_Desius.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freportn/Ton_Twostring.pl
+++ b/freportn/Ton_Twostring.pl
@@ -52,7 +52,7 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/freportn/Valeron_Dushire.pl
+++ b/freportn/Valeron_Dushire.pl
@@ -50,5 +50,5 @@ sub EVENT_ITEM {
 		quest::faction(311, 10);		#:: + Steel Warriors
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freportn/Zigg_Flin.pl
+++ b/freportn/Zigg_Flin.pl
@@ -47,5 +47,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freportn/a_minnow.pl
+++ b/freportn/a_minnow.pl
@@ -14,5 +14,5 @@ sub EVENT_ITEM {
 		quest::faction(311, -2);		#:: - Steel Warriors
 	}
 	#:: Return unused items
-    plugin::returnUnusedItems();quest::summonitem(quest::ChooseRandom($item1));
+    plugin::return_items(\%itemcount);quest::summonitem(quest::ChooseRandom($item1));
 }

--- a/freportw/Armorer_Dellin.pl
+++ b/freportw/Armorer_Dellin.pl
@@ -21,5 +21,5 @@ sub EVENT_ITEM {
 		quest::faction(362, -30); 		#:: - Priests of Marr
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }	

--- a/freportw/Cain_Darkmoore.pl
+++ b/freportw/Cain_Darkmoore.pl
@@ -77,5 +77,5 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freportw/Captain_Hazran.pl
+++ b/freportw/Captain_Hazran.pl
@@ -77,7 +77,7 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }	
 
 sub EVENT_DEATH_COMPLETE {

--- a/freportw/Driana_Poxsbourne.pl
+++ b/freportw/Driana_Poxsbourne.pl
@@ -25,5 +25,5 @@ sub EVENT_ITEM {
 		quest::faction(341, -1); 		#:: - Priests of Life
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }	

--- a/freportw/Guard_Alayle.pl
+++ b/freportw/Guard_Alayle.pl
@@ -32,7 +32,7 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }	
 
 sub EVENT_SIGNAL { 

--- a/freportw/Guard_Lithnon.pl
+++ b/freportw/Guard_Lithnon.pl
@@ -8,5 +8,5 @@ sub EVENT_SIGNAL {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freportw/Hemia_Skemner.pl
+++ b/freportw/Hemia_Skemner.pl
@@ -32,5 +32,5 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freportw/Hyrill_Pon.pl
+++ b/freportw/Hyrill_Pon.pl
@@ -61,5 +61,5 @@ sub EVENT_ITEM {
 		quest::exp(1000);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }	

--- a/freportw/Lady_Shae.pl
+++ b/freportw/Lady_Shae.pl
@@ -150,7 +150,7 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/freportw/Larn_Brugal.pl
+++ b/freportw/Larn_Brugal.pl
@@ -43,6 +43,6 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 #:: 	quest::say("This is only one sword. I requested four altogether. You shall not get your payment until I get my fourth sword");
 }

--- a/freportw/Linadian.pl
+++ b/freportw/Linadian.pl
@@ -45,5 +45,5 @@ sub EVENT_ITEM {
 		quest::exp(150);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freportw/Lorme_Tredore.pl
+++ b/freportw/Lorme_Tredore.pl
@@ -25,5 +25,5 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freportw/Nusk_Treton.pl
+++ b/freportw/Nusk_Treton.pl
@@ -69,5 +69,5 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freportw/Opal_Darkbriar.pl
+++ b/freportw/Opal_Darkbriar.pl
@@ -21,5 +21,5 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freportw/Palon_Deskeb.pl
+++ b/freportw/Palon_Deskeb.pl
@@ -33,5 +33,5 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freportw/Pandos_Flintside.pl
+++ b/freportw/Pandos_Flintside.pl
@@ -118,5 +118,5 @@ sub EVENT_ITEM {
 		quest::exp(25);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freportw/Pincia_Brownloe.pl
+++ b/freportw/Pincia_Brownloe.pl
@@ -21,5 +21,5 @@ sub EVENT_SIGNAL {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freportw/Ping_Fuzzlecutter.pl
+++ b/freportw/Ping_Fuzzlecutter.pl
@@ -47,5 +47,5 @@ sub EVENT_ITEM {
 		quest::faction(336,3); 	#:: + Coalition of Tradefolk Underground
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freportw/Plagus_Ladeson.pl
+++ b/freportw/Plagus_Ladeson.pl
@@ -73,5 +73,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freportw/Puab_Closk.pl
+++ b/freportw/Puab_Closk.pl
@@ -60,5 +60,5 @@ sub EVENT_ITEM {
 		quest::exp(1000);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freportw/Raenna_Griff.pl
+++ b/freportw/Raenna_Griff.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freportw/Ran-un.pl
+++ b/freportw/Ran-un.pl
@@ -12,5 +12,5 @@ sub EVENT_TIMER {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freportw/Reyia_Beslin.pl
+++ b/freportw/Reyia_Beslin.pl
@@ -61,5 +61,5 @@ sub EVENT_ITEM {
 		quest::exp(400);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freportw/Romiak_Jusathorn.pl
+++ b/freportw/Romiak_Jusathorn.pl
@@ -14,5 +14,5 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freportw/Shintl_Lowbrew.pl
+++ b/freportw/Shintl_Lowbrew.pl
@@ -26,5 +26,5 @@ sub EVENT_WAYPOINT_ARRIVE{
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freportw/Swin_Blackeye.pl
+++ b/freportw/Swin_Blackeye.pl
@@ -31,5 +31,5 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freportw/Tara_Neklene.pl
+++ b/freportw/Tara_Neklene.pl
@@ -77,5 +77,5 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freportw/Tarsa_Yovar.pl
+++ b/freportw/Tarsa_Yovar.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freportw/Thena_Lonnes.pl
+++ b/freportw/Thena_Lonnes.pl
@@ -12,5 +12,5 @@ sub EVENT_TIMER {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freportw/Toala_Nehron.pl
+++ b/freportw/Toala_Nehron.pl
@@ -69,5 +69,5 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freportw/Toxdil.pl
+++ b/freportw/Toxdil.pl
@@ -46,8 +46,8 @@ sub EVENT_ITEM {
 			quest::summonitem(14017);
 		}
 		#:: Return unused items
-		plugin::returnUnusedItems();
+		plugin::return_items(\%itemcount);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freportw/Ulia_Yovar.pl
+++ b/freportw/Ulia_Yovar.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freportw/Velan_Torresk.pl
+++ b/freportw/Velan_Torresk.pl
@@ -82,5 +82,5 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freportw/Yovik_Splegle.pl
+++ b/freportw/Yovik_Splegle.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freportw/a_prisoner.pl
+++ b/freportw/a_prisoner.pl
@@ -45,5 +45,5 @@ sub EVENT_ITEM {
 	}
 	quest::say("Bog n Goo.. Blanket too!!");
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/freportw/peasant_woman.pl
+++ b/freportw/peasant_woman.pl
@@ -20,5 +20,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/gfaydark/Lieutenant_Leafstalker.pl
+++ b/gfaydark/Lieutenant_Leafstalker.pl
@@ -15,5 +15,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/global/Priest_of_Discord.pl
+++ b/global/Priest_of_Discord.pl
@@ -22,5 +22,5 @@ sub EVENT_ITEM {
 		quest::pvp("on");
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/grobb/Basher_Avisk.pl
+++ b/grobb/Basher_Avisk.pl
@@ -12,5 +12,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/grobb/Basher_Nanrum.pl
+++ b/grobb/Basher_Nanrum.pl
@@ -39,5 +39,5 @@ sub EVENT_ITEM {
 		quest::summonitem(10307,1);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/grobb/Bregna.pl
+++ b/grobb/Bregna.pl
@@ -60,5 +60,5 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/grobb/Carver_Cagrek.pl
+++ b/grobb/Carver_Cagrek.pl
@@ -62,5 +62,5 @@ sub EVENT_ITEM {
 		quest::faction(222, -4);	#:: - Broken Skull Clan
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/grobb/Hergor.pl
+++ b/grobb/Hergor.pl
@@ -38,5 +38,5 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/grobb/Hukulk.pl
+++ b/grobb/Hukulk.pl
@@ -77,5 +77,5 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/grobb/Kaglari.pl
+++ b/grobb/Kaglari.pl
@@ -66,5 +66,5 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/grobb/Ranjor.pl
+++ b/grobb/Ranjor.pl
@@ -47,5 +47,5 @@ sub EVENT_ITEM {
 		quest::exp(250);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/grobb/Treskar.pl
+++ b/grobb/Treskar.pl
@@ -313,5 +313,5 @@ sub EVENT_ITEM {
 		quest::summonitem(12199);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/grobb/Urako.pl
+++ b/grobb/Urako.pl
@@ -100,5 +100,5 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/grobb/a_prisoner.pl
+++ b/grobb/a_prisoner.pl
@@ -29,5 +29,5 @@ sub EVENT_ITEM {
 		$client->AddLevelBasedExp(14,1);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/gukbottom/a_ghoul_scribe.pl
+++ b/gukbottom/a_ghoul_scribe.pl
@@ -1,4 +1,4 @@
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/guktop/Tempus.pl
+++ b/guktop/Tempus.pl
@@ -7,5 +7,5 @@ sub EVENT_COMBAT {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/guktop/a_troll_prisoner.pl
+++ b/guktop/a_troll_prisoner.pl
@@ -7,5 +7,5 @@ sub EVENT_COMBAT {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/halas/Alec_McMarrin.pl
+++ b/halas/Alec_McMarrin.pl
@@ -7,5 +7,5 @@ sub EVENT_SAY {
 	
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/halas/Andres_McMarrin.pl
+++ b/halas/Andres_McMarrin.pl
@@ -12,7 +12,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/halas/April.pl
+++ b/halas/April.pl
@@ -11,5 +11,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/halas/Brandyn_McDonald.pl
+++ b/halas/Brandyn_McDonald.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/halas/Cindl.pl
+++ b/halas/Cindl.pl
@@ -64,5 +64,5 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/halas/DargonOLD.pl
+++ b/halas/DargonOLD.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/halas/Dargon_McPherson.pl
+++ b/halas/Dargon_McPherson.pl
@@ -67,5 +67,5 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/halas/Dok.pl
+++ b/halas/Dok.pl
@@ -61,5 +61,5 @@ sub EVENT_ITEM {
 		quest::exp(50000);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/halas/Dun_McDowell.pl
+++ b/halas/Dun_McDowell.pl
@@ -37,5 +37,5 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/halas/Gorth_Bearsoul.pl
+++ b/halas/Gorth_Bearsoul.pl
@@ -22,5 +22,5 @@ sub EVENT_ITEM {
 		quest::exp(1250);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/halas/Greta_Terrilon.pl
+++ b/halas/Greta_Terrilon.pl
@@ -11,5 +11,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/halas/Hetie_McDonald.pl
+++ b/halas/Hetie_McDonald.pl
@@ -51,5 +51,5 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/halas/Holana_Oleary.pl
+++ b/halas/Holana_Oleary.pl
@@ -58,5 +58,5 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/halas/Jinkus_Felligan.pl
+++ b/halas/Jinkus_Felligan.pl
@@ -88,5 +88,5 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/halas/Kylan_O-Danos.pl
+++ b/halas/Kylan_O-Danos.pl
@@ -40,5 +40,5 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/halas/Lysbith_McNaff.pl
+++ b/halas/Lysbith_McNaff.pl
@@ -79,5 +79,5 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}	
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/halas/Margyn_McCann.pl
+++ b/halas/Margyn_McCann.pl
@@ -60,5 +60,5 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/halas/Marton_Stringsinger.pl
+++ b/halas/Marton_Stringsinger.pl
@@ -17,5 +17,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/halas/Mils_McMarrin.pl
+++ b/halas/Mils_McMarrin.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/halas/Murtog_MacYee.pl
+++ b/halas/Murtog_MacYee.pl
@@ -13,5 +13,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/halas/Quillion_O-Zinn.pl
+++ b/halas/Quillion_O-Zinn.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/halas/Renth_McLanis.pl
+++ b/halas/Renth_McLanis.pl
@@ -150,5 +150,5 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/halas/Shamus_Felligan.pl
+++ b/halas/Shamus_Felligan.pl
@@ -52,5 +52,5 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
     	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/halas/Skoni.pl
+++ b/halas/Skoni.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/halas/Teria_O-Danos.pl
+++ b/halas/Teria_O-Danos.pl
@@ -33,5 +33,5 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/halas/Thadres_Thyme.pl
+++ b/halas/Thadres_Thyme.pl
@@ -28,5 +28,5 @@ sub EVENT_ITEM {
 		quest::exp(200);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/halas/Waltor_Felligan.pl
+++ b/halas/Waltor_Felligan.pl
@@ -121,5 +121,5 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/halas/Ysanna_MacGibbon.pl
+++ b/halas/Ysanna_MacGibbon.pl
@@ -36,5 +36,5 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/highpasshold.DISABLED/Dyllin_Starsine.pl
+++ b/highpasshold.DISABLED/Dyllin_Starsine.pl
@@ -10,5 +10,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/highpasshold/Barn_Bloodstone.pl
+++ b/highpasshold/Barn_Bloodstone.pl
@@ -19,7 +19,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_WAYPOINT_ARRIVE {

--- a/highpasshold/Beef.pl
+++ b/highpasshold/Beef.pl
@@ -17,5 +17,5 @@ sub EVENT_SIGNAL {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/highpasshold/Brenon.pl
+++ b/highpasshold/Brenon.pl
@@ -4,5 +4,5 @@ sub EVENT_DEATH_COMPLETE {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/highpasshold/Bryan_McGee.pl
+++ b/highpasshold/Bryan_McGee.pl
@@ -59,7 +59,7 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/highpasshold/Captain_Ashlan.pl
+++ b/highpasshold/Captain_Ashlan.pl
@@ -112,5 +112,5 @@ sub EVENT_ITEM {
 		#:: Else eat the items
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/highpasshold/Captain_Orben.pl
+++ b/highpasshold/Captain_Orben.pl
@@ -95,5 +95,5 @@ sub EVENT_ITEM {
 		}
 	}	
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/highpasshold/Cytodl_Krish.pl
+++ b/highpasshold/Cytodl_Krish.pl
@@ -11,5 +11,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/highpasshold/Dalishea.pl
+++ b/highpasshold/Dalishea.pl
@@ -1,6 +1,6 @@
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/highpasshold/Dyllin_Starsine.pl
+++ b/highpasshold/Dyllin_Starsine.pl
@@ -10,5 +10,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/highpasshold/Falyn_Farreach.pl
+++ b/highpasshold/Falyn_Farreach.pl
@@ -9,5 +9,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/highpasshold/Gornolin.pl
+++ b/highpasshold/Gornolin.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/highpasshold/Guard_Becker.pl
+++ b/highpasshold/Guard_Becker.pl
@@ -7,5 +7,5 @@ sub EVENT_COMBAT {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/highpasshold/Guard_Ranlem.pl
+++ b/highpasshold/Guard_Ranlem.pl
@@ -7,5 +7,5 @@ sub EVENT_COMBAT {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/highpasshold/Guard_Stald.pl
+++ b/highpasshold/Guard_Stald.pl
@@ -7,5 +7,5 @@ sub EVENT_COMBAT {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/highpasshold/Gublink_Furnhorn.pl
+++ b/highpasshold/Gublink_Furnhorn.pl
@@ -7,5 +7,5 @@ sub EVENT_COMBAT {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/highpasshold/Jovan.pl
+++ b/highpasshold/Jovan.pl
@@ -19,5 +19,5 @@ sub EVENT_ITEM {
 		quest::depop_withtimer();
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/highpasshold/Kaden_Gron.pl
+++ b/highpasshold/Kaden_Gron.pl
@@ -1,6 +1,6 @@
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/highpasshold/Lydl_the_Great.pl
+++ b/highpasshold/Lydl_the_Great.pl
@@ -7,5 +7,5 @@ sub EVENT_COMBAT {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/highpasshold/Marlin_Shirtov.pl
+++ b/highpasshold/Marlin_Shirtov.pl
@@ -26,5 +26,5 @@ sub EVENT_ITEM {
 		quest::exp(500);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/highpasshold/Mutt_Rootlit.pl
+++ b/highpasshold/Mutt_Rootlit.pl
@@ -9,7 +9,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/highpasshold/Prak.pl
+++ b/highpasshold/Prak.pl
@@ -75,5 +75,5 @@ sub EVENT_ITEM {
 		}	
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/highpasshold/Volunteer_Delharn.pl
+++ b/highpasshold/Volunteer_Delharn.pl
@@ -22,5 +22,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/highpasshold/Wres_Corber.pl
+++ b/highpasshold/Wres_Corber.pl
@@ -1,6 +1,6 @@
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/kael/Svekk_Fangbinder.pl
+++ b/kael/Svekk_Fangbinder.pl
@@ -78,7 +78,7 @@ sub EVENT_ITEM {
 			quest::summonitem(25269); # Large Supply Sack for Bekerak
 		}
 	}
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 # EOF

--- a/kaladima/Vacto_Molunel.pl
+++ b/kaladima/Vacto_Molunel.pl
@@ -130,5 +130,5 @@ sub EVENT_ITEM {
 		quest::exp(500);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/kaladimb/Harnoff_Splitrock_.pl
+++ b/kaladimb/Harnoff_Splitrock_.pl
@@ -20,7 +20,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
   	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/kerraridge/Allix.pl
+++ b/kerraridge/Allix.pl
@@ -17,7 +17,7 @@ sub EVENT_ITEM {
 		#:: Ding!
 		quest::ding();
 		#:: Give a 1120 - Erudehide Tunic
-		quest::summonitem(11120);
+		quest::summonitem(1120);
 		#:: Grant a small amount of experience
 		quest::exp(25);
 	}

--- a/kerraridge/Feren.pl
+++ b/kerraridge/Feren.pl
@@ -24,5 +24,5 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/kerraridge/Feren.pl
+++ b/kerraridge/Feren.pl
@@ -15,7 +15,7 @@ sub EVENT_ITEM {
 	if (plugin::check_handin(\%itemcount, 6348 => 1)) {
 		quest::say("Razortooth! You catch him! Truly, you be great fisher. Please take this from me. Feren is forever owing you.");
 		#:: Give a 1062 - Kerran Fishingpole
-		quest::summonitem(11062);
+		quest::summonitem(1062);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/kerraridge/Roary_Fishpouncer.pl
+++ b/kerraridge/Roary_Fishpouncer.pl
@@ -14,7 +14,7 @@ sub EVENT_ITEM {
                 #:: Ding!
                 quest::ding();
                 #:: Give a 7027 - Kerran Fishing Spear
-                quest::summonitem(17027);
+                quest::summonitem(7027);
                 #:: Grant a small amount of experience
                 quest::exp(500);
         }

--- a/kerraridge/Thalith_Mamluk.pl
+++ b/kerraridge/Thalith_Mamluk.pl
@@ -12,7 +12,7 @@ sub EVENT_ITEM {
 	if (plugin::check_handin(\%itemcount, 6347 => 1)) {
 		quest::say("You.. You kill the rats? Errr. Thalith thanks you. Here. Take this. It's good luck charm I've had for years.");
 		#:: Give a 1061 - Fishbone Necklace
-		quest::summonitem(11061);
+		quest::summonitem(1061);
 		#:: Ding!
 		quest::ding();
 		#:: Set factions

--- a/kerraridge/Urkath_Greyface.pl
+++ b/kerraridge/Urkath_Greyface.pl
@@ -15,7 +15,7 @@ sub EVENT_ITEM {
 	if (plugin::check_handin(\%itemcount, 1155 => 1)) {
 		quest::say("Excellent! I can't believe you found it.  Here is the rrrreward that I promised you.");
 		#:: Give a 2045 - Worn Leather Shoulderpads
-		quest::summonitem(12045);
+		quest::summonitem(2045);
 		#:: Ding!
 		quest::ding();
 		#:: Grant a moderate amount of experience

--- a/kerraridge/a_banished_kerran.pl
+++ b/kerraridge/a_banished_kerran.pl
@@ -28,5 +28,5 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/kithicor/Brollus_Hoost.pl
+++ b/kithicor/Brollus_Hoost.pl
@@ -12,5 +12,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/kithicor/Leaf_Falldim.pl
+++ b/kithicor/Leaf_Falldim.pl
@@ -44,7 +44,7 @@ sub EVENT_ITEM {
 		quest::faction(324,-60); # unkempt druids
 		quest::exp(10000);		
     }
-    plugin::returnUnusedItems();
+    plugin::return_items(\%itemcount);
 }
 
 

--- a/kithicor/Tallyn_Starwatch.pl
+++ b/kithicor/Tallyn_Starwatch.pl
@@ -7,7 +7,7 @@ sub EVENT_COMBAT {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/kithicor/a_goblin_worker.pl
+++ b/kithicor/a_goblin_worker.pl
@@ -20,7 +20,7 @@ sub EVENT_TIMER {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/lavastorm/old/#Miner_Welnik.pl
+++ b/lavastorm/old/#Miner_Welnik.pl
@@ -36,7 +36,7 @@ sub EVENT_ITEM {
 		quest::summonitem(71706); # Item: Glowing Magma Ring
 		quest::exp(1000);
 	} 
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_SPAWN {

--- a/lavastorm/old/#Sir_Lindeal.pl
+++ b/lavastorm/old/#Sir_Lindeal.pl
@@ -21,5 +21,5 @@ sub EVENT_DEATH_COMPLETE {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/lavastorm/old/Tizina.pl
+++ b/lavastorm/old/Tizina.pl
@@ -16,5 +16,5 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/najena/#Rathyl.pl
+++ b/najena/#Rathyl.pl
@@ -5,5 +5,5 @@ sub EVENT_DEATH_COMPLETE {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/najena/Ekeros.pl
+++ b/najena/Ekeros.pl
@@ -11,5 +11,5 @@ sub EVENT_DEATH_COMPLETE {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/najena/Najena.pl
+++ b/najena/Najena.pl
@@ -21,7 +21,7 @@ sub EVENT_COMBAT {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/najena/The_Widowmistress.pl
+++ b/najena/The_Widowmistress.pl
@@ -7,5 +7,5 @@ sub EVENT_COMBAT {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/najena/a_magician.pl
+++ b/najena/a_magician.pl
@@ -21,7 +21,7 @@ sub EVENT_COMBAT {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/najena/a_necromancer.pl
+++ b/najena/a_necromancer.pl
@@ -21,7 +21,7 @@ sub EVENT_COMBAT {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/neriaka/Guard_Swang.pl
+++ b/neriaka/Guard_Swang.pl
@@ -1,6 +1,6 @@
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/neriaka/Jacker.pl
+++ b/neriaka/Jacker.pl
@@ -1,6 +1,6 @@
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/neriaka/Oosa_Shadowthumper.pl
+++ b/neriaka/Oosa_Shadowthumper.pl
@@ -1,6 +1,6 @@
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/neriaka/Pungla.pl
+++ b/neriaka/Pungla.pl
@@ -18,5 +18,5 @@ sub EVENT_ITEM {
 		quest::ding();
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriaka/Rolynn_Bdoph.pl
+++ b/neriaka/Rolynn_Bdoph.pl
@@ -13,5 +13,5 @@ sub EVENT_WAYPOINT_ARRIVE {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriaka/Uglan.pl
+++ b/neriaka/Uglan.pl
@@ -42,5 +42,5 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Antian_F-Lok.pl
+++ b/neriakb/Antian_F-Lok.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Asyln_C-Luzz.pl
+++ b/neriakb/Asyln_C-Luzz.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Belux_J-Ver.pl
+++ b/neriakb/Belux_J-Ver.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Cizzar_J-Axx.pl
+++ b/neriakb/Cizzar_J-Axx.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Dianax_C-Luzz.pl
+++ b/neriakb/Dianax_C-Luzz.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Dissa_C-Luzz.pl
+++ b/neriakb/Dissa_C-Luzz.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Drizm_J-Axx.pl
+++ b/neriakb/Drizm_J-Axx.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Dunred_M-Trik.pl
+++ b/neriakb/Dunred_M-Trik.pl
@@ -30,5 +30,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Footman_M-oze.pl
+++ b/neriakb/Footman_M-oze.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Frivsa_Punox.pl
+++ b/neriakb/Frivsa_Punox.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Garren_D-Vek.pl
+++ b/neriakb/Garren_D-Vek.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Genzal_R-Jyen.pl
+++ b/neriakb/Genzal_R-Jyen.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Glazn_D-Unnar.pl
+++ b/neriakb/Glazn_D-Unnar.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Guard_D-Bious.pl
+++ b/neriakb/Guard_D-Bious.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Guard_D`Unnar.pl
+++ b/neriakb/Guard_D`Unnar.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Guard_Dmizza.pl
+++ b/neriakb/Guard_Dmizza.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Guard_F-Mazz.pl
+++ b/neriakb/Guard_F-Mazz.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Guard_G-Noir.pl
+++ b/neriakb/Guard_G-Noir.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Guard_J-Axx.pl
+++ b/neriakb/Guard_J-Axx.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Guard_K-Jartan.pl
+++ b/neriakb/Guard_K-Jartan.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Guard_L-Crit.pl
+++ b/neriakb/Guard_L-Crit.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Guard_N-Mar.pl
+++ b/neriakb/Guard_N-Mar.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Guard_Q-Tentu.pl
+++ b/neriakb/Guard_Q-Tentu.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Guard_Quexill.pl
+++ b/neriakb/Guard_Quexill.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Guard_S-Lon.pl
+++ b/neriakb/Guard_S-Lon.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Guard_S-Tai.pl
+++ b/neriakb/Guard_S-Tai.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Guard_To-Biath.pl
+++ b/neriakb/Guard_To-Biath.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Guard_Tolax.pl
+++ b/neriakb/Guard_Tolax.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Guard_V-Resh.pl
+++ b/neriakb/Guard_V-Resh.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Guard_W-Selo.pl
+++ b/neriakb/Guard_W-Selo.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Guard_Zexus.pl
+++ b/neriakb/Guard_Zexus.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Halvn_B-Div.pl
+++ b/neriakb/Halvn_B-Div.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Isvan_S-Lon.pl
+++ b/neriakb/Isvan_S-Lon.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Jucra_V-Lask.pl
+++ b/neriakb/Jucra_V-Lask.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Kis_K-Jartan.pl
+++ b/neriakb/Kis_K-Jartan.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Kizya_D-Dbth.pl
+++ b/neriakb/Kizya_D-Dbth.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Litz_B-Div.pl
+++ b/neriakb/Litz_B-Div.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Lizza_D-Unnar.pl
+++ b/neriakb/Lizza_D-Unnar.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Lysanda_S-Kor.pl
+++ b/neriakb/Lysanda_S-Kor.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Mak_Ixtaz.pl
+++ b/neriakb/Mak_Ixtaz.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Mariz_Ixtaz.pl
+++ b/neriakb/Mariz_Ixtaz.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Marza_T-Kix.pl
+++ b/neriakb/Marza_T-Kix.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Mavin_D-Dbth.pl
+++ b/neriakb/Mavin_D-Dbth.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Mikaela_S-Kor.pl
+++ b/neriakb/Mikaela_S-Kor.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Mirzna_N-Mar.pl
+++ b/neriakb/Mirzna_N-Mar.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Myrva_N-Tan.pl
+++ b/neriakb/Myrva_N-Tan.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Mys_S-Tai.pl
+++ b/neriakb/Mys_S-Tai.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Nekola_N-Ryt.pl
+++ b/neriakb/Nekola_N-Ryt.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Niz_L-Crit.pl
+++ b/neriakb/Niz_L-Crit.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Olavn_N-Mar.pl
+++ b/neriakb/Olavn_N-Mar.pl
@@ -27,7 +27,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/neriakb/Opal_H-Rugla.pl
+++ b/neriakb/Opal_H-Rugla.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Opizel_G-Efia.pl
+++ b/neriakb/Opizel_G-Efia.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Pisna_H-Rugla.pl
+++ b/neriakb/Pisna_H-Rugla.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Ranza_S-lon.pl
+++ b/neriakb/Ranza_S-lon.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Razran_F-Lok.pl
+++ b/neriakb/Razran_F-Lok.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Rista_S-lon.pl
+++ b/neriakb/Rista_S-lon.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Riv_N-Mar.pl
+++ b/neriakb/Riv_N-Mar.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Shanez_X-Teria.pl
+++ b/neriakb/Shanez_X-Teria.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Svlis_C-Luzz.pl
+++ b/neriakb/Svlis_C-Luzz.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Syrn_L-Crit.pl
+++ b/neriakb/Syrn_L-Crit.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Tal_G-Noir.pl
+++ b/neriakb/Tal_G-Noir.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Tenso_H-Rugla.pl
+++ b/neriakb/Tenso_H-Rugla.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Tizzy_C-Luzz.pl
+++ b/neriakb/Tizzy_C-Luzz.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Tkaz_H-Rugla.pl
+++ b/neriakb/Tkaz_H-Rugla.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Treven_Ru-Soe.pl
+++ b/neriakb/Treven_Ru-Soe.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Trista_N-Ryt.pl
+++ b/neriakb/Trista_N-Ryt.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Utvex_D-Jerna.pl
+++ b/neriakb/Utvex_D-Jerna.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Veca_S-Karn.pl
+++ b/neriakb/Veca_S-Karn.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakb/Zartox_Ru-Soe.pl
+++ b/neriakb/Zartox_Ru-Soe.pl
@@ -27,5 +27,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/neriakc/Lokar_To-Biath.pl
+++ b/neriakc/Lokar_To-Biath.pl
@@ -61,7 +61,7 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/neriakc/Mare_X-Lottl.pl
+++ b/neriakc/Mare_X-Lottl.pl
@@ -38,7 +38,7 @@ sub EVENT_ITEM {
 		quest::settimer("dance", 3);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_TIMER {

--- a/neriakc/Xantis_Ixtax.pl
+++ b/neriakc/Xantis_Ixtax.pl
@@ -27,7 +27,7 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 #END of FILE Zone:neriakc  ID:42063 -- Xantis_Ixtax

--- a/oasis/Taldrik_Stumpystout.pl
+++ b/oasis/Taldrik_Stumpystout.pl
@@ -35,5 +35,5 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/oggok/Ambassador_K-Ryn.pl
+++ b/oggok/Ambassador_K-Ryn.pl
@@ -16,7 +16,7 @@ sub EVENT_ITEM {
 		quest::exp(250);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH {

--- a/oot/#Marrey_McGrannel.pl
+++ b/oot/#Marrey_McGrannel.pl
@@ -76,5 +76,5 @@ sub EVENT_ITEM {
 		#:: Test handin with no epic in progress--eat item?
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/oot/Sentry_Xyrin.pl
+++ b/oot/Sentry_Xyrin.pl
@@ -77,7 +77,7 @@ sub EVENT_ITEM {
 		quest::start(62);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub KillUndead {

--- a/oot/Styria_Fearnon.pl
+++ b/oot/Styria_Fearnon.pl
@@ -57,5 +57,5 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/paw/#a_gnoll_prisoner.pl
+++ b/paw/#a_gnoll_prisoner.pl
@@ -18,5 +18,5 @@ sub EVENT_TIMER {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/paw/Brother_Gruff.pl
+++ b/paw/Brother_Gruff.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/plugins/default-actions.pl
+++ b/plugins/default-actions.pl
@@ -66,7 +66,7 @@ sub defaultSay{
 
 sub defaultItem
 {
-  plugin::returnUnusedItems();
+  plugin::return_items(\%itemcount);
 }
 
 sub defaultDeath

--- a/qcat/Bait_Masterson.pl
+++ b/qcat/Bait_Masterson.pl
@@ -31,5 +31,5 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qcat/Chan_Whinstone.pl
+++ b/qcat/Chan_Whinstone.pl
@@ -1,6 +1,6 @@
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/qcat/Chou_Whinstone.pl
+++ b/qcat/Chou_Whinstone.pl
@@ -1,6 +1,6 @@
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/qcat/Commander_Kane.pl
+++ b/qcat/Commander_Kane.pl
@@ -38,5 +38,5 @@ sub EVENT_SAY {
 sub EVENT_ITEM {
 	plugin::try_tome_handins(\%itemcount, $class, 'Warrior');
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qcat/Garuc_Anehm.pl
+++ b/qcat/Garuc_Anehm.pl
@@ -109,5 +109,5 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qcat/Kron_Redstepp.pl
+++ b/qcat/Kron_Redstepp.pl
@@ -1,6 +1,6 @@
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/qcat/Krytn_Redstepp.pl
+++ b/qcat/Krytn_Redstepp.pl
@@ -1,6 +1,6 @@
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/qcat/Kurne_Rextula.pl
+++ b/qcat/Kurne_Rextula.pl
@@ -91,5 +91,5 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qcat/Marn_Darkson.pl
+++ b/qcat/Marn_Darkson.pl
@@ -1,6 +1,6 @@
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/qcat/Morn_Darkson.pl
+++ b/qcat/Morn_Darkson.pl
@@ -1,6 +1,6 @@
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/qcat/Neab.pl
+++ b/qcat/Neab.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qcat/Riggin_Vix.pl
+++ b/qcat/Riggin_Vix.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qcat/Van_Shatblack.pl
+++ b/qcat/Van_Shatblack.pl
@@ -4,5 +4,5 @@ sub EVENT_DEATH_COMPLETE {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qcat/Vun_Shatblack.pl
+++ b/qcat/Vun_Shatblack.pl
@@ -4,5 +4,5 @@ sub EVENT_DEATH_COMPLETE {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qcat/a_ring_leader.pl
+++ b/qcat/a_ring_leader.pl
@@ -4,7 +4,7 @@ sub EVENT_AGGRO {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/qcat/a_smuggler.pl
+++ b/qcat/a_smuggler.pl
@@ -4,7 +4,7 @@ sub EVENT_AGGRO {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/qcat/an_injured_brigand.pl
+++ b/qcat/an_injured_brigand.pl
@@ -27,5 +27,5 @@ sub EVENT_COMBAT {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qey2hh1/Basil.pl
+++ b/qey2hh1/Basil.pl
@@ -25,5 +25,5 @@ sub EVENT_COMBAT {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qey2hh1/Brother_Estle.pl
+++ b/qey2hh1/Brother_Estle.pl
@@ -59,7 +59,7 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/qey2hh1/Brother_Trintle.pl
+++ b/qey2hh1/Brother_Trintle.pl
@@ -19,5 +19,5 @@ sub EVENT_WAYPOINT_ARRIVE {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qey2hh1/Caninel.pl
+++ b/qey2hh1/Caninel.pl
@@ -31,5 +31,5 @@ sub EVENT_ITEM {
 		quest::set_data($key, 1, 300);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qey2hh1/Chrislin_Baker.pl
+++ b/qey2hh1/Chrislin_Baker.pl
@@ -23,5 +23,5 @@ sub EVENT_ITEM {
 		#:: quest::spawn2(12172, 0, 0, -11570, 878, 14, 135);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qey2hh1/Cleet_Miller.pl
+++ b/qey2hh1/Cleet_Miller.pl
@@ -39,5 +39,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qey2hh1/Cleet_Miller_Jr.pl
+++ b/qey2hh1/Cleet_Miller_Jr.pl
@@ -9,5 +9,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qey2hh1/Einhorst_McMannus.pl
+++ b/qey2hh1/Einhorst_McMannus.pl
@@ -47,7 +47,7 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/qey2hh1/Frostbite.pl
+++ b/qey2hh1/Frostbite.pl
@@ -21,7 +21,7 @@ sub EVENT_ITEM {
 		quest::settimer("depop", 1200);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_TIMER {

--- a/qey2hh1/Furball_Miller.pl
+++ b/qey2hh1/Furball_Miller.pl
@@ -15,5 +15,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qey2hh1/Gindlin_Toxfodder.pl
+++ b/qey2hh1/Gindlin_Toxfodder.pl
@@ -19,5 +19,5 @@ sub EVENT_ITEM {
 		quest::exp(1000);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qey2hh1/Gomo_Limerin.pl
+++ b/qey2hh1/Gomo_Limerin.pl
@@ -11,5 +11,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qey2hh1/Grebin_Sneztop.pl
+++ b/qey2hh1/Grebin_Sneztop.pl
@@ -11,5 +11,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qey2hh1/Guard_Gregor.pl
+++ b/qey2hh1/Guard_Gregor.pl
@@ -7,5 +7,5 @@ sub EVENT_COMBAT {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qey2hh1/Habastash_Gikin.pl
+++ b/qey2hh1/Habastash_Gikin.pl
@@ -11,5 +11,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qey2hh1/Henina_Miller.pl
+++ b/qey2hh1/Henina_Miller.pl
@@ -53,5 +53,5 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qey2hh1/Innkeep_Rislarn.pl
+++ b/qey2hh1/Innkeep_Rislarn.pl
@@ -58,5 +58,5 @@ sub EVENT_ITEM {
 		quest::MerchantSetItem(12103, 13014, 20);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qey2hh1/Kobot_Dellin.pl
+++ b/qey2hh1/Kobot_Dellin.pl
@@ -19,5 +19,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qey2hh1/Kyle_Rinlin.pl
+++ b/qey2hh1/Kyle_Rinlin.pl
@@ -11,5 +11,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qey2hh1/Lander_Billkin.pl
+++ b/qey2hh1/Lander_Billkin.pl
@@ -11,5 +11,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qey2hh1/Lempeck_Hargrin.pl
+++ b/qey2hh1/Lempeck_Hargrin.pl
@@ -56,7 +56,7 @@ sub EVENT_ITEM {
 		quest::exp(1000);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/qey2hh1/Linaya_Sowlin.pl
+++ b/qey2hh1/Linaya_Sowlin.pl
@@ -35,5 +35,5 @@ sub EVENT_ITEM {
 		quest::unique_spawn(12181, 0, 0, -8000, -3400, 23, 102.9);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qey2hh1/Minda.pl
+++ b/qey2hh1/Minda.pl
@@ -30,5 +30,5 @@ sub EVENT_ITEM {
 		quest::exp(500);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qey2hh1/Misla_McMannus.pl
+++ b/qey2hh1/Misla_McMannus.pl
@@ -11,5 +11,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qey2hh1/Misty_Storyswapper.pl
+++ b/qey2hh1/Misty_Storyswapper.pl
@@ -9,5 +9,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qey2hh1/Paglan.pl
+++ b/qey2hh1/Paglan.pl
@@ -25,5 +25,5 @@ sub EVENT_COMBAT {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qey2hh1/Parcil_Vinder.pl
+++ b/qey2hh1/Parcil_Vinder.pl
@@ -21,5 +21,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qey2hh1/Quegin_Hadder.pl
+++ b/qey2hh1/Quegin_Hadder.pl
@@ -11,5 +11,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qey2hh1/Rongol.pl
+++ b/qey2hh1/Rongol.pl
@@ -33,5 +33,5 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qey2hh1/Ronly_Jogmill.pl
+++ b/qey2hh1/Ronly_Jogmill.pl
@@ -11,5 +11,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qey2hh1/Tiny_Miller.pl
+++ b/qey2hh1/Tiny_Miller.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qey2hh1/Tolony_Marle.pl
+++ b/qey2hh1/Tolony_Marle.pl
@@ -11,5 +11,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qey2hh1/Tukk.pl
+++ b/qey2hh1/Tukk.pl
@@ -33,5 +33,5 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qey2hh1/Ulrich_McMannus.pl
+++ b/qey2hh1/Ulrich_McMannus.pl
@@ -12,7 +12,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 #:: Converted to Perl by SS

--- a/qey2hh1/Yiz_Pon.pl
+++ b/qey2hh1/Yiz_Pon.pl
@@ -45,7 +45,7 @@ sub EVENT_SIGNAL {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/qeynos2/Nax_Ghruna.pl
+++ b/qeynos2/Nax_Ghruna.pl
@@ -9,7 +9,7 @@ sub EVENT_SAY {
 }
 
 sub EVENT_ITEM {
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/qeytoqrg/Axe_Broadsmith.pl
+++ b/qeytoqrg/Axe_Broadsmith.pl
@@ -43,5 +43,5 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qeytoqrg/Baobob_Miller.pl
+++ b/qeytoqrg/Baobob_Miller.pl
@@ -139,7 +139,7 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/qeytoqrg/Barn_Bloodstone.pl
+++ b/qeytoqrg/Barn_Bloodstone.pl
@@ -13,5 +13,5 @@ sub EVENT_WAYPOINT_ARRIVE {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qeytoqrg/Buzzlin_Bornahm.pl
+++ b/qeytoqrg/Buzzlin_Bornahm.pl
@@ -13,5 +13,5 @@ sub EVENT_WAYPOINT_ARRIVE {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qeytoqrg/Chanda_Miller.pl
+++ b/qeytoqrg/Chanda_Miller.pl
@@ -141,5 +141,5 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qeytoqrg/Cros_Treewind.pl
+++ b/qeytoqrg/Cros_Treewind.pl
@@ -27,7 +27,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/qeytoqrg/Crumpy_Irontoe.pl
+++ b/qeytoqrg/Crumpy_Irontoe.pl
@@ -13,5 +13,5 @@ sub EVENT_WAYPOINT_ARRIVE {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qeytoqrg/Gnasher_Furgutt.pl
+++ b/qeytoqrg/Gnasher_Furgutt.pl
@@ -22,5 +22,5 @@ sub EVENT_ITEM {
 		quest::exp(200);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qeytoqrg/Guard_Cheslin.pl
+++ b/qeytoqrg/Guard_Cheslin.pl
@@ -199,5 +199,5 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qeytoqrg/Guard_Leopold.pl
+++ b/qeytoqrg/Guard_Leopold.pl
@@ -30,5 +30,5 @@ sub EVENT_WAYPOINT_ARRIVE {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qeytoqrg/Hadden.pl
+++ b/qeytoqrg/Hadden.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qeytoqrg/Hefax_Tinmar.pl
+++ b/qeytoqrg/Hefax_Tinmar.pl
@@ -14,5 +14,5 @@ sub EVENT_SIGNAL {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qeytoqrg/Holly_Windstalker.pl
+++ b/qeytoqrg/Holly_Windstalker.pl
@@ -16,5 +16,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qeytoqrg/Konem_Matse.pl
+++ b/qeytoqrg/Konem_Matse.pl
@@ -33,7 +33,7 @@ sub EVENT_ITEM {
 		quest::exp(200);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/qeytoqrg/Marton_Sayer.pl
+++ b/qeytoqrg/Marton_Sayer.pl
@@ -56,5 +56,5 @@ sub EVENT_ITEM {
 		quest::exp(500);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qeytoqrg/Mira_Sayer.pl
+++ b/qeytoqrg/Mira_Sayer.pl
@@ -24,5 +24,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qeytoqrg/Mogan_Delfin.pl
+++ b/qeytoqrg/Mogan_Delfin.pl
@@ -14,5 +14,5 @@ sub EVENT_SIGNAL {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qeytoqrg/Neclo_Rheslar.pl
+++ b/qeytoqrg/Neclo_Rheslar.pl
@@ -29,5 +29,5 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qeytoqrg/Niclaus_Ressinn.pl
+++ b/qeytoqrg/Niclaus_Ressinn.pl
@@ -79,5 +79,5 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qeytoqrg/Rephas.pl
+++ b/qeytoqrg/Rephas.pl
@@ -70,5 +70,5 @@ sub EVENT_ITEM {
 		quest::exp(50);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qeytoqrg/Sir_Edwin_Motte.pl
+++ b/qeytoqrg/Sir_Edwin_Motte.pl
@@ -13,5 +13,5 @@ sub EVENT_WAYPOINT_ARRIVE {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qeytoqrg/Talym_Shoontar.pl
+++ b/qeytoqrg/Talym_Shoontar.pl
@@ -13,5 +13,5 @@ sub EVENT_WAYPOINT_ARRIVE {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qeytoqrg/Tol_Nicelot.pl
+++ b/qeytoqrg/Tol_Nicelot.pl
@@ -13,5 +13,5 @@ sub EVENT_WAYPOINT_ARRIVE {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/qeytoqrg/Wyle_Bimlin.pl
+++ b/qeytoqrg/Wyle_Bimlin.pl
@@ -13,5 +13,5 @@ sub EVENT_WAYPOINT_ARRIVE {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rathemtn/Hasten_Bootstrutter.pl
+++ b/rathemtn/Hasten_Bootstrutter.pl
@@ -132,5 +132,5 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rathemtn/Loancal_Joonan.pl
+++ b/rathemtn/Loancal_Joonan.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rathemtn/Peltin_Funter.pl
+++ b/rathemtn/Peltin_Funter.pl
@@ -1,6 +1,6 @@
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/rathemtn/Zepin_Winsle.pl
+++ b/rathemtn/Zepin_Winsle.pl
@@ -1,6 +1,6 @@
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/rivervale/Ace_Slighthand.pl
+++ b/rivervale/Ace_Slighthand.pl
@@ -24,5 +24,5 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Beek_Guinders.pl
+++ b/rivervale/Beek_Guinders.pl
@@ -70,5 +70,5 @@ sub EVENT_ITEM {
 		quest::faction(263, 10);	#:: + Guardians of the Vale
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Blinza_Toepopal.pl
+++ b/rivervale/Blinza_Toepopal.pl
@@ -78,5 +78,5 @@ sub EVENT_ITEM {
 		quest::faction(329, -1);	#:: + Carson McCabe
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Daleen_Leafsway.pl
+++ b/rivervale/Daleen_Leafsway.pl
@@ -37,5 +37,5 @@ sub EVENT_PROXIMITY_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Deputy_Alltin.pl
+++ b/rivervale/Deputy_Alltin.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {	
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Deputy_Antana.pl
+++ b/rivervale/Deputy_Antana.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {	
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Deputy_Banto.pl
+++ b/rivervale/Deputy_Banto.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {	
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Deputy_Beedo.pl
+++ b/rivervale/Deputy_Beedo.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {	
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Deputy_Cheel.pl
+++ b/rivervale/Deputy_Cheel.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {	
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Deputy_Chopo.pl
+++ b/rivervale/Deputy_Chopo.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {	
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Deputy_Deego.pl
+++ b/rivervale/Deputy_Deego.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {	
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Deputy_Dopkin.pl
+++ b/rivervale/Deputy_Dopkin.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {	
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Deputy_Finlip.pl
+++ b/rivervale/Deputy_Finlip.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {	
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Deputy_Fozon.pl
+++ b/rivervale/Deputy_Fozon.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {	
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Deputy_Goltin.pl
+++ b/rivervale/Deputy_Goltin.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {	
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Deputy_Gozan.pl
+++ b/rivervale/Deputy_Gozan.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {	
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Deputy_Heepo.pl
+++ b/rivervale/Deputy_Heepo.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {	
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Deputy_Higley.pl
+++ b/rivervale/Deputy_Higley.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {	
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Deputy_Higrin.pl
+++ b/rivervale/Deputy_Higrin.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {	
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Deputy_Hiltop.pl
+++ b/rivervale/Deputy_Hiltop.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {	
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Deputy_Jeggin.pl
+++ b/rivervale/Deputy_Jeggin.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {	
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Deputy_Kapop.pl
+++ b/rivervale/Deputy_Kapop.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {	
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Deputy_Leeot.pl
+++ b/rivervale/Deputy_Leeot.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {	
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Deputy_Lowmot.pl
+++ b/rivervale/Deputy_Lowmot.pl
@@ -24,5 +24,5 @@ sub EVENT_ITEM {
 		quest::faction(334, -1);	#:: + Dreadguard Outer
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Deputy_Millin.pl
+++ b/rivervale/Deputy_Millin.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {	
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Deputy_Niepo.pl
+++ b/rivervale/Deputy_Niepo.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {	
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Deputy_Olo.pl
+++ b/rivervale/Deputy_Olo.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {	
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Deputy_Percin.pl
+++ b/rivervale/Deputy_Percin.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {	
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Deputy_Pigon.pl
+++ b/rivervale/Deputy_Pigon.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {	
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Deputy_Pittin.pl
+++ b/rivervale/Deputy_Pittin.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {	
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Deputy_Quillto.pl
+++ b/rivervale/Deputy_Quillto.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {	
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Deputy_Raynin.pl
+++ b/rivervale/Deputy_Raynin.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {	
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Deputy_Regno.pl
+++ b/rivervale/Deputy_Regno.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {	
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Deputy_Rollin.pl
+++ b/rivervale/Deputy_Rollin.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {	
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Deputy_Sertlin.pl
+++ b/rivervale/Deputy_Sertlin.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {	
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Deputy_Shelmy.pl
+++ b/rivervale/Deputy_Shelmy.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {	
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Deputy_Tilo.pl
+++ b/rivervale/Deputy_Tilo.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {	
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Deputy_Tizzin.pl
+++ b/rivervale/Deputy_Tizzin.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {	
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Deputy_Tocat.pl
+++ b/rivervale/Deputy_Tocat.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {	
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Deputy_Tonlo.pl
+++ b/rivervale/Deputy_Tonlo.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {	
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Deputy_Zopo.pl
+++ b/rivervale/Deputy_Zopo.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {	
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Fiddy_Bobick.pl
+++ b/rivervale/Fiddy_Bobick.pl
@@ -33,5 +33,5 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Gapeers_Johhanis.pl
+++ b/rivervale/Gapeers_Johhanis.pl
@@ -39,5 +39,5 @@ sub EVENT_ITEM {
 		quest::faction(263,20);		#:: + Guardians of the Vale
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Hendi_Mrubble.pl
+++ b/rivervale/Hendi_Mrubble.pl
@@ -49,5 +49,5 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Hibbs_Rootenpaw.pl
+++ b/rivervale/Hibbs_Rootenpaw.pl
@@ -71,5 +71,5 @@ sub EVENT_ITEM {
 #POP		quest::faction(324, -15);	#:: - Unkempt Druids
 #POP	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Ilscent_Tagglefoot.pl
+++ b/rivervale/Ilscent_Tagglefoot.pl
@@ -14,5 +14,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Kaya_Cloudfoot.pl
+++ b/rivervale/Kaya_Cloudfoot.pl
@@ -46,5 +46,5 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Kevlin_Diggs.pl
+++ b/rivervale/Kevlin_Diggs.pl
@@ -28,5 +28,5 @@ sub EVENT_SIGNAL {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Kizzie_Mintopp.pl
+++ b/rivervale/Kizzie_Mintopp.pl
@@ -37,5 +37,5 @@ sub EVENT_ITEM {
 		quest::exp(500);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Lendel_Deeppockets.pl
+++ b/rivervale/Lendel_Deeppockets.pl
@@ -52,5 +52,5 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Marshal_Anrey.pl
+++ b/rivervale/Marshal_Anrey.pl
@@ -52,5 +52,5 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}		
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Marshal_Ghobber.pl
+++ b/rivervale/Marshal_Ghobber.pl
@@ -51,5 +51,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Marshal_Lanena.pl
+++ b/rivervale/Marshal_Lanena.pl
@@ -92,5 +92,5 @@ sub EVENT_ITEM {
 		}
 	}		
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Mayor_Gubbin.pl
+++ b/rivervale/Mayor_Gubbin.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Meeka_Diggs.pl
+++ b/rivervale/Meeka_Diggs.pl
@@ -18,5 +18,5 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Megosh_Thistlethorn.pl
+++ b/rivervale/Megosh_Thistlethorn.pl
@@ -43,5 +43,5 @@ sub EVENT_ITEM {
 		quest::exp(100);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Reebo_Leafsway.pl
+++ b/rivervale/Reebo_Leafsway.pl
@@ -105,7 +105,7 @@ sub EVENT_ITEM {
 		quest::summonitem(13974);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_WAYPOINT_ARRIVE {

--- a/rivervale/Rueppy_Kutpurse.pl
+++ b/rivervale/Rueppy_Kutpurse.pl
@@ -48,5 +48,5 @@ sub EVENT_ITEM {
 		quest::faction(329, 1);		#:: + Carson McCabe	
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Shakey_Scarecrow.pl
+++ b/rivervale/Shakey_Scarecrow.pl
@@ -27,5 +27,5 @@ sub EVENT_ITEM {
 		quest::faction(324, -1);	#:: - Unkempt Druids
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Sheriff_Roglio.pl
+++ b/rivervale/Sheriff_Roglio.pl
@@ -71,5 +71,5 @@ sub EVENT_ITEM {
 		quest::faction(334, -1); 	#:: - Dreadguard Outer
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Silna_Songsmith.pl
+++ b/rivervale/Silna_Songsmith.pl
@@ -17,5 +17,5 @@ sub EVENT_SAY {
 	
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Thekela_Meepup.pl
+++ b/rivervale/Thekela_Meepup.pl
@@ -6,5 +6,5 @@ sub EVENT_SAY {
 	
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Toelia_Snuckery.pl
+++ b/rivervale/Toelia_Snuckery.pl
@@ -84,5 +84,5 @@ sub EVENT_ITEM {
 		}
 	}	
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/rivervale/Uner_Gnarltrunk.pl
+++ b/rivervale/Uner_Gnarltrunk.pl
@@ -30,5 +30,5 @@ sub EVENT_ITEM {
 		quest::faction(324, -1);	#:: - Unkempt Druids
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/runnyeye/11169.pl
+++ b/runnyeye/11169.pl
@@ -9,7 +9,7 @@ sub EVENT_COMBAT {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/runnyeye/11170.pl
+++ b/runnyeye/11170.pl
@@ -9,7 +9,7 @@ sub EVENT_COMBAT {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/runnyeye/A_Goblin_Rogue.pl
+++ b/runnyeye/A_Goblin_Rogue.pl
@@ -7,7 +7,7 @@ sub EVENT_COMBAT {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/runnyeye/A_Goblin_Warlord.pl
+++ b/runnyeye/A_Goblin_Warlord.pl
@@ -7,7 +7,7 @@ sub EVENT_COMBAT {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/runnyeye/a_Runnyeye_Trustee.pl
+++ b/runnyeye/a_Runnyeye_Trustee.pl
@@ -7,7 +7,7 @@ sub EVENT_COMBAT {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/runnyeye/a_Runnyeye_conscript.pl
+++ b/runnyeye/a_Runnyeye_conscript.pl
@@ -7,7 +7,7 @@ sub EVENT_COMBAT {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/runnyeye/a_goblin_cleric.pl
+++ b/runnyeye/a_goblin_cleric.pl
@@ -7,7 +7,7 @@ sub EVENT_COMBAT {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/runnyeye/a_goblin_mindripper.pl
+++ b/runnyeye/a_goblin_mindripper.pl
@@ -7,7 +7,7 @@ sub EVENT_COMBAT {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/runnyeye/a_goblin_wizard.pl
+++ b/runnyeye/a_goblin_wizard.pl
@@ -7,7 +7,7 @@ sub EVENT_COMBAT {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/runnyeye/a_goblin_worker.pl
+++ b/runnyeye/a_goblin_worker.pl
@@ -7,7 +7,7 @@ sub EVENT_COMBAT {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }
 
 sub EVENT_DEATH_COMPLETE {

--- a/runnyeye/a_sporeling.pl
+++ b/runnyeye/a_sporeling.pl
@@ -19,5 +19,5 @@ sub EVENT_TIMER {
 
 sub EVENT_ITEM {
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/shadowhaven/Mark_Blotter.pl
+++ b/shadowhaven/Mark_Blotter.pl
@@ -17,6 +17,6 @@ sub EVENT_ITEM {
 	}
 	else {
 		quest::say("I have no need for this $name. You can have it back");
-		plugin::returnUnusedItems();
+		plugin::return_items(\%itemcount);
 	}
 }

--- a/shadowhaven/Pietro_Guiccini.pl
+++ b/shadowhaven/Pietro_Guiccini.pl
@@ -17,7 +17,7 @@ sub EVENT_ITEM {
 	}
 	else {
 		quest::say("I have no need for this $name. You can have it back");
-		plugin::returnUnusedItems();
+		plugin::return_items(\%itemcount);
 	}
 }
 

--- a/sharvahl/Alchemist_Hikal.pl
+++ b/sharvahl/Alchemist_Hikal.pl
@@ -17,7 +17,7 @@ sub EVENT_ITEM {
 	}
 	else {
 		quest::say("I have no need for this $name. You can have it back");
-		plugin::returnUnusedItems();
+		plugin::return_items(\%itemcount);
 	}
 }
 

--- a/soltemple/Romar_Sunto.pl
+++ b/soltemple/Romar_Sunto.pl
@@ -55,5 +55,5 @@ sub EVENT_ITEM {
     }
 
     #:: Return unused items
-    plugin::returnUnusedItems();
+    plugin::return_items(\%itemcount);
 }

--- a/soltemple/Solomen.pl
+++ b/soltemple/Solomen.pl
@@ -24,7 +24,7 @@ sub EVENT_ITEM {
     }
 
     # Return unused items
-    plugin::returnUnusedItems();
+    plugin::return_items(\%itemcount);
 }
 
 

--- a/southkarana/#Brother_Hayle.pl
+++ b/southkarana/#Brother_Hayle.pl
@@ -64,5 +64,5 @@ sub EVENT_ITEM {
 		#:: Else eat the items
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/southkarana/Jarlen_Meadowgreen.pl
+++ b/southkarana/Jarlen_Meadowgreen.pl
@@ -26,5 +26,5 @@ sub EVENT_ITEM {
 		quest::ding();
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/southkarana/Shakrn_Meadowgreen.pl
+++ b/southkarana/Shakrn_Meadowgreen.pl
@@ -79,5 +79,5 @@ sub EVENT_ITEM {
 		quest::exp(25000);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/southkarana/Ulan_Meadowgreen.pl
+++ b/southkarana/Ulan_Meadowgreen.pl
@@ -85,5 +85,5 @@ sub EVENT_ITEM {
 		quest::exp(25000);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/southkarana/Vhalen_Nostrolo.pl
+++ b/southkarana/Vhalen_Nostrolo.pl
@@ -54,5 +54,5 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/southkarana/a_hermit.pl
+++ b/southkarana/a_hermit.pl
@@ -60,5 +60,5 @@ sub EVENT_ITEM {
 		quest::exp(1000);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/sro/Ortallius.pl
+++ b/sro/Ortallius.pl
@@ -46,5 +46,5 @@ sub EVENT_ITEM {
 		quest::givecash($cash{copper},$cash{silver},$cash{gold},$cash{platinum});
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/sro/Rathmana_Allin.pl
+++ b/sro/Rathmana_Allin.pl
@@ -43,5 +43,5 @@ sub EVENT_ITEM {
 		quest::exp(1000);
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }

--- a/sro/Smith_Tv-ysa.pl
+++ b/sro/Smith_Tv-ysa.pl
@@ -74,5 +74,5 @@ sub EVENT_ITEM {
 		}
 	}
 	#:: Return unused items
-	plugin::returnUnusedItems();
+	plugin::return_items(\%itemcount);
 }


### PR DESCRIPTION
Replaces all usages of `plugin::returnUnusedItems();` with `plugin::return_items(\%itemcount);`

Also included some fixes for invalid item IDs in `kerraridge` that someone reported while I was doing this.