### PR TITLE
Reduce chances of receiving an Ivandyr's Hoop or Midnight Mallet from Lynuga

### DIFF
--- a/innothule/Lynuga.lua
+++ b/innothule/Lynuga.lua
@@ -13,12 +13,12 @@ function event_trade(e)
 	if(item_lib.check_turn_in(e.trade, {item1 = 10035})) then -- Handin: Ruby
 		e.self:Say("Mmm. Ruby!! Me thank's you! Here take this, me got it off dead someone who try take my collection. Me think's this valuable thing..");
 		local item_random = math.random(100);
-		if item_random < 10 then
+		if item_random < 1 then
 			e.other:SummonItem(10082, 6); -- Ivandyr's Hoop
-		elseif item_random < 50 then
-			e.other:SummonItem(10080); -- Brutechopper
-		else
+		elseif item_random < 5 then
 			e.other:SummonItem(10081, 5); -- Midnight Mallet
+		else
+			e.other:SummonItem(10080); -- Brutechopper
 		end
 		e.other:Ding();
 		e.other:Faction(222,1,0); -- Faction: Broken Skull Clan


### PR DESCRIPTION
For consideration here -- if it were up to me, I would remove this quest completely -- this reduces the chances of receiving either a Midnight Mallet or Ivandyr's Hoop as a reward from Lynuga.

It's still possible to receive them as rewards but it will be much more expensive to acquire them.

These items can be used to either:
1) Remove the need for including a class with slow in your composition (devalues the utility of slow classes)
2) Trivialize encounters by allowing infinite lifetapping

You can see the bags from a player who posted a screenshot from 3 days into the server here as evidence that it is way too cheap right now to acquire these extremely powerful items: 
![image](https://github.com/user-attachments/assets/e9a26570-64b6-4aa8-806e-4989e53401fc)
