### PR TITLE
Spiroc Lord: Spawn Sirran if Guardian is dead

### DIFF
--- a/airplane/The_Spiroc_Lord.lua
+++ b/airplane/The_Spiroc_Lord.lua
@@ -2,7 +2,7 @@ function event_death_complete(e)
 	local instance_id = eq.get_zone_instance_id() or 0;
 	local airplane_sirran_status = tonumber(eq.get_data("airplane-sirran-" .. instance_id)) or 0;
 
-	if not (eq.get_entity_list():IsMobSpawnedByNpcTypeID(71009) or eq.get_entity_list():IsMobSpawnedByNpcTypeID(71020) or eq.get_entity_list():IsMobSpawnedByNpcTypeID(71022)) then
+	if not (eq.get_entity_list():IsMobSpawnedByNpcTypeID(71013)) then -- Don't spawn Sirran if Guardian is still up
 		eq.set_data("airplane-sirran-" .. instance_id, "5", tostring(eq.seconds("24h")));
 		eq.unique_spawn(71058,0,0,955,-570,466,390); -- NPC: Sirran_the_Lunatic
 	end


### PR DESCRIPTION
Before this change, the Spiroc Lord death event was only spawning Sirran if the following NPC IDs were not spawned:

- 71009 (a_spiroc_vanquisher)
- 71020 (a_watchful_guard)
- 71022 (a_watchful_guard)

After this change, the Spiroc Lord death event will spawn Sirran if the following NPC IDs are not spawned:

- 71013 (The_Spiroc_Guardian)