### PR TITLE
Only allow spawning Fleshless Servant if appropriate qglobals are set

### DIFF
--- a/tox/Assistant_T-os.pl
+++ b/tox/Assistant_T-os.pl
@@ -1,8 +1,4 @@
 sub EVENT_SAY {
-  if ($text=~/hail/i) {
-    quest::say("Hmm. You aren't familiar. . .no matter. All is ready. Prepare yourself. Who knows what may happen. . .");
-    quest::spawn2(38173,0,0,1630,2137,-54,270); # NPC: #Fleshless_Servant
-  }
   if (defined $qglobals{tsoma} && $qglobals{tsoma} == 2) {
     if ($text=~/hail/i) {
       quest::say("You're late! Never mind. Prepare yourself. I do not trust these magics T`soma has constructed.");


### PR DESCRIPTION
This should be fixed afterwards to also use a timer like Tolon here:
https://github.com/The-Heroes-Journey-EQEMU/quests/blob/33743b47f43b33b97d14529c142530e906b9dd2a/felwithea/Tolon_Nurbyte.pl#L1-L14

But for now, we don't want this quest to be doable during Classic -- right now this just allows bypassing the entire quest chain.