### PR TITLE
Loosens quest text check for Burning Rapier

### DIFF
--- a/soltemple/Lon_the_Redeemed.pl
+++ b/soltemple/Lon_the_Redeemed.pl
@@ -3,7 +3,7 @@ sub EVENT_SAY {
   if($text=~/Hail/i){
     quest::say("Welcome. friend. I am one of the redeemed. I once walked the path of evil and woe. My talents were those of the House of V'ree of Neriak. I now serve the Burning Prince. Are you a [rogue in need of redemption] also?");
   }
-  if($text=~/i am a rogue in need of redemption/i){
+  if($text=~/rogue in need of redemption/i){
     quest::say("Then so be it. Ro commands you to aid the saved one. Ortallius of the hot sands. He is in need of two gems: the gem of stamina, also known as the gem of passion, and the gem of righteousness. I once owned these gems in my former life. They rest with my old friend, [Conium Darkblade]. Take this note to him and he shall give you the gems which you will then take to Ortallius.  Be off.");
     quest::summonitem(18955); # Item: Sealed Note
   }


### PR DESCRIPTION
The say link that gets generated in the first part here just says `rogue in need of redemption` and there was a player with a language barrier very confused about why that wasn't working.

This loosens the check to match the say link (it'll also still match the original full text) to avoid confusing Frenchmen interested in questing.