### PR TITLE
Fades invulnerability effects when disconnecting from the server

### DIFF
--- a/global/global_player.pl
+++ b/global/global_player.pl
@@ -112,6 +112,11 @@ sub EVENT_CONNECT {
 	}
 }
 
+sub EVENT_DISCONNECT {
+    # Removes invulnerability effects when disconnecting from the server.
+    $client->BuffFadeByEffect(40);
+}
+
 sub EVENT_POPUPRESPONSE {
     plugin::check_tutorial_popup_response($popupid, $client);  
        


### PR DESCRIPTION
This fixes a reported exploit where players are intentionally disconnecting their characters from the server with invulnerability effects applied in order to bypass and trivialize raid content.

SPA 40 is invulnerability.