### PR TITLE
Fixes a couple Monk epic chances to check class / level before eating hand in items.

### DIFF
--- a/airplane/a_presence.lua
+++ b/airplane/a_presence.lua
@@ -7,7 +7,7 @@ end
 
 function event_trade(e)
 	local item_lib = require("items");
-	if((item_lib.check_turn_in(e.trade, {item1 = 1684})) and (e.other:GetLevel() >= 46) and (e.other:HasClass(Class.MONK))) then
+	if((e.other:GetLevel() >= 46) and (e.other:HasClass(Class.MONK)) and (item_lib.check_turn_in(e.trade, {item1 = 1684}))) then
 		e.self:Say("Hahaha! That dolt Eejag fell to the likes of you? Im not surprised. So, I guess this means you are here to challenge me. Normally, I wouldnt waste my time, but since you have defeated my younger brother, I suppose Im obligated.");
 		eq.depop_with_timer();
 		eq.spawn2(71069,0,0,e.self:GetX(),e.self:GetY(),-8,e.self:GetHeading()); -- NPC: Gwan

--- a/erudnext/Tomekeeper_Danl.lua
+++ b/erudnext/Tomekeeper_Danl.lua
@@ -29,7 +29,7 @@ function event_trade(e)
 	local item_lib = require("items");
 	local qglobals = eq.get_qglobals(e.other);
 	
-	if(item_lib.check_turn_in(e.trade, {item1 = 18195}) and e.other:GetLevel() >= 46 and e.other:HasClass(Class.MONK)) then
+	if(e.other:GetLevel() >= 46 and e.other:HasClass(Class.MONK) and item_lib.check_turn_in(e.trade, {item1 = 18195})) then
 		e.self:Emote("gasps at the sight of the rare book. 'This is a great find indeed! I can only imagine who you had to.. persuade to give you the book. Our library would be very interested in acquiring this and I am prepared to give you this referral that marks you as a friend of the library. If only [" .. eq.say_link("Lheao") .. "] could see this.'");
 		e.other:SummonItem(1682); -- Danl's Reference
 		e.other:Ding();

--- a/lakerathe/Deep.pl
+++ b/lakerathe/Deep.pl
@@ -6,7 +6,7 @@ sub EVENT_SAY {
 }
 
 sub EVENT_ITEM {
-  if((plugin::check_handin(\%itemcount, 1686 => 1)) && ($ulevel >= 46) && (plugin::HasClassName($client, "Monk"))) { #Trunt's Head
+  if(($ulevel >= 46) && (plugin::HasClassName($client, "Monk")) && (plugin::check_handin(\%itemcount, 1686 => 1))) { #Trunt's Head
     quest::emote("slowly opens her eyes and looks up at you. She stares at you a long while and then closes her eyes and lowers her head again.");
     quest::say("Very well, $name, if you wish death so greatly, we will be happy to oblige. My master projects part of himself in the wilder lands known as the Overthere. He has granted you an audience. Find him and show him the head of our earth brother. At that point, we will discuss how we will end your life.");
     quest::summonitem(1686); #Trunt's Head


### PR DESCRIPTION
We've had a few people report that they're not having items returned when working on the Monk epic with the wrong class / at the wrong level.

This _should_ fix it so that they'll get their items back instead of having them eaten.