### PR TITLE
[Bug Fix] HasClass Fixes and soft disabling lua quests with 1.5 mobs

### DIFF
--- a/butcher/Gridbar_Galund.lua
+++ b/butcher/Gridbar_Galund.lua
@@ -1,37 +1,45 @@
 --butcher/Gridbar_Galund.lua NPCID 68234
 --Warrior Epic 1.5
 -- items: 60312, 60313, 60314, 60315, 60316, 15433, 60311, 60318, 60319, 60320
+
+local epic_disabled = true; -- Disabling for omens (epics) cannot reference perl expansion vars from lua.
+
 function event_say(e)
 	local qglobals = eq.get_qglobals(e.other);
-	if(e.message:findi("hail") and qglobals["warrior_epic"] >= "11") then
-		e.self:Say("Hiya there. Oh me oh my, never mind. Huh? What can I do for ya? Er... wow, look at that bright... huh? I'm here! Hi! Are you looking for Gridbar? I think he's around here somewhere...");
-	elseif(e.message:findi("Korbuk sent me") and qglobals["warrior_epic"] >= "11") then
-		e.self:Say("Ooh, Korbuk. Big and important, yes. Gridbar should know what Korbuk wants. You say your name is Korbuk? Or did you say you were Gridbar? Huh? Who are you? Right, Korbuk. Did you bring the stones?");
-	elseif(e.message:findi("gemming tool") and qglobals["warrior_epic"] >= "13") then
-		e.self:Say("Yes, yes. Gemming tool. Very strong... huh? Korbuk wants a cookie? Where's Gridbar? Gridbar who? I know I'm a horse, so what? Huh? Right, tool. Need a flask of water... huh? Two high quality metal bits. Where's the beef? One gemming mold. Cook them in a forge, you got yourself a... what? Tool, gemming tool.");
-	elseif(e.message:findi("spell called fire") and qglobals["warrior_epic"] >= "13") then
-		e.self:Say("Can buy it from a... what? Wow! Look at the stars! What stars? Where's Korbuk? Who are you?! Buy from a shop. Someone has it. Not me. Maybe Gridbar.");	
+
+	if not epic_disabled then
+		if e.message:findi("hail") and qglobals["warrior_epic"] ~= nil and qglobals["warrior_epic"] >= "11" then
+			e.self:Say("Hiya there. Oh me oh my, never mind. Huh? What can I do for ya? Er... wow, look at that bright... huh? I'm here! Hi! Are you looking for Gridbar? I think he's around here somewhere...");
+		elseif e.message:findi("Korbuk sent me") and qglobals["warrior_epic"] >= "11" then
+			e.self:Say("Ooh, Korbuk. Big and important, yes. Gridbar should know what Korbuk wants. You say your name is Korbuk? Or did you say you were Gridbar? Huh? Who are you? Right, Korbuk. Did you bring the stones?");
+		elseif e.message:findi("gemming tool") and qglobals["warrior_epic"] >= "13" then
+			e.self:Say("Yes, yes. Gemming tool. Very strong... huh? Korbuk wants a cookie? Where's Gridbar? Gridbar who? I know I'm a horse, so what? Huh? Right, tool. Need a flask of water... huh? Two high quality metal bits. Where's the beef? One gemming mold. Cook them in a forge, you got yourself a... what? Tool, gemming tool.");
+		elseif e.message:findi("spell called fire") and qglobals["warrior_epic"] >= "13" then
+			e.self:Say("Can buy it from a... what? Wow! Look at the stars! What stars? Where's Korbuk? Who are you?! Buy from a shop. Someone has it. Not me. Maybe Gridbar.");	
+		end
+	else
+		e.self:Say("Go away, I am busy.");
 	end
 end
 
 function event_trade(e)
 	local item_lib = require("items");
 	local qglobals = eq.get_qglobals(e.other);
-	if qglobals["warrior_epic"] ~= nil and qglobals["warrior_epic"] >= "11" and item_lib.check_turn_in(e.trade, {item1 = 60312, item2 = 60313, item3 = 60314, item4 = 60315}) then --4x Stone of Eternal Power
-		e.self:Say("Ah... huh? Oh, Gridbar says he needs a [" .. eq.say_link("gemming tool") .. "]. Who? What do you want? Something about Korbuk? Where's Gridbar? He says you need a [" .. eq.say_link("spell called Fire") .. "]. Huh? Gridbar who? No cookies for me now, thanks. Huh?");
-		eq.set_global("warrior_epic","12",5,"F");
-	end
-	if qglobals["warrior_epic"] ~= nil and qglobals["warrior_epic"] >= "12" and item_lib.check_turn_in(e.trade, {item1 = 60316, item2 = 15433}) then --Gemming Tool and Spell:Fire
-		e.self:Say("Oh, a hammer! No? Who are you? Where's Gridbar? I need a bottle of milk! No you don't. Gridbar says to eat some bread. Why? Huh? Give Gridbar the receptacle. What? The eye sockets! Give him the socket piece!");
-		eq.set_global("warrior_epic","13",5,"F");
-	end
-	if qglobals["warrior_epic"] ~= nil and qglobals["warrior_epic"] >= "13" and item_lib.check_turn_in(e.trade, {item1 = 60311}) then --Glistening Hilt
-		e.self:Say("Ooh, pretty. Huh? Gridbar likes it. Not me though, I think it's too bright. Who are you? What? Fine, I need some time with this. Gridbar does, not me. Who? He'll work on it, but I need you to... no wait, Gridbar needs you to do something for him. For me. For who? My sister is in Shadowhaven and needs a keg stamp. Give this to her for her brother. Who? Gridbar. That's me? Why?");
-		e.other:SummonItem(60318); --Carved Keg Stamp
-	end
-	if qglobals["warrior_epic"] ~= nil and qglobals["warrior_epic"] >= "13" and item_lib.check_turn_in(e.trade, {item1 = 60319}) then --Tube of Setting Solution
-		e.self:Say("Nice, just what Gridbar needed. I needed. No he didn't. I want a sandwich. Gnome sandwich? Which sandwich is which? Aha! Genius! Who? This helps me finish the gem setting. Good good. Here's your socket piece. Gridbar likes it. Huh?");
-		e.other:SummonItem(60320) --Hilt of Eternal Power
+
+	if not epic_disabled then
+		if qglobals["warrior_epic"] ~= nil and qglobals["warrior_epic"] >= "11" and item_lib.check_turn_in(e.trade, {item1 = 60312, item2 = 60313, item3 = 60314, item4 = 60315}) then -- Item: Stone of Eternal Power x4
+			e.self:Say("Ah... huh? Oh, Gridbar says he needs a [" .. eq.say_link("gemming tool") .. "]. Who? What do you want? Something about Korbuk? Where's Gridbar? He says you need a [" .. eq.say_link("spell called Fire") .. "]. Huh? Gridbar who? No cookies for me now, thanks. Huh?");
+			eq.set_global("warrior_epic","12",5,"F");
+		elseif qglobals["warrior_epic"] ~= nil and qglobals["warrior_epic"] >= "12" and item_lib.check_turn_in(e.trade, {item1 = 60316, item2 = 15433}) then -- Item: Gemming Tool and Spell:Fire
+			e.self:Say("Oh, a hammer! No? Who are you? Where's Gridbar? I need a bottle of milk! No you don't. Gridbar says to eat some bread. Why? Huh? Give Gridbar the receptacle. What? The eye sockets! Give him the socket piece!");
+			eq.set_global("warrior_epic","13",5,"F");
+		elseif qglobals["warrior_epic"] ~= nil and qglobals["warrior_epic"] >= "13" and item_lib.check_turn_in(e.trade, {item1 = 60311}) then -- Item: Glistening Hilt
+			e.self:Say("Ooh, pretty. Huh? Gridbar likes it. Not me though, I think it's too bright. Who are you? What? Fine, I need some time with this. Gridbar does, not me. Who? He'll work on it, but I need you to... no wait, Gridbar needs you to do something for him. For me. For who? My sister is in Shadowhaven and needs a keg stamp. Give this to her for her brother. Who? Gridbar. That's me? Why?");
+			e.other:SummonItem(60318); -- Item: Carved Keg Stamp
+		elseif qglobals["warrior_epic"] ~= nil and qglobals["warrior_epic"] >= "13" and item_lib.check_turn_in(e.trade, {item1 = 60319}) then -- Item: Tube of Setting Solution
+			e.self:Say("Nice, just what Gridbar needed. I needed. No he didn't. I want a sandwich. Gnome sandwich? Which sandwich is which? Aha! Genius! Who? This helps me finish the gem setting. Good good. Here's your socket piece. Gridbar likes it. Huh?");
+			e.other:SummonItem(60320) -- Item: Hilt of Eternal Power
+		end
 	end
 	item_lib.return_items(e.self, e.other, e.trade);
 end

--- a/cobaltscar/Yoppa_Greenthumb.lua
+++ b/cobaltscar/Yoppa_Greenthumb.lua
@@ -1,12 +1,18 @@
 --cobaltscar/Yoppa_Greenthumb.lua NPCID 117088
 --Shaman Epic 1.5
+
+local epic_disabled = true; -- Disabling for omens (epics) cannot reference perl expansion vars from lua.
+
 function event_say(e)
 	local qglobals = eq.get_qglobals(e.other);
-	if(e.message:findi("elder spirit sent me") and qglobals["shaman_epic"] == "1") then
-		e.self:Say("Huh? Oh. Me see you help. Poor spirit. Me hope it okay. Only saw few days ago and it seem sad and sick. We make it better! Me hope yous okay wit' breathin' under here. Me be waiting for dat pesky fish to come back wit' my bark dat I got down here. You can help. In fact, you do it. He big nasty shark and me tired. If you wait, he come back for more. It probably still sniff me blood from dat last bite he took. You keep and take to spirit . . . Look out, dere it is and it got friends!");
-		eq.spawn2(117091,0,0,1048,353,-39,256) --Gnashing_Killer_Shark
-		eq.spawn2(117089,0,0,1038,353,-39,256) --Darting_Shark
-		eq.spawn2(117090,0,0,1058,353,-39,256) --Feeder_Shark
+
+	if not epic_disabled then
+		if e.message:findi("elder spirit sent me") and qglobals["shaman_epic"] ~= nil and qglobals["shaman_epic"] == "1" then
+			e.self:Say("Huh? Oh. Me see you help. Poor spirit. Me hope it okay. Only saw few days ago and it seem sad and sick. We make it better! Me hope yous okay wit' breathin' under here. Me be waiting for dat pesky fish to come back wit' my bark dat I got down here. You can help. In fact, you do it. He big nasty shark and me tired. If you wait, he come back for more. It probably still sniff me blood from dat last bite he took. You keep and take to spirit . . . Look out, dere it is and it got friends!");
+			eq.spawn2(117091,0,0,1048,353,-39,256) -- NPC: Gnashing_Killer_Shark
+			eq.spawn2(117089,0,0,1038,353,-39,256) -- NPC: Darting_Shark
+			eq.spawn2(117090,0,0,1058,353,-39,256) -- NPC: Feeder_Shark
+		end
 	end
 end
 
@@ -14,5 +20,3 @@ function event_trade(e)
 	local item_lib = require("items");
 	item_lib.return_items(e.self, e.other, e.trade);
 end
-	
-	

--- a/dulak/Quigli.lua
+++ b/dulak/Quigli.lua
@@ -1,8 +1,8 @@
 -- Monk Epic 1.5
-local disabled = true; -- Disabling for omens (epics) cannot reference perl expansion vars from lua.
+local epic_disabled = true; -- Disabling for omens (epics) cannot reference perl expansion vars from lua.
 
 function event_say(e)
-	if disabled then
+	if not epic_disabled then
 		if e.other:HasClass(Class.MONK) then
 			local data_bucket = ("Epic-Monk-"..e.other:CharacterID());
 			if eq.get_data(data_bucket) ~= "" then -- Has Started
@@ -10,7 +10,7 @@ function event_say(e)
 				s = eq.split(temp, ',');
 
 				local epic_pre_onefive	= tonumber(s[1]);
-				local epic_onefive		= tonumber(s[2]);		
+				local epic_onefive		= tonumber(s[2]);
 				local epic_two			= tonumber(s[3]);
 				local epic_twofive		= tonumber(s[4]);
 

--- a/eastkarana/player.lua
+++ b/eastkarana/player.lua
@@ -1,10 +1,12 @@
 -- BeginFile: eastkarana\player.pl
 -- Quest file for East Karana: Paladin message during Necromancer Epic 1.5 (Soulwhisper)
 
+local epic_disabled = true; -- Disabling for omens (epics) cannot reference perl expansion vars from lua.
+
 function event_loot(e)
-	if(e.item:GetID() == 11430 and e.self:HasItem(26896) == true and e.self:HasItem(14344) == true and e.self:HasItem(22892) == true) then -- All 4 Paladin Heads
-		e.self:Message(15, "With his last breath, the paladin says, 'You are too late. The last paladin has fled to Natimbi with the staff and is on his way to destroy it!'");
+	if not epic_disabled then
+		if e.item:GetID() == 11430 and e.self:HasItem(26896) and e.self:HasItem(14344) and e.self:HasItem(22892) then -- All 4 Paladin Heads
+			e.self:Message(15, "With his last breath, the paladin says, 'You are too late. The last paladin has fled to Natimbi with the staff and is on his way to destroy it!'");
+		end
 	end
 end
-
--- EndFile: eastkarana\player.pl

--- a/everfrost/#Kimber_Whitefoot.lua
+++ b/everfrost/#Kimber_Whitefoot.lua
@@ -1,29 +1,38 @@
 --everfrost/Kimber_Whitefoot.lua NPCID 30104
 --Warrior Epic 1.5
 -- items: 60306, 60305
+
+local epic_disabled = true; -- Disabling for omens (epics) cannot reference perl expansion vars from lua.
+
 function event_say(e)
 	local qglobals = eq.get_qglobals(e.other);
-	if(e.message:findi("hail") and qglobals["warrior_epic"] ~= nil and qglobals["warrior_epic"] >= "4") then
-		e.self:Say("Yes, yes, you again. I had a chance to examine the vial you gave me. Quite an interesting substance, I must say. Scary though. Where did you say you found it? Never mind, it's not important. I made a potion out of the vial, but I can feel an evil presence within. I want to be rid of it, so you can have it back. Please don't come to me with anything like that again. I'm really not into dealing with spirits of such heinous design. Good luck.");
-		e.other:SummonItem(60306); --Potion of Blackfall Spirit
+
+	if not epic_disabled then
+		if e.message:findi("hail") and qglobals["warrior_epic"] ~= nil and qglobals["warrior_epic"] >= "4" then
+			e.self:Say("Yes, yes, you again. I had a chance to examine the vial you gave me. Quite an interesting substance, I must say. Scary though. Where did you say you found it? Never mind, it's not important. I made a potion out of the vial, but I can feel an evil presence within. I want to be rid of it, so you can have it back. Please don't come to me with anything like that again. I'm really not into dealing with spirits of such heinous design. Good luck.");
+			e.other:SummonItem(60306); -- Item: Potion of Blackfall Spirit
+		end
 	end
 end
 
 function event_trade(e)
 	local item_lib = require("items");
 	local qglobals = eq.get_qglobals(e.other);
-	if(qglobals["warrior_epic"] ~= nil and qglobals["warrior_epic"] >= "3" and item_lib.check_turn_in(e.trade, {item1 = 60305})) then --Sealed Vial of Blackfall Blood (from korbuk)
-		e.self:Say("Great, wait out here for a while. I've got to make a trip into the frozen mountain of Permafrost, but I'll be out some time this evening. I should have enough time on my trek to examine the vial. I'll be back soon!");
-		if(qglobals["warrior_epic"] < "4") then
-			eq.set_global("warrior_epic","4",5,"F");
+
+	if not epic_disabled then
+		if qglobals["warrior_epic"] ~= nil and qglobals["warrior_epic"] >= "3" and item_lib.check_turn_in(e.trade, {item1 = 60305}) then -- Item: Sealed Vial of Blackfall Blood (from korbuk)
+			e.self:Say("Great, wait out here for a while. I've got to make a trip into the frozen mountain of Permafrost, but I'll be out some time this evening. I should have enough time on my trek to examine the vial. I'll be back soon!");
+			if qglobals["warrior_epic"] < "4" then
+				eq.set_global("warrior_epic","4",5,"F");
+			end
+			eq.depop_with_timer();
 		end
-		eq.depop_with_timer();
 	end
 	item_lib.return_items(e.self, e.other, e.trade);
 end
-	
+
 function event_waypoint_arrive(e)
-	if(e.wp == 9) then
+	if e.wp == 9 then
 		eq.depop_with_timer();
 	end
 end

--- a/everfrost/Kimber_Whitefoot.lua
+++ b/everfrost/Kimber_Whitefoot.lua
@@ -1,29 +1,38 @@
 --everfrost/Kimber_Whitefoot.lua NPCID 30104
 --Warrior Epic 1.5
 -- items: 60306, 60305
+
+local epic_disabled = true; -- Disabling for omens (epics) cannot reference perl expansion vars from lua.
+
 function event_say(e)
 	local qglobals = eq.get_qglobals(e.other);
-	if(e.message:findi("hail") and qglobals["warrior_epic"] ~= nil and qglobals["warrior_epic"] >= "4") then
-		e.self:Say("Yes, yes, you again. I had a chance to examine the vial you gave me. Quite an interesting substance, I must say. Scary though. Where did you say you found it? Never mind, it's not important. I made a potion out of the vial, but I can feel an evil presence within. I want to be rid of it, so you can have it back. Please don't come to me with anything like that again. I'm really not into dealing with spirits of such heinous design. Good luck.");
-		e.other:SummonItem(60306); --Potion of Blackfall Spirit
+
+	if not epic_disabled then
+		if e.message:findi("hail") and qglobals["warrior_epic"] ~= nil and qglobals["warrior_epic"] >= "4" then
+			e.self:Say("Yes, yes, you again. I had a chance to examine the vial you gave me. Quite an interesting substance, I must say. Scary though. Where did you say you found it? Never mind, it's not important. I made a potion out of the vial, but I can feel an evil presence within. I want to be rid of it, so you can have it back. Please don't come to me with anything like that again. I'm really not into dealing with spirits of such heinous design. Good luck.");
+			e.other:SummonItem(60306); -- Item: Potion of Blackfall Spirit
+		end
 	end
 end
 
 function event_trade(e)
 	local item_lib = require("items");
 	local qglobals = eq.get_qglobals(e.other);
-	if(qglobals["warrior_epic"] ~= nil and qglobals["warrior_epic"] >= "3" and item_lib.check_turn_in(e.trade, {item1 = 60305})) then --Sealed Vial of Blackfall Blood (from korbuk)
-		e.self:Say("Great, wait out here for a while. I've got to make a trip into the frozen mountain of Permafrost, but I'll be out some time this evening. I should have enough time on my trek to examine the vial. I'll be back soon!");
-		if(qglobals["warrior_epic"] < "4") then
-			eq.set_global("warrior_epic","4",5,"F");
+
+	if not epic_disabled then
+		if qglobals["warrior_epic"] ~= nil and qglobals["warrior_epic"] >= "3" and item_lib.check_turn_in(e.trade, {item1 = 60305}) then -- Item: Sealed Vial of Blackfall Blood (from korbuk)
+			e.self:Say("Great, wait out here for a while. I've got to make a trip into the frozen mountain of Permafrost, but I'll be out some time this evening. I should have enough time on my trek to examine the vial. I'll be back soon!");
+			if qglobals["warrior_epic"] < "4" then
+				eq.set_global("warrior_epic","4",5,"F");
+			end
+			eq.depop_with_timer();
 		end
-		eq.depop_with_timer();
 	end
 	item_lib.return_items(e.self, e.other, e.trade);
 end
-	
+
 function event_waypoint_arrive(e)
-	if(e.wp == 9) then
+	if e.wp == 9 then
 		eq.depop_with_timer();
 	end
 end

--- a/firiona/Corfia_Nultethen.lua
+++ b/firiona/Corfia_Nultethen.lua
@@ -1,55 +1,61 @@
 --firiona/Corfia_Nultethen.lua NPCID 84318
 --Warrior Epic 1.5
 -- items: 16503, 60309, 60307, 60310, 60311
+
+local epic_disabled = true; -- Disabling for omens (epics) cannot reference perl expansion vars from lua.
+
 function event_say(e)
-	if(e.language == 12) then
+	if e.language == 12 then
 		local qglobals = eq.get_qglobals(e.other);
-		if(e.message:findi("hail") and e.other:GetLanguageSkill(12) >= 100) then	
+		if e.message:findi("hail") and e.other:GetLanguageSkill(12) >= 100 then
 			e.self:Say("Yes, what can I do for you?");
-		elseif(e.message:findi("Korbuk sent me") and qglobals["warrior_epic"] >= "6") then
-			e.self:Say("That's really quite fascinating, but doesn't mean a whole lot to me. I really don't care who sent you. You don't have any [items of value] to me, so be gone.");
-		elseif(e.message:findi("items of value") and qglobals["warrior_epic"] >= "6") then
-			e.self:Say("Well... if you must know, I'm in need of a platinum bar so I can continue my work.");
-		elseif(e.message:findi("Nocturnal Mask of Acuity") and qglobals["warrior_epic"] >= "7") then	
-			e.self:Say("The mask is an interesting blend that will allow me to see much better in the darkness, where we elves can sometimes have trouble. To make it, you'll need an enchanted electrum bar and two darkened star rose quartz. Show it to me when you've made it.");
-		elseif(e.message:findi("favor") and qglobals["warrior_epic"] >= "9") then
-			e.self:Say("Yes indeed. I've been spending such a long time in the city lately that I just haven't had time to go on the expeditions I used to. Such a strong and capable person as you would be able to fill in nicely. You see, I've always wanted to explore the depths of [Veksar] to find out what treasures are hidden down there.");
-		elseif(e.message:findi("veksar") and qglobals["warrior_epic"] >= "9") then	
-			e.self:Say("I've heard plenty of stories and read a number of tales about artifacts of great wealth down there. In fact, I was able to get a sneak peek into the ruins some time ago, but not enough to find what I needed. One of the most interesting things I've read about is a tome of bones made for a necromancer named [Galuk Drek].");
-		elseif(e.message:findi("Galuk Drek") and qglobals["warrior_epic"] >= "9") then	
-			e.self:Say("Oh, he was a beast, to be sure. One of the nastier creatures down there, but also one of the most brilliant, from what I've read. Drek kept the tome full of information on various crafts, and one of them just happens to be jewelcraft. I'd love to set my hands on that tome, and if you can find it, I'd be more than willing to finish up this hilt for you in no time!");
-			eq.set_global("warrior_epic_veksar","1",5,"F"); --flagged to spawn Galuk Drek in Veksar
-		end	
+		end
+		
+		if not epic_disabled and qglobals["warrior_epic"] ~= nil then
+			if e.message:findi("Korbuk sent me") and qglobals["warrior_epic"] >= "6" then
+				e.self:Say("That's really quite fascinating, but doesn't mean a whole lot to me. I really don't care who sent you. You don't have any [items of value] to me, so be gone.");
+			elseif e.message:findi("items of value") and qglobals["warrior_epic"] >= "6" then
+				e.self:Say("Well... if you must know, I'm in need of a platinum bar so I can continue my work.");
+			elseif e.message:findi("Nocturnal Mask of Acuity") and qglobals["warrior_epic"] >= "7" then
+				e.self:Say("The mask is an interesting blend that will allow me to see much better in the darkness, where we elves can sometimes have trouble. To make it, you'll need an enchanted electrum bar and two darkened star rose quartz. Show it to me when you've made it.");
+			elseif e.message:findi("favor") and qglobals["warrior_epic"] >= "9" then
+				e.self:Say("Yes indeed. I've been spending such a long time in the city lately that I just haven't had time to go on the expeditions I used to. Such a strong and capable person as you would be able to fill in nicely. You see, I've always wanted to explore the depths of [Veksar] to find out what treasures are hidden down there.");
+			elseif e.message:findi("veksar") and qglobals["warrior_epic"] >= "9" then
+				e.self:Say("I've heard plenty of stories and read a number of tales about artifacts of great wealth down there. In fact, I was able to get a sneak peek into the ruins some time ago, but not enough to find what I needed. One of the most interesting things I've read about is a tome of bones made for a necromancer named [Galuk Drek].");
+			elseif e.message:findi("Galuk Drek") and qglobals["warrior_epic"] >= "9" then
+				e.self:Say("Oh, he was a beast, to be sure. One of the nastier creatures down there, but also one of the most brilliant, from what I've read. Drek kept the tome full of information on various crafts, and one of them just happens to be jewelcraft. I'd love to set my hands on that tome, and if you can find it, I'd be more than willing to finish up this hilt for you in no time!");
+				eq.set_global("warrior_epic_veksar","1",5,"F"); -- flagged to spawn Galuk Drek in Veksar
+			end	
+		end
 	end
 end
 
 function event_trade(e)
 	local item_lib = require("items");
 	local qglobals = eq.get_qglobals(e.other);
-	if(qglobals["warrior_epic"] ~= nil and qglobals["warrior_epic"] >= "6" and item_lib.check_turn_in(e.trade, {item1 = 16503})) then --Platinum Bar (vendor sold)
-		e.self:Say("Aha, something worth my time. But I've changed my mind. I'd prefer if you made me something that really showed me how interested you are in my craft. We jewelers are hard to please, but if you can present me with a [Nocturnal Mask of Acuity], I'd be more than willing to at least speak with you.");
-		if(qglobals["warrior_epic"] < "7") then
-			eq.set_global("warrior_epic","7",5,"F");
+
+	if not epic_disabled then
+		if qglobals["warrior_epic"] ~= nil and qglobals["warrior_epic"] >= "6" and item_lib.check_turn_in(e.trade, {item1 = 16503}) then -- Item: Platinum Bar (vendor sold)
+			e.self:Say("Aha, something worth my time. But I've changed my mind. I'd prefer if you made me something that really showed me how interested you are in my craft. We jewelers are hard to please, but if you can present me with a [Nocturnal Mask of Acuity], I'd be more than willing to at least speak with you.");
+			if qglobals["warrior_epic"] < "7" then
+				eq.set_global("warrior_epic","7",5,"F");
+			end
+		elseif qglobals["warrior_epic"] ~= nil and qglobals["warrior_epic"] >= "7" and item_lib.check_turn_in(e.trade, {item1 = 60309}) then -- Item: Nocturnal Mask of Acuity (crafted)
+			e.self:Say("Well done, but not great. It doesn't have the sight properties I'd hoped for, but it looks nice nonetheless. I half thought you'd shy away from creating such a lustrous piece of jeweled metal. You didn't though, so now you have my attention. What is it that you have for me to look at?");
+			if qglobals["warrior_epic"] < "8" then
+				eq.set_global("warrior_epic","8",5,"F");
+			end
+		elseif qglobals["warrior_epic"] ~= nil and qglobals["warrior_epic"] >= "8" and item_lib.check_turn_in(e.trade, {item1 = 60307}) then -- Item: Decrepit Hilt
+			e.self:Say("What a filthy piece of rubbish! This will need a good deal of work, I can guarantee you that. I have a small repository of supplies that I only rarely use, and one of the things I have is a cleaning solution. I don't often use it for most mundane things, but I'd be willing to part with some if you're willing to do me a [favor].");
+			if qglobals["warrior_epic"] < "9" then
+				eq.set_global("warrior_epic","9",5,"F");
+			end
+		elseif qglobals["warrior_epic"] ~= nil and qglobals["warrior_epic"] == "9" and item_lib.check_turn_in(e.trade, {item1 = 60310}) then -- Item: Skeletal Tome of Galuk Drek (drops from Decaying Lord Galuk Drek in veksar)
+			e.self:Say("Wow... I hadn't expected you'd be so quick about things. This is the most amazing find ever, you've helped me more then you could ever know! Thanks so much! I made sure to polish that hilt up for you as best as I could, and even added a few touches to it that'll make even stronger that it was before.");
+			e.other:SummonItem(60311); -- Item: Glistening Hilt
+			eq.delete_global("warrior_epic_veksar");
 		end
-	end
-	if(qglobals["warrior_epic"] ~= nil and qglobals["warrior_epic"] >= "7" and item_lib.check_turn_in(e.trade, {item1 = 60309})) then --Nocturnal Mask of Acuity (crafted)
-		e.self:Say("Well done, but not great. It doesn't have the sight properties I'd hoped for, but it looks nice nonetheless. I half thought you'd shy away from creating such a lustrous piece of jeweled metal. You didn't though, so now you have my attention. What is it that you have for me to look at?");
-		if(qglobals["warrior_epic"] < "8") then
-			eq.set_global("warrior_epic","8",5,"F");
-		end
-	end
-	if(qglobals["warrior_epic"] ~= nil and qglobals["warrior_epic"] >= "8" and item_lib.check_turn_in(e.trade, {item1 = 60307})) then --Decrepit Hilt
-		e.self:Say("What a filthy piece of rubbish! This will need a good deal of work, I can guarantee you that. I have a small repository of supplies that I only rarely use, and one of the things I have is a cleaning solution. I don't often use it for most mundane things, but I'd be willing to part with some if you're willing to do me a [favor].");
-		if(qglobals["warrior_epic"] < "9") then
-			eq.set_global("warrior_epic","9",5,"F");
-		end
-	end
-	if(qglobals["warrior_epic"] ~= nil and qglobals["warrior_epic"] == "9" and item_lib.check_turn_in(e.trade, {item1 = 60310})) then --Skeletal Tome of Galuk Drek (drops from Decaying Lord Galuk Drek in veksar)
-		e.self:Say("Wow... I hadn't expected you'd be so quick about things. This is the most amazing find ever, you've helped me more then you could ever know! Thanks so much! I made sure to polish that hilt up for you as best as I could, and even added a few touches to it that'll make even stronger that it was before.");
-		e.other:SummonItem(60311); --Glistening Hilt
-		eq.delete_global("warrior_epic_veksar");
 	end
 	item_lib.return_items(e.self, e.other, e.trade);
 end
-	
-	
+

--- a/freportn/#Elder_Spirit_of_Enlightenment.lua
+++ b/freportn/#Elder_Spirit_of_Enlightenment.lua
@@ -5,154 +5,164 @@ local count = 0;
 local char_id = 0;
 local client;
 
+local epic_disabled = true; -- Disabling for omens (epics) cannot reference perl expansion vars from lua.
+
 function event_say(e)
 	local qglobals = eq.get_qglobals(e.other);
-	if(e.other:HasClass(Class.SHAMAN)) then
-		if(e.other:HasItem(10651) or e.other:HasItem(36223) or qglobals["shaman_pre"] == "3") then --Have the Spear of Fate (two in db 36223 or 10651) or finished prequest
-			if(e.message:findi("hail")) then
-				e.self:Emote("eyes you with an ageless wisdom.");
-				e.self:Say("Ah, your spirit shines brightly. Should I know you?");
-			elseif(e.message:findi("shaman")) then
-				e.self:Say("Ah, yes. You are not only a shaman, but one who has passed the tests of the heyokah. There are many problems that face us now and I grow weaker by the day. If you feel you are ready to bear a great burden and help all of those like us, including the immortals that charge our essence and consciousness, say [" .. eq.say_link("it is so") .. "].");
-				if(qglobals["shaman_epic"] == nil) then
-					eq.set_global("shaman_epic","1",5,"F"); --Flagged to start epic
+
+	if not epic_disabled then
+		if(e.other:HasClass(Class.SHAMAN)) then
+			if(e.other:HasItem(10651) or e.other:HasItem(36223) or qglobals["shaman_pre"] == "3") then --Have the Spear of Fate (two in db 36223 or 10651) or finished prequest
+				if(e.message:findi("hail")) then
+					e.self:Emote("eyes you with an ageless wisdom.");
+					e.self:Say("Ah, your spirit shines brightly. Should I know you?");
+				elseif(e.message:findi("shaman")) then
+					e.self:Say("Ah, yes. You are not only a shaman, but one who has passed the tests of the heyokah. There are many problems that face us now and I grow weaker by the day. If you feel you are ready to bear a great burden and help all of those like us, including the immortals that charge our essence and consciousness, say [" .. eq.say_link("it is so") .. "].");
+					if(qglobals["shaman_epic"] == nil) then
+						eq.set_global("shaman_epic","1",5,"F"); --Flagged to start epic
+					end
 				end
+			elseif(e.message:findi("hail") and e.other:HasItem(57400)) then
+				e.self:Say("Should you choose to continue your journey, tell me that you are [" .. eq.say_link("prepared to carry on") .. "] and save the spirits.");
+			else --Dont have the Spear of Fate and haven't completed Prequest
+				if(e.message:findi("hail")) then
+					e.self:Say("It appears you are not yet ready for the great tasks that I require to be done. There are others lesser than me that can guide you and prepare you to walk a greater path should you choose. You should seek them out. You can perhaps seek knowledge from your elders and peers.");
+					if(qglobals["shaman_pre"] == nil) then
+						eq.set_global("shaman_pre","1",5,"F"); --Flagged to start Prequest
+					end
+				end	
 			end
-		elseif(e.message:findi("hail") and e.other:HasItem(57400)) then
-			e.self:Say("Should you choose to continue your journey, tell me that you are [" .. eq.say_link("prepared to carry on") .. "] and save the spirits.");
-		else --Dont have the Spear of Fate and haven't completed Prequest
-			if(e.message:findi("hail")) then
-				e.self:Say("It appears you are not yet ready for the great tasks that I require to be done. There are others lesser than me that can guide you and prepare you to walk a greater path should you choose. You should seek them out. You can perhaps seek knowledge from your elders and peers.");
-				if(qglobals["shaman_pre"] == nil) then
-					eq.set_global("shaman_pre","1",5,"F"); --Flagged to start Prequest
+			if(e.message:findi("it is so") and qglobals["shaman_epic"] == "1") then
+				e.self:Say("To have you here, believing in us and our existence does give me warmth, but my length of time here and others like me may be at an end. The spirits are troubled and a darkness washes through our existence that we seem helpless to prevent. That is why I talk to you now -- to help us. Without the help of mortals, we may [" .. eq.say_link("blow away") .. "] with the winds.");	
+			elseif(e.message:findi("blow away") and qglobals["shaman_epic"] == "1") then
+				e.self:Say("You have heard of the darkness in Taelosia that came from another place. You may have even seen the world that is overshadowed by the dark influence of Discord. That seeping ill that is not touchable by claw or paw has wormed its way into the [" .. eq.say_link("streams of the spirit world") .. "] and the more it does, the more we, and I weaken.");
+			elseif(e.message:findi("streams of the spirit world") and qglobals["shaman_epic"] == "1") then
+				e.self:Say("Yes, it is true. I feel myself fading more with each turn of time. You are familiar with the ways of herbs and potions and you can aid me, should you [" .. eq.say_link("find the will") .. "]. With strength to keep me before you in the mortal realm, I can guide you so that you may aid us all. There is much to tell you that I will not reveal yet, lest you be tempted to take advantage -- which has happened before.");
+			elseif(e.message:findi("find the will") and qglobals["shaman_epic"] == "1") then
+				e.self:Say("Very well. You will not find this an easy task. There are several things you must do and other heyokah you must find that have helped us in the past. Where there is glitter upon the setting of Ro, you will find an agent of the spirits. In the deep waters where the megalodon is said to hunt, there is another. And where the wonders of nature rise in the dark, another ally awaits. Look for light in the denseness of entwined shadows. One will greet you with all you have learned. She is doing research in a bustling labyrinth of creatures and can educate you where I cannot. Tell them all of me and they will give you audience");
+			elseif(e.message:findi("wasichu") and qglobals["shaman_epic"] == "2") then
+				e.self:Say("The wasichu are those that turn their backs on serving the spirit world for its own sake. They hunger for their wn power. At greater risk now are the spirits of Wisdom and Patience. They have become weakened and their fading is eroding what you as shaman often rely upon. The Spirit of Might has lost its way altogether and has crossed over into the darkness of Discord in that other realm. It has veen mobing amongst the [" .. eq.say_link("dark creatures") .. "] there, using its influence to guide and move some beasts in strange ways.");
+			elseif(e.message:findi("dark creatures") and qglobals["shaman_epic"] == "2") then
+				e.self:Say("We must prepare a [" .. eq.say_link("ritual") .. "] that has not been performed in many, many years. We hope this one ritual will return the strength of the failing spirits and restore the honor and humility of the Spirit of Might, but there is much preparation to be done. If you are prepared to take on this task, I will tell you what I know. This is no small endeavor, friend. Your mind and body and your strngth of spirit will be put to the test.");
+			elseif(e.message:findi("ritual") and qglobals["shaman_epic"] == "2") then	
+				e.self:Say("The ritual we need to perform is an ancient one, called Ruchu, and it will require a lot of preparation and planning on our parts. To begin with, we need to call upon our allies for help. One thing we need is spirit talismans. In times past, the spirits bestowed very powerful talismans upon a few, but [" .. eq.say_link("great heyokah") .. "] heyokah. We are going to need some of them to perform this ritual as they contain some of the essence of the very beings we are tying to save.");
+			elseif(e.message:findi("great heyokah") and qglobals["shaman_epic"] == "2") then
+				e.self:Say("One of them was a [" .. eq.say_link("wise") .. "] shaman who once walked the lands and gahered every morsel of wisfom his mind could consume in the ways of alchemy and magic. Even though he was a froglok, he was incrediby gifted. His name was Juktopp Gantroc. Though he was small in stature, his knoledge seemed and endless expanse.");
+			elseif(e.message:findi("wise") and qglobals["shaman_epic"] == "2") then
+				e.self:Say("We had [" .. eq.say_link("watched") .. "] him and were amazed by the depth and breadth of his knowledge and how he applied it to his arts. Over time, he began to learn things that we did not know or piece together ourselves, adding great value to the spirits and shaman everywhere.");
+			elseif(e.message:findi("watched") and qglobals["shaman_epic"] == "2") then
+				e.self:Say("Upon his death, which he made no attempts to prevent and he likely could have, he accepted the passage from the confines of flesh into the spirit world with great grace and dignity. Several of us spirits gathered that night and chose to appear to him and offer him a [" .. eq.say_link("rare gift") .. "]... a place among the everlasting spirits where he could share his knowledge and continue to learn.");
+			elseif(e.message:findi("rare gift") and qglobals["shaman_epic"] == "2") then
+				e.self:Say("The Spirit of Wisdom itself blessed a talisman and gave it to Juktopp, telling him of our offer. Needless to say, he was overwhelmed and overjoyed. To this day, he remains light as air and just as free in a planar realm of great beauty. You must find him and retrieve the talisman. Give him this potion whihc will sustain him while we prepare for Ruchu. There is [" .. eq.say_link("still more") .. "] you must do.");
+				e.other:SummonItem(57081); --Potion of Sustenance
+			elseif(e.message:findi("still more") and qglobals["shaman_epic"] == "2") then
+				e.self:Say("When the gods were still young and the ethereal planes were not much more than imagination, the Tribunal wished to create an infallible system of justice. They also wanted those who approached them to hear or plead their casr to have their resolve tested so the Tribunal's time would not be wasted. Thus, the Tribunal chose to create [" .. eq.say_link("trials of justice") .. "] so that Norrathians would be required to prove thier worth to have thier case heard.");
+			elseif(e.message:findi("trials of justice") and qglobals["shaman_epic"] == "2") then
+				e.self:Say("But it was not that simple. It did take some time to decide how the trials would be created so that they were fair and just and would provide a good test of strength and might. There was a high shaman of halas who followed th path lain by the Tribunal and lived his life according to law and justice. His name was [" .. eq.say_link("Veshtaq") .. "] MacDunahon.");
+			elseif(e.message:findi("veshtaq") and qglobals["shaman_epic"] == "2") then
+				e.self:Say("Veshtaq's strict asherence to justice eventually earned the attention of the Tribunal and he was asked to ascend from the mortal realm to aid them in creating trials that would be suitable to place before Norathians wishing to approach the greatness of the Tribunal. Of course, Veshtaq obliged and [" .. eq.say_link("succeeded") .. "] in creating a series of trials that allowed Norrathians to prove thier worth.");
+			elseif(e.message:findi("succeeded") and qglobals["shaman_epic"] == "2") then
+				e.self:Say("When his work was done, Veshtaq suddenly realized that he had grown much olde and his time in the lane had weakened his ties with the natual spirits of the world. This [" .. eq.say_link("troubled") .. "] him greatly. He felt his life perhaps had come to no real meaning.");
+			elseif(e.message:findi("troubled") and qglobals["shaman_epic"] == "2") then
+				e.self:Say("Somehow, the Tribunal then became aware of Veshtaq's concerns and passed a judgment -- that Ceshtaq be granted a place among the trials he created, becoming immortal. With that judgment, the Tribunal had contacted one of the great spirits, that of Patience, and asked for a [" .. eq.say_link("meaningful way") .. "] for a shaman to become immortal.");
+			elseif(e.message:findi("meaningful way") and qglobals["shaman_epic"] == "2") then
+				e.self:Say("For a shaman, a blessing of eternal life from any spirit is an honor, so a talisman was created by the Spirit of Patience to sustain Veshtaq for all time and he would be once again be rejoined with the spirit world. Now, Mwinda, it is up to you to retrieve the talisman. You may not simply ask for it. You will have to complete the ery tial he commands and defeat his essence. Do not fret. The Tribunal will sustain him in that plane so he may continue his work.");
+			elseif(e.message:findi("stolen") and qglobals["shaman_epic"] == "3") then
+				e.self:Say("Very well. You will need to return to Wunshi for more information. He will be able to lead you to some of what we need if you ask him. Return to me and tell me when your business with Wunshi is finished. I am too tired to continue.");
+			elseif(e.message:findi("business with Wunshi is finished") and qglobals["shaman_epic"] == "4") then
+				e.self:Say("Is that so? I am both grateful and anxious. My sight into the spirit world grows darker with each hour. You have done well, but I am ever fearful that we are not moving quickly enough. You must use all of your skills for your next task. Return to Kimm McShannel and when you return to me, tell me that you have created the potion. Show her this bangle.");
+				e.other:SummonItem(57088); --Gemmed Bangle of Enlightenment
+			elseif(e.message:findi("take part") and qglobals["shaman_epic"] == "6") then
+				e.self:Say("We are still a long way from that, but I feel it is time to [" .. eq.say_link("acknowledge") .. "] you as a true shaman spirit that has earned the respect of many spirits of the world.");
+			elseif(e.message:findi("acknowledge") and qglobals["shaman_epic"] == "6") then
+				e.self:Say("We, the spirits, have chosen to grant you a gift for all that you've done for us and what you still have left to do. It is just a sampling of the power you may obtain one day as you move forward as one of the heyokah. Guard it and use it well. Should you choose to continue your journey, tell me that you are [" .. eq.say_link("prepared to carry on") .. "] and save the spirits.");
+				e.other:SummonItem(57400); -- Crafted Talisman of Fates (Epic 1.5)
+				e.other:AddAAPoints(5);
+				e.other:Ding();
+				e.other:Message(15,'You have gained 5 ability points!');
+				e.other:AddEXP(25000);
+				eq.set_global("shaman_epic","7",5,"F");
+			elseif(e.message:findi("prepared to carry on") and e.other:HasItem(57400)) then
+				e.self:Say("I knew we could count on you, " .. e.other:GetName() .. ".  The time for Ruchu is drawing ever nearer, but we still must gather some essential elements. Soon, you will have to cross the barrier into that realm of Discord. Lupot Nukla can help you.");
+				if(qglobals["shaman_epic"] == nil or tonumber(qglobals["shaman_epic"]) <=7) then
+					eq.set_global("shaman_epic","8",5,"F");
 				end
-			end	
-		end
-		if(e.message:findi("it is so") and qglobals["shaman_epic"] == "1") then
-			e.self:Say("To have you here, believing in us and our existence does give me warmth, but my length of time here and others like me may be at an end. The spirits are troubled and a darkness washes through our existence that we seem helpless to prevent. That is why I talk to you now -- to help us. Without the help of mortals, we may [" .. eq.say_link("blow away") .. "] with the winds.");	
-		elseif(e.message:findi("blow away") and qglobals["shaman_epic"] == "1") then
-			e.self:Say("You have heard of the darkness in Taelosia that came from another place. You may have even seen the world that is overshadowed by the dark influence of Discord. That seeping ill that is not touchable by claw or paw has wormed its way into the [" .. eq.say_link("streams of the spirit world") .. "] and the more it does, the more we, and I weaken.");
-		elseif(e.message:findi("streams of the spirit world") and qglobals["shaman_epic"] == "1") then
-			e.self:Say("Yes, it is true. I feel myself fading more with each turn of time. You are familiar with the ways of herbs and potions and you can aid me, should you [" .. eq.say_link("find the will") .. "]. With strength to keep me before you in the mortal realm, I can guide you so that you may aid us all. There is much to tell you that I will not reveal yet, lest you be tempted to take advantage -- which has happened before.");
-		elseif(e.message:findi("find the will") and qglobals["shaman_epic"] == "1") then
-			e.self:Say("Very well. You will not find this an easy task. There are several things you must do and other heyokah you must find that have helped us in the past. Where there is glitter upon the setting of Ro, you will find an agent of the spirits. In the deep waters where the megalodon is said to hunt, there is another. And where the wonders of nature rise in the dark, another ally awaits. Look for light in the denseness of entwined shadows. One will greet you with all you have learned. She is doing research in a bustling labyrinth of creatures and can educate you where I cannot. Tell them all of me and they will give you audience");
-		elseif(e.message:findi("wasichu") and qglobals["shaman_epic"] == "2") then
-			e.self:Say("The wasichu are those that turn their backs on serving the spirit world for its own sake. They hunger for their wn power. At greater risk now are the spirits of Wisdom and Patience. They have become weakened and their fading is eroding what you as shaman often rely upon. The Spirit of Might has lost its way altogether and has crossed over into the darkness of Discord in that other realm. It has veen mobing amongst the [" .. eq.say_link("dark creatures") .. "] there, using its influence to guide and move some beasts in strange ways.");
-		elseif(e.message:findi("dark creatures") and qglobals["shaman_epic"] == "2") then
-			e.self:Say("We must prepare a [" .. eq.say_link("ritual") .. "] that has not been performed in many, many years. We hope this one ritual will return the strength of the failing spirits and restore the honor and humility of the Spirit of Might, but there is much preparation to be done. If you are prepared to take on this task, I will tell you what I know. This is no small endeavor, friend. Your mind and body and your strngth of spirit will be put to the test.");
-		elseif(e.message:findi("ritual") and qglobals["shaman_epic"] == "2") then	
-			e.self:Say("The ritual we need to perform is an ancient one, called Ruchu, and it will require a lot of preparation and planning on our parts. To begin with, we need to call upon our allies for help. One thing we need is spirit talismans. In times past, the spirits bestowed very powerful talismans upon a few, but [" .. eq.say_link("great heyokah") .. "] heyokah. We are going to need some of them to perform this ritual as they contain some of the essence of the very beings we are tying to save.");
-		elseif(e.message:findi("great heyokah") and qglobals["shaman_epic"] == "2") then
-			e.self:Say("One of them was a [" .. eq.say_link("wise") .. "] shaman who once walked the lands and gahered every morsel of wisfom his mind could consume in the ways of alchemy and magic. Even though he was a froglok, he was incrediby gifted. His name was Juktopp Gantroc. Though he was small in stature, his knoledge seemed and endless expanse.");
-		elseif(e.message:findi("wise") and qglobals["shaman_epic"] == "2") then
-			e.self:Say("We had [" .. eq.say_link("watched") .. "] him and were amazed by the depth and breadth of his knowledge and how he applied it to his arts. Over time, he began to learn things that we did not know or piece together ourselves, adding great value to the spirits and shaman everywhere.");
-		elseif(e.message:findi("watched") and qglobals["shaman_epic"] == "2") then
-			e.self:Say("Upon his death, which he made no attempts to prevent and he likely could have, he accepted the passage from the confines of flesh into the spirit world with great grace and dignity. Several of us spirits gathered that night and chose to appear to him and offer him a [" .. eq.say_link("rare gift") .. "]... a place among the everlasting spirits where he could share his knowledge and continue to learn.");
-		elseif(e.message:findi("rare gift") and qglobals["shaman_epic"] == "2") then
-			e.self:Say("The Spirit of Wisdom itself blessed a talisman and gave it to Juktopp, telling him of our offer. Needless to say, he was overwhelmed and overjoyed. To this day, he remains light as air and just as free in a planar realm of great beauty. You must find him and retrieve the talisman. Give him this potion whihc will sustain him while we prepare for Ruchu. There is [" .. eq.say_link("still more") .. "] you must do.");
-			e.other:SummonItem(57081); --Potion of Sustenance
-		elseif(e.message:findi("still more") and qglobals["shaman_epic"] == "2") then
-			e.self:Say("When the gods were still young and the ethereal planes were not much more than imagination, the Tribunal wished to create an infallible system of justice. They also wanted those who approached them to hear or plead their casr to have their resolve tested so the Tribunal's time would not be wasted. Thus, the Tribunal chose to create [" .. eq.say_link("trials of justice") .. "] so that Norrathians would be required to prove thier worth to have thier case heard.");
-		elseif(e.message:findi("trials of justice") and qglobals["shaman_epic"] == "2") then
-			e.self:Say("But it was not that simple. It did take some time to decide how the trials would be created so that they were fair and just and would provide a good test of strength and might. There was a high shaman of halas who followed th path lain by the Tribunal and lived his life according to law and justice. His name was [" .. eq.say_link("Veshtaq") .. "] MacDunahon.");
-		elseif(e.message:findi("veshtaq") and qglobals["shaman_epic"] == "2") then
-			e.self:Say("Veshtaq's strict asherence to justice eventually earned the attention of the Tribunal and he was asked to ascend from the mortal realm to aid them in creating trials that would be suitable to place before Norathians wishing to approach the greatness of the Tribunal. Of course, Veshtaq obliged and [" .. eq.say_link("succeeded") .. "] in creating a series of trials that allowed Norrathians to prove thier worth.");
-		elseif(e.message:findi("succeeded") and qglobals["shaman_epic"] == "2") then
-			e.self:Say("When his work was done, Veshtaq suddenly realized that he had grown much olde and his time in the lane had weakened his ties with the natual spirits of the world. This [" .. eq.say_link("troubled") .. "] him greatly. He felt his life perhaps had come to no real meaning.");
-		elseif(e.message:findi("troubled") and qglobals["shaman_epic"] == "2") then
-			e.self:Say("Somehow, the Tribunal then became aware of Veshtaq's concerns and passed a judgment -- that Ceshtaq be granted a place among the trials he created, becoming immortal. With that judgment, the Tribunal had contacted one of the great spirits, that of Patience, and asked for a [" .. eq.say_link("meaningful way") .. "] for a shaman to become immortal.");
-		elseif(e.message:findi("meaningful way") and qglobals["shaman_epic"] == "2") then
-			e.self:Say("For a shaman, a blessing of eternal life from any spirit is an honor, so a talisman was created by the Spirit of Patience to sustain Veshtaq for all time and he would be once again be rejoined with the spirit world. Now, Mwinda, it is up to you to retrieve the talisman. You may not simply ask for it. You will have to complete the ery tial he commands and defeat his essence. Do not fret. The Tribunal will sustain him in that plane so he may continue his work.");
-		elseif(e.message:findi("stolen") and qglobals["shaman_epic"] == "3") then
-			e.self:Say("Very well. You will need to return to Wunshi for more information. He will be able to lead you to some of what we need if you ask him. Return to me and tell me when your business with Wunshi is finished. I am too tired to continue.");
-		elseif(e.message:findi("business with Wunshi is finished") and qglobals["shaman_epic"] == "4") then
-			e.self:Say("Is that so? I am both grateful and anxious. My sight into the spirit world grows darker with each hour. You have done well, but I am ever fearful that we are not moving quickly enough. You must use all of your skills for your next task. Return to Kimm McShannel and when you return to me, tell me that you have created the potion. Show her this bangle.");
-			e.other:SummonItem(57088); --Gemmed Bangle of Enlightenment
-		elseif(e.message:findi("take part") and qglobals["shaman_epic"] == "6") then
-			e.self:Say("We are still a long way from that, but I feel it is time to [" .. eq.say_link("acknowledge") .. "] you as a true shaman spirit that has earned the respect of many spirits of the world.");
-		elseif(e.message:findi("acknowledge") and qglobals["shaman_epic"] == "6") then
-			e.self:Say("We, the spirits, have chosen to grant you a gift for all that you've done for us and what you still have left to do. It is just a sampling of the power you may obtain one day as you move forward as one of the heyokah. Guard it and use it well. Should you choose to continue your journey, tell me that you are [" .. eq.say_link("prepared to carry on") .. "] and save the spirits.");
-			e.other:SummonItem(57400); -- Crafted Talisman of Fates (Epic 1.5)
-			e.other:AddAAPoints(5);
-			e.other:Ding();
-			e.other:Message(15,'You have gained 5 ability points!');
-			e.other:AddEXP(25000);
-			eq.set_global("shaman_epic","7",5,"F");
-		elseif(e.message:findi("prepared to carry on") and e.other:HasItem(57400)) then
-			e.self:Say("I knew we could count on you, " .. e.other:GetName() .. ".  The time for Ruchu is drawing ever nearer, but we still must gather some essential elements. Soon, you will have to cross the barrier into that realm of Discord. Lupot Nukla can help you.");
-			if(qglobals["shaman_epic"] == nil or tonumber(qglobals["shaman_epic"]) <=7) then
-				eq.set_global("shaman_epic","8",5,"F");
+			elseif(e.message:findi("discord") and qglobals["shaman_epic"] == "11") then
+				e.self:Say("We know the Spirit of Might is beginning to disperse not just in Norrath, but that place shadowed by Discord as well. The spirit has passed through many beasts and is corrupting them, each one commanded by a trace of the spirit. You must find several beasts and find those traces of the wasichu. One is an airy, fluid creature. Yet another is a fierce beast that has grown beyond all normal proportions because of the spirit of Might. You must find them. And there are still others you must [" .. eq.say_link("seek") .. "].");
+			elseif(e.message:findi("seek") and qglobals["shaman_epic"] == "11") then
+				e.self:Say("The other creature you must find is a soldier of evil. Another is an scurrying creature that is not bound to our realm. You have much ahead of you. Take this pouch and carefully piece together everything you find and return it to me. You will know how to do it. The spirits will guide you.");
+				e.other:SummonItem(57710); --Pouch of Spirit Dust
+			elseif(e.message:findi("spiritcaller") and qglobals["shaman_epic"] == "12") then
+				e.self:Say("The fiend that is consuming our spirits is in Discord and is siphoning what little energy and strength we have remaining. We are losing ourselves in the passage of Discord. Without the spirits of Might, Patience, and Wisdom, we may not [" .. eq.say_link("survive") .. "]. We are not whole without them.");
+			elseif(e.message:findi("survive") and qglobals["shaman_epic"] == "12") then
+				e.self:Say("Make your way to a place of great suffering and death in Kuua. You will need to investigate to help us learn more about our waning spirits. We have no influence there and it is a wholly unpredictable place.");
+			elseif(e.message:findi("prepared for the ceremony") and qglobals["shaman_epic"] == "14" and char_id == 0) then
+				e.self:Say("Follow me closely. We must gather the spirits and try to call our ethereal kin of Might, Patience, and Wisdom. The other spirits will join us for Ruchu, namely the Spirit of Perseverance, Spirit of Understanding, Spirit of Fortitude, Spirit of Will, and the Spirit of Sense.");
+				eq.set_timer("start_event",5000);
+				char_id = e.other:CharacterID();
+				count=0;
+			elseif(e.message:findi("faithful heyokah") and qglobals["shaman_epic"] == "14") then
+				e.self:Say("Well, then, the time has come. Give me your Crafted Talisman of Fates, heyokah. Should you not have it now, give it to me when you do. If you have lost it, tell me so. I may be able to help you.");	
 			end
-		elseif(e.message:findi("discord") and qglobals["shaman_epic"] == "11") then
-			e.self:Say("We know the Spirit of Might is beginning to disperse not just in Norrath, but that place shadowed by Discord as well. The spirit has passed through many beasts and is corrupting them, each one commanded by a trace of the spirit. You must find several beasts and find those traces of the wasichu. One is an airy, fluid creature. Yet another is a fierce beast that has grown beyond all normal proportions because of the spirit of Might. You must find them. And there are still others you must [" .. eq.say_link("seek") .. "].");
-		elseif(e.message:findi("seek") and qglobals["shaman_epic"] == "11") then
-			e.self:Say("The other creature you must find is a soldier of evil. Another is an scurrying creature that is not bound to our realm. You have much ahead of you. Take this pouch and carefully piece together everything you find and return it to me. You will know how to do it. The spirits will guide you.");
-			e.other:SummonItem(57710); --Pouch of Spirit Dust
-		elseif(e.message:findi("spiritcaller") and qglobals["shaman_epic"] == "12") then
-			e.self:Say("The fiend that is consuming our spirits is in Discord and is siphoning what little energy and strength we have remaining. We are losing ourselves in the passage of Discord. Without the spirits of Might, Patience, and Wisdom, we may not [" .. eq.say_link("survive") .. "]. We are not whole without them.");
-		elseif(e.message:findi("survive") and qglobals["shaman_epic"] == "12") then
-			e.self:Say("Make your way to a place of great suffering and death in Kuua. You will need to investigate to help us learn more about our waning spirits. We have no influence there and it is a wholly unpredictable place.");
-		elseif(e.message:findi("prepared for the ceremony") and qglobals["shaman_epic"] == "14" and char_id == 0) then
-			e.self:Say("Follow me closely. We must gather the spirits and try to call our ethereal kin of Might, Patience, and Wisdom. The other spirits will join us for Ruchu, namely the Spirit of Perseverance, Spirit of Understanding, Spirit of Fortitude, Spirit of Will, and the Spirit of Sense.");
-			eq.set_timer("start_event",5000);
-			char_id = e.other:CharacterID();
-			count=0;
-		elseif(e.message:findi("faithful heyokah") and qglobals["shaman_epic"] == "14") then
-			e.self:Say("Well, then, the time has come. Give me your Crafted Talisman of Fates, heyokah. Should you not have it now, give it to me when you do. If you have lost it, tell me so. I may be able to help you.");	
 		end
+	else
+		e.self:Say("Go away, I am busy.");
 	end
 end
 
 function event_trade(e)
 	local qglobals = eq.get_qglobals(e.other);
 	local item_lib = require("items");
-	if(qglobals["shaman_epic"] == "1" and item_lib.check_turn_in(e.trade, {item1 = 52921})) then --hand in the Distilled Potion of Endurance (Received from Wilslik Gissu on the previous step)
-		e.self:Emote("drinks the potion hastily and shudders. Its essence grows brighter and it's dull eyes begin to sparkle with renewed strength.");
-		e.self:Say("You have bought me time -- time to explain how you may aid us all. The darkness of Discord seeps ever deeper into Norrath and the spirit world. Some of the most revered and oldest spirits known have turned to grim pursuits, becoming the [" .. eq.say_link("wasichu") .. "] -- those creatures you may remember from you time conversing with another great spirit.");
-		eq.set_global("shaman_epic","2",5,"F");
-	end
-	if(qglobals["shaman_epic"] == "2" and item_lib.check_turn_in(e.trade, {item1 = 57083, item2 = 57084})) then --hand in Talisman of Patience (drops from  Punisher Veshtaq in POJ Trial of Torture, which needs to be added) and Talisman of Wisdom (from Eternal Spirit in PoSky in exchange for Potion of Sustenance)
-		e.self:Say("This is a start. There is still much to do. While we have gotten the talismans from our allies, there are those that are not our friends -- the wasichu and worse -- who carry or have [" .. eq.say_link("stolen") .. "] items we need. They will not part with them willingly. This is where your strength and might will be put to the test . . . and your presence of mind. Are you certain you wish to go on?");
-		eq.set_global("shaman_epic","3",5,"F");
-	end
-	if(qglobals["shaman_epic"] == "5" and item_lib.check_turn_in(e.trade, {item1 = 57614})) then --hand in Runed Purse of the McShannels
-		e.self:Say("I will have to pass these along as soon as my messenger gets here. I'm sure you understand that as each spirit loses strength, each of our abilities to keep a form in this tangible world becomes very difficult. We must find a way to sustain a physical presence here or the Ruchu will be in jeopardy. We will ask you to [" .. eq.say_link("take part") .. "] in the ceremony where our strength may fail us.");
-		eq.set_global("shaman_epic","6",5,"F");
-	end
-	if(qglobals["shaman_epic"] == "10" and item_lib.check_turn_in(e.trade, {item1 = 57551})) then --hand in Impervious Medicine Bag (received from Lupot Nukla in Fungus Grove)
-		e.self:Say("You never cease to surprise me. I felt in my heart that you would get this far, but I did not expect you to be so bold and steady with your advance. Can you feel the spirits smiling on you?' The spirit lifts its weary head and closes its eyes . . . Yes, yes, they are pleased, but they are weak just as I am. And now the path grows dark and dreary. We must ask you to once again to risk your life, but not in this world, but the world of [" .. eq.say_link("Discord") .. "].");
-		eq.set_global("shaman_epic","11",5,"F");
-	end
-	if(qglobals["shaman_epic"] == "11" and item_lib.check_turn_in(e.trade, {item1 = 57987})) then --hand in Glowing Spirit Charm of Might (made from combine, probably needs added to db)
-		e.self:Say("The time is nearly here! We have only a few remaining pieces that we must collect in order to restore our spirits. We did miss something, however, and it must be stopped. You must gather your allies and return to Discord. A wasichu has learned to summon the fiercest beasts and has grown out of control. It is now a [" .. eq.say_link("spiritcaller") .. "] who is drawing the strength of our most precious elders to do it.");
-		eq.set_global("shaman_epic","12",5,"F");
-	end
-	if(qglobals["shaman_epic"] == "12" and item_lib.check_turn_in(e.trade, {item1 = 57404})) then --hand in Spiritcaller Beads (looted from Discordling Spiritcaller in Walls of Slaughter)
-		e.self:Say("There is one last thing you must do. Your defeat of the spiritcaller has proven your strength and I believe you are ready. Do not fail us now. You must go into the lair of Mata Muram himself. There is a strange orb that only exists there. We believe some of our spirits, beyond those we shall restore with Ruchu, are becoming absorbed or attracted to these orbs. You must find one and bring it to me and then we shall have all we need.");
-		eq.set_global("shaman_epic","13",5,"F");
-	end
-	if(qglobals["shaman_epic"] == "13" and item_lib.check_turn_in(e.trade, {item1 = 47100})) then --hand in Globe of Discordant Energy (from Citadel of Anguish)
-		e.self:Emote("lowers its head and you believe you see a shade of a tear drop from its eyes and disappear into nothingness. 'You have done it. You cannot imagine our gratitude. The time for Ruchu is at hand and we offer you the privilege of taking part. If you are able to do the ceremony now, tell me you are [" .. eq.say_link("prepared for the ceremony") .. "].'");
-		eq.set_global("shaman_epic","14",5,"F");
-	end
-	if(qglobals["shaman_epic"] == "14" and item_lib.check_turn_in(e.trade, {item1 = 57400})) then --hand in Crafted Talisman of Fates (Epic 1.5)
-		e.self:Say("You have heard the stories of the blessings bestowed on some of Norrath's most faithful to the ways of the heyokah. To reward you for all that you've done, the spirits have chosen to bless this talisman and offer it to you as our thanks, for without you, all shaman would have suffered without our presence in this realm. Walk proud, heyokah, and never forget what you are.' All around you, you feel the strength of the spirit world begin to strengthen as the spirit leaves to tend to his wounded companions.");
-		e.other:QuestReward(e.self,{itemid=57405, exp=50000}); --Blessed Spiritstaff of the Heyokah (Epic 2.0)
-		e.other:AddAAPoints(10);
-		e.other:Message(15,'You have gained 10 ability points!');
-		eq.set_global("shaman_epic","15",5,"F");
-		eq.depop_all(8119);
-		eq.depop_all(8120);
-		eq.depop_all(8121);
-		eq.depop_all(8122);
-		eq.depop_all(8123);
-		eq.depop_all(8124);
-		eq.depop_all(8125);
-		eq.depop_all(8126);
-		-- reset variables if they skip the event
-		eq.stop_timer("event");
-		char_id = 0;
-		client = nil;
+
+	if not epic_disabled then
+		if(qglobals["shaman_epic"] == "1" and item_lib.check_turn_in(e.trade, {item1 = 52921})) then --hand in the Distilled Potion of Endurance (Received from Wilslik Gissu on the previous step)
+			e.self:Emote("drinks the potion hastily and shudders. Its essence grows brighter and it's dull eyes begin to sparkle with renewed strength.");
+			e.self:Say("You have bought me time -- time to explain how you may aid us all. The darkness of Discord seeps ever deeper into Norrath and the spirit world. Some of the most revered and oldest spirits known have turned to grim pursuits, becoming the [" .. eq.say_link("wasichu") .. "] -- those creatures you may remember from you time conversing with another great spirit.");
+			eq.set_global("shaman_epic","2",5,"F");
+		end
+		if(qglobals["shaman_epic"] == "2" and item_lib.check_turn_in(e.trade, {item1 = 57083, item2 = 57084})) then --hand in Talisman of Patience (drops from  Punisher Veshtaq in POJ Trial of Torture, which needs to be added) and Talisman of Wisdom (from Eternal Spirit in PoSky in exchange for Potion of Sustenance)
+			e.self:Say("This is a start. There is still much to do. While we have gotten the talismans from our allies, there are those that are not our friends -- the wasichu and worse -- who carry or have [" .. eq.say_link("stolen") .. "] items we need. They will not part with them willingly. This is where your strength and might will be put to the test . . . and your presence of mind. Are you certain you wish to go on?");
+			eq.set_global("shaman_epic","3",5,"F");
+		end
+		if(qglobals["shaman_epic"] == "5" and item_lib.check_turn_in(e.trade, {item1 = 57614})) then --hand in Runed Purse of the McShannels
+			e.self:Say("I will have to pass these along as soon as my messenger gets here. I'm sure you understand that as each spirit loses strength, each of our abilities to keep a form in this tangible world becomes very difficult. We must find a way to sustain a physical presence here or the Ruchu will be in jeopardy. We will ask you to [" .. eq.say_link("take part") .. "] in the ceremony where our strength may fail us.");
+			eq.set_global("shaman_epic","6",5,"F");
+		end
+		if(qglobals["shaman_epic"] == "10" and item_lib.check_turn_in(e.trade, {item1 = 57551})) then --hand in Impervious Medicine Bag (received from Lupot Nukla in Fungus Grove)
+			e.self:Say("You never cease to surprise me. I felt in my heart that you would get this far, but I did not expect you to be so bold and steady with your advance. Can you feel the spirits smiling on you?' The spirit lifts its weary head and closes its eyes . . . Yes, yes, they are pleased, but they are weak just as I am. And now the path grows dark and dreary. We must ask you to once again to risk your life, but not in this world, but the world of [" .. eq.say_link("Discord") .. "].");
+			eq.set_global("shaman_epic","11",5,"F");
+		end
+		if(qglobals["shaman_epic"] == "11" and item_lib.check_turn_in(e.trade, {item1 = 57987})) then --hand in Glowing Spirit Charm of Might (made from combine, probably needs added to db)
+			e.self:Say("The time is nearly here! We have only a few remaining pieces that we must collect in order to restore our spirits. We did miss something, however, and it must be stopped. You must gather your allies and return to Discord. A wasichu has learned to summon the fiercest beasts and has grown out of control. It is now a [" .. eq.say_link("spiritcaller") .. "] who is drawing the strength of our most precious elders to do it.");
+			eq.set_global("shaman_epic","12",5,"F");
+		end
+		if(qglobals["shaman_epic"] == "12" and item_lib.check_turn_in(e.trade, {item1 = 57404})) then --hand in Spiritcaller Beads (looted from Discordling Spiritcaller in Walls of Slaughter)
+			e.self:Say("There is one last thing you must do. Your defeat of the spiritcaller has proven your strength and I believe you are ready. Do not fail us now. You must go into the lair of Mata Muram himself. There is a strange orb that only exists there. We believe some of our spirits, beyond those we shall restore with Ruchu, are becoming absorbed or attracted to these orbs. You must find one and bring it to me and then we shall have all we need.");
+			eq.set_global("shaman_epic","13",5,"F");
+		end
+		if(qglobals["shaman_epic"] == "13" and item_lib.check_turn_in(e.trade, {item1 = 47100})) then --hand in Globe of Discordant Energy (from Citadel of Anguish)
+			e.self:Emote("lowers its head and you believe you see a shade of a tear drop from its eyes and disappear into nothingness. 'You have done it. You cannot imagine our gratitude. The time for Ruchu is at hand and we offer you the privilege of taking part. If you are able to do the ceremony now, tell me you are [" .. eq.say_link("prepared for the ceremony") .. "].'");
+			eq.set_global("shaman_epic","14",5,"F");
+		end
+		if(qglobals["shaman_epic"] == "14" and item_lib.check_turn_in(e.trade, {item1 = 57400})) then --hand in Crafted Talisman of Fates (Epic 1.5)
+			e.self:Say("You have heard the stories of the blessings bestowed on some of Norrath's most faithful to the ways of the heyokah. To reward you for all that you've done, the spirits have chosen to bless this talisman and offer it to you as our thanks, for without you, all shaman would have suffered without our presence in this realm. Walk proud, heyokah, and never forget what you are.' All around you, you feel the strength of the spirit world begin to strengthen as the spirit leaves to tend to his wounded companions.");
+			e.other:QuestReward(e.self,{itemid=57405, exp=50000}); --Blessed Spiritstaff of the Heyokah (Epic 2.0)
+			e.other:AddAAPoints(10);
+			e.other:Message(15,'You have gained 10 ability points!');
+			eq.set_global("shaman_epic","15",5,"F");
+			eq.depop_all(8119);
+			eq.depop_all(8120);
+			eq.depop_all(8121);
+			eq.depop_all(8122);
+			eq.depop_all(8123);
+			eq.depop_all(8124);
+			eq.depop_all(8125);
+			eq.depop_all(8126);
+			-- reset variables if they skip the event
+			eq.stop_timer("event");
+			char_id = 0;
+			client = nil;
+		end
 	end
 	item_lib.return_items(e.self, e.other, e.trade);
 end

--- a/global/items/CHRMFewerMemmed.lua
+++ b/global/items/CHRMFewerMemmed.lua
@@ -14,7 +14,7 @@ local memmed_table = {  [1] = {0,1},
 }
 
 function event_scale_calc(e)
-    if not enable_melee_bypass and (e.owner:HasClass() == Class.WARRIOR or e.owner:HasClass() == Class.MONK or e.owner:HasClass() == Class.ROGUE or e.owner:HasClass() == Class.BERSERKER) then -- Notes show it doesn't work for pure melee classes
+    if not enable_melee_bypass and (e.owner:HasClass(Class.WARRIOR) or e.owner:HasClass(Class.MONK) or e.owner:HasClass(Class.ROGUE) or e.owner:HasClass(Class.BERSERKER)) then -- Notes show it doesn't work for pure melee classes
         e.self:SetScale(0);
     else
         for id, v in pairs(memmed_table) do

--- a/hatesfury/Broken_Skull_Armsmaster.lua
+++ b/hatesfury/Broken_Skull_Armsmaster.lua
@@ -1,6 +1,6 @@
 -- Berserker Pre Epic 1.5
 
-local epic_disabled = true;
+local epic_disabled = true; -- Disabling for omens (epics) cannot reference perl expansion vars from lua.
 
 local weakened = false;
 local client = nil;

--- a/iceclad/Giligatabbus_Igglebix.lua
+++ b/iceclad/Giligatabbus_Igglebix.lua
@@ -1,17 +1,23 @@
 --iceclad/Giligatabbus_Igglebix.lua NPCID 
 --SK Epic 1.5
+
+local epic_disabled = true; -- Disabling for omens (epics) cannot reference perl expansion vars from lua.
+
 function event_say(e)
-	local qglobals = eq.get_qglobals(e.other);	
-	if(e.message:findi("hail")) then
-		if ( qglobals["shadowknight_epic"] == "6") then
-			e.self:Say("arggg!");
-			e.self:SetSpecialAbility(19, 0);
-			e.self:SetSpecialAbility(20, 0);
-			e.self:SetSpecialAbility(24, 0);
-			e.self:SetSpecialAbility(25, 0);
-			e.self:SetSpecialAbility(35, 0);
-			e.self:SetLevel(66);
-			e.self:AddToHateList(e.other,1);
+	local qglobals = eq.get_qglobals(e.other);
+
+	if not epic_disabled then
+		if e.message:findi("hail") then
+			if qglobals["shadowknight_epic"] ~= nil and  qglobals["shadowknight_epic"] == "6" then
+				e.self:Say("arggg!");
+				e.self:SetSpecialAbility(19, 0);
+				e.self:SetSpecialAbility(20, 0);
+				e.self:SetSpecialAbility(24, 0);
+				e.self:SetSpecialAbility(25, 0);
+				e.self:SetSpecialAbility(35, 0);
+				e.self:SetLevel(66);
+				e.self:AddToHateList(e.other,1);
+			end
 		end
 	end
 end
@@ -20,5 +26,3 @@ function event_trade(e)
 	local item_lib = require("items");
 	item_lib.return_items(e.self, e.other, e.trade);
 end
-	
-	

--- a/jaggedpine/#Derick_Goodroot.lua
+++ b/jaggedpine/#Derick_Goodroot.lua
@@ -77,46 +77,51 @@
 -- Epic 2.5 Details - Subfield 4 (INT)
 ---- SubField - 1 = Completed Epic 2.5
 
+
+local epic_disabled = true; -- Disabling for omens (epics) cannot reference perl expansion vars from lua.
+
 function event_say(e)
-	if e.other:HasClass(Class.DRUID) then
+	if not epic_disabled then
+		if e.other:HasClass(Class.DRUID) then
 
-		local data_bucket = ("Epic-Druid-"..e.other:CharacterID());
+			local data_bucket = ("Epic-Druid-"..e.other:CharacterID());
 
-		local epic_pre_onefive	= nil;	-- Epic 1.5 Pre Quest Status
-		local epic_onefive		= nil;	-- Epic 1.5 Status
-		local epic_two			= nil;	-- Epic 2.0 Status
-		local epic_twofive		= nil;	-- Epic 2.5 Status
-		local s					= nil;	-- Status Array
+			local epic_pre_onefive	= nil;	-- Epic 1.5 Pre Quest Status
+			local epic_onefive		= nil;	-- Epic 1.5 Status
+			local epic_two			= nil;	-- Epic 2.0 Status
+			local epic_twofive		= nil;	-- Epic 2.5 Status
+			local s					= nil;	-- Status Array
 
-		if eq.get_data(data_bucket) ~= "" then -- Has Started
-			local temp = eq.get_data(data_bucket);
-			s = eq.split(temp, ',');
-	
-			epic_pre_onefive	= tonumber(s[1]);
-			epic_onefive		= tonumber(s[2]);		
-			epic_two			= tonumber(s[3]);
-			epic_twofive		= tonumber(s[4]);
-		else -- Set variables to 0 and update databuckets
-			epic_pre_onefive = 0;
-			epic_onefive = 0;
-			epic_two = 0;
-			epic_twofive = 0;
-			update_druid_epic_databucket(e,epic_pre_onefive,epic_onefive,epic_two,epic_twofive);
-		end
-
-		if epic_pre_onefive == 0 and not e.other:HasItem(20490) then -- Doesn't have Nature Walkers Scimitar (Epic 1.0)
-			if e.message:findi("hail") then
-				e.other:Message(MT.NPCQuestSay, "Derick Goodroot says 'No I don't have anything for sale and no I don't want any of your filthy 'money', can't you see I have important [work] to do? Why don't you go talk to that banker and give it to him. There has been nothing but trouble since you all arrived. I'm sick and tired of you people traipsing through here like you own the place. Before you know it, this place will be a smelly den of inequity like Qeynos. I'd like to take that Banker Mardalson and all the rest and feed them to the [river]!'");
-			elseif e.message:findi("work") then
-				e.other:Message(MT.NPCQuestSay, "Derick Goodroot says 'I prepare seeds for planting to replace the ruin that those accursed Wayfarers have made of the forest. What would you know about it? I don't suppose you have any viable seeds in your pocket? I didn't think so. Just once I'd like to find some new seeds.' Derick looks lost in thought for a moment before barking, 'Go off to your adventures and leave me be. If you have to speak to me again then bring me a good seed or I'll not tolerate you in my home.'");
-			elseif e.message:findi("river") then
-				e.other:Message(MT.NPCQuestSay, "Derick Goodroot says 'Yeah, go have yourself a nice walk and visit the river. Say hello to the [Potameids] while you're there. They'll be as happy as I am to see you.'");
-			elseif e.message:findi("Potameids") then
-				e.other:Message(MT.NPCQuestSay, "Derick Goodroot says 'Yes, Potameids. Water Nymphs. They guard the river. Legend has it that long ago the Unkempt asked their queen to prevent intruders from crossing the river and entering the Unkempt Woods. The Queen agreed and now to this day everyone that gets close to the river is seldom heard from again. Why don't you go take a look already and leave me alone!'");
-				update_druid_epic_databucket(e,1,epic_onefive,epic_two,epic_twofive);
+			if eq.get_data(data_bucket) ~= "" then -- Has Started
+				local temp = eq.get_data(data_bucket);
+				s = eq.split(temp, ',');
+		
+				epic_pre_onefive	= tonumber(s[1]);
+				epic_onefive		= tonumber(s[2]);		
+				epic_two			= tonumber(s[3]);
+				epic_twofive		= tonumber(s[4]);
+			else -- Set variables to 0 and update databuckets
+				epic_pre_onefive = 0;
+				epic_onefive = 0;
+				epic_two = 0;
+				epic_twofive = 0;
+				update_druid_epic_databucket(e,epic_pre_onefive,epic_onefive,epic_two,epic_twofive);
 			end
-		elseif epic_pre_onefive == 2 and e.message:findi("seed") then
-			e.other:Message(MT.NPCQuestSay, "Derick Goodroot says 'If you can find the text for the ritual, I'll help you with it. Bring it to me and I think we can make it work. It's unlikely that any such text exists, though, so don't get your hopes up.'");
+
+			if epic_pre_onefive == 0 and not e.other:HasItem(20490) then -- Doesn't have Nature Walkers Scimitar (Epic 1.0)
+				if e.message:findi("hail") then
+					e.other:Message(MT.NPCQuestSay, "Derick Goodroot says 'No I don't have anything for sale and no I don't want any of your filthy 'money', can't you see I have important [work] to do? Why don't you go talk to that banker and give it to him. There has been nothing but trouble since you all arrived. I'm sick and tired of you people traipsing through here like you own the place. Before you know it, this place will be a smelly den of inequity like Qeynos. I'd like to take that Banker Mardalson and all the rest and feed them to the [river]!'");
+				elseif e.message:findi("work") then
+					e.other:Message(MT.NPCQuestSay, "Derick Goodroot says 'I prepare seeds for planting to replace the ruin that those accursed Wayfarers have made of the forest. What would you know about it? I don't suppose you have any viable seeds in your pocket? I didn't think so. Just once I'd like to find some new seeds.' Derick looks lost in thought for a moment before barking, 'Go off to your adventures and leave me be. If you have to speak to me again then bring me a good seed or I'll not tolerate you in my home.'");
+				elseif e.message:findi("river") then
+					e.other:Message(MT.NPCQuestSay, "Derick Goodroot says 'Yeah, go have yourself a nice walk and visit the river. Say hello to the [Potameids] while you're there. They'll be as happy as I am to see you.'");
+				elseif e.message:findi("Potameids") then
+					e.other:Message(MT.NPCQuestSay, "Derick Goodroot says 'Yes, Potameids. Water Nymphs. They guard the river. Legend has it that long ago the Unkempt asked their queen to prevent intruders from crossing the river and entering the Unkempt Woods. The Queen agreed and now to this day everyone that gets close to the river is seldom heard from again. Why don't you go take a look already and leave me alone!'");
+					update_druid_epic_databucket(e,1,epic_onefive,epic_two,epic_twofive);
+				end
+			elseif epic_pre_onefive == 2 and e.message:findi("seed") then
+				e.other:Message(MT.NPCQuestSay, "Derick Goodroot says 'If you can find the text for the ritual, I'll help you with it. Bring it to me and I think we can make it work. It's unlikely that any such text exists, though, so don't get your hopes up.'");
+			end
 		end
 	end
 end
@@ -128,35 +133,38 @@ end
 
 function event_trade(e)
 	local item_lib = require("items");
-	if e.other:HasClass(Class.DRUID) then
-		local data_bucket = ("Epic-Druid-"..e.other:CharacterID());
 
-		if eq.get_data(data_bucket) ~= "" then
-			local temp = eq.get_data(data_bucket);
-			s = eq.split(temp, ',');
+	if not epic_disabled then
+		if e.other:HasClass(Class.DRUID) then
+			local data_bucket = ("Epic-Druid-"..e.other:CharacterID());
 
-			local epic_pre_onefive	= tonumber(s[1]);
-			local epic_onefive		= tonumber(s[2]);		
-			local epic_two			= tonumber(s[3]);
-			local epic_twofive		= tonumber(s[4]);
+			if eq.get_data(data_bucket) ~= "" then
+				local temp = eq.get_data(data_bucket);
+				s = eq.split(temp, ',');
 
-			if epic_pre_onefive == 1 and item_lib.check_turn_in(e.trade, {item1 = 62800}) then -- Items: Redwood Seed
-				e.other:Message(MT.NPCQuestSay, "Derick Goodroot says 'This is a wonderful specimen, unblemished and healthy. You know, if I had a seed like this I might just try one of those Unkempt [seed rituals], that is if they hadn't been lost along with the Unkempt so many years ago. It's unlikely that any record of them exists these days. Why, there was one ritual that they say could evolve a redwood seed into something new and powerful.'");
-				e.other:SummonItem(62800); -- Item: Redwood Seed
-				update_druid_epic_databucket(e,2,epic_onefive,epic_two,epic_twofive);
-			elseif epic_pre_onefive == 2 and item_lib.check_turn_in(e.trade, {item1 = 62801}) then -- Items: Unkempt Seed Rituals
-				e.other:Message(MT.NPCQuestSay, "Derick Goodroot says 'Well you actually found it. It has a new cover, but most of the original pages seem to be here. I can't read all of this very well. Nobody reads this language anymore, but I think I understand the basics. You will need some high quality loam and some magic earth. Marshes are a good place to find loam. Magical soil might be a problem, but certainly you can find some that will work. These two items are used to create the cleansing loam. It's the third item that I don't like. I know the Unkempt were different than we are, but I find this hard to believe. The ritual seems to say that you must take the seed and insert it into the heart of a noble creature to give it strength, then rest that in the loam and earth. I don't like the idea of killing anything noble for such a ritual. I'm not sure what I think of this whole thing now. I'll leave that up to you. Here is a pot that you can use for the ritual. If you still want to do this and you find a heart that might work, bring it to me and I'll see if I can help.'");
-				e.other:SummonItem(62802); -- Item: Aerated Pot
-				update_druid_epic_databucket(e,3,epic_onefive,epic_two,epic_twofive);
-			elseif epic_pre_onefive == 4 and item_lib.check_turn_in(e.trade, {item1 = 62805}) then -- Items: Corrupted Storm Giant Heart
-				e.other:Message(MT.NPCQuestSay, "Derick Goodroot sighs. 'I suppose you had no option if he was corrupt. I might even be able to help you purify it for use. I'm not sure how well it will work with the seed ritual. I'm certain that the original intent was to rip the heart from an honorable foe. Here, take this bowl. You'll need to go back to the Plane of Storms and find some pure rain water to cleanse the hart. Pouring the water over the heart while in the bowl, should purify it, though it might also destroy the bowl. Never mind that, though. If it works you should be able to use the heart for the ritual. Please bring me the seed when you are done. I'd like to see it.'");
-				e.other:SummonItem(62805); -- Item: Corrupted Storm Giant Heart
-				e.other:SummonItem(62807); -- Item: Cleansing Bowl
-				update_druid_epic_databucket(e,5,epic_onefive,epic_two,epic_twofive);
-			elseif epic_pre_onefive == 5 and item_lib.check_turn_in(e.trade, {item1 = 62809}) then -- Items: Seed of Wrath
-				e.other:Message(MT.NPCQuestSay, "Derick Goodroot says, 'Wonderful! This is an amazing seed. It has a resonance of the power of life that seems familiar. It reminds me very much of the feeling I get when one of the Storm Wardens come through here with their Nature Walkers Scimitars. It's a thrill to be able to examine it, thank you.'");
-				e.other:SummonItem(62809); -- Items: Seed of Wrath
-				update_druid_epic_databucket(e,6,epic_onefive,epic_two,epic_twofive);
+				local epic_pre_onefive	= tonumber(s[1]);
+				local epic_onefive		= tonumber(s[2]);		
+				local epic_two			= tonumber(s[3]);
+				local epic_twofive		= tonumber(s[4]);
+
+				if epic_pre_onefive == 1 and item_lib.check_turn_in(e.trade, {item1 = 62800}) then -- Items: Redwood Seed
+					e.other:Message(MT.NPCQuestSay, "Derick Goodroot says 'This is a wonderful specimen, unblemished and healthy. You know, if I had a seed like this I might just try one of those Unkempt [seed rituals], that is if they hadn't been lost along with the Unkempt so many years ago. It's unlikely that any record of them exists these days. Why, there was one ritual that they say could evolve a redwood seed into something new and powerful.'");
+					e.other:SummonItem(62800); -- Item: Redwood Seed
+					update_druid_epic_databucket(e,2,epic_onefive,epic_two,epic_twofive);
+				elseif epic_pre_onefive == 2 and item_lib.check_turn_in(e.trade, {item1 = 62801}) then -- Items: Unkempt Seed Rituals
+					e.other:Message(MT.NPCQuestSay, "Derick Goodroot says 'Well you actually found it. It has a new cover, but most of the original pages seem to be here. I can't read all of this very well. Nobody reads this language anymore, but I think I understand the basics. You will need some high quality loam and some magic earth. Marshes are a good place to find loam. Magical soil might be a problem, but certainly you can find some that will work. These two items are used to create the cleansing loam. It's the third item that I don't like. I know the Unkempt were different than we are, but I find this hard to believe. The ritual seems to say that you must take the seed and insert it into the heart of a noble creature to give it strength, then rest that in the loam and earth. I don't like the idea of killing anything noble for such a ritual. I'm not sure what I think of this whole thing now. I'll leave that up to you. Here is a pot that you can use for the ritual. If you still want to do this and you find a heart that might work, bring it to me and I'll see if I can help.'");
+					e.other:SummonItem(62802); -- Item: Aerated Pot
+					update_druid_epic_databucket(e,3,epic_onefive,epic_two,epic_twofive);
+				elseif epic_pre_onefive == 4 and item_lib.check_turn_in(e.trade, {item1 = 62805}) then -- Items: Corrupted Storm Giant Heart
+					e.other:Message(MT.NPCQuestSay, "Derick Goodroot sighs. 'I suppose you had no option if he was corrupt. I might even be able to help you purify it for use. I'm not sure how well it will work with the seed ritual. I'm certain that the original intent was to rip the heart from an honorable foe. Here, take this bowl. You'll need to go back to the Plane of Storms and find some pure rain water to cleanse the hart. Pouring the water over the heart while in the bowl, should purify it, though it might also destroy the bowl. Never mind that, though. If it works you should be able to use the heart for the ritual. Please bring me the seed when you are done. I'd like to see it.'");
+					e.other:SummonItem(62805); -- Item: Corrupted Storm Giant Heart
+					e.other:SummonItem(62807); -- Item: Cleansing Bowl
+					update_druid_epic_databucket(e,5,epic_onefive,epic_two,epic_twofive);
+				elseif epic_pre_onefive == 5 and item_lib.check_turn_in(e.trade, {item1 = 62809}) then -- Items: Seed of Wrath
+					e.other:Message(MT.NPCQuestSay, "Derick Goodroot says, 'Wonderful! This is an amazing seed. It has a resonance of the power of life that seems familiar. It reminds me very much of the feeling I get when one of the Storm Wardens come through here with their Nature Walkers Scimitars. It's a thrill to be able to examine it, thank you.'");
+					e.other:SummonItem(62809); -- Items: Seed of Wrath
+					update_druid_epic_databucket(e,6,epic_onefive,epic_two,epic_twofive);
+				end
 			end
 		end
 	end

--- a/kithicor/Tarnamil.lua
+++ b/kithicor/Tarnamil.lua
@@ -1,16 +1,22 @@
 --kithicor/Tarnamil.lua NPCID 20199
 --SK Epic 1.5
+
+local epic_disabled = true; -- Disabling for omens (epics) cannot reference perl expansion vars from lua.
+
 function event_say(e)
 	local qglobals = eq.get_qglobals(e.other);
-	if(e.message:findi("hail") and qglobals["shadowknight_epic"] == "7") then
-		e.self:Say("The paladins are coming from the west, my lord. The come to destroy the dead that walk at night. Already, the undead generals plot their demise, but they are powerful. They approach soon. I am getting out of here.");
-		 eq.spawn2(20293 ,0,0,1774,708,210,112); --Uglib Gaibido
-		 eq.spawn2(20294 ,0,0,1859,741,219,296); -- Xotmidd Ferlop
-		 eq.spawn2(20295 ,0,0,1856,686,219,472); --Jarnig Kilanid
-		 eq.spawn2(20298 ,0,0,1839,669,217,40); --Tilminos Farondi
-		 eq.spawn2(20297 ,0,0,1872,700,221,384); --Shressa Farondi
-		 eq.spawn2(20296 ,0,0,1819,731,215,216); --Valinda Ergington
-		 eq.depop_with_timer();
+
+	if not epic_disabled then
+		if e.message:findi("hail") and qglobals["shadowknight_epic"] ~= nil and qglobals["shadowknight_epic"] == "7" then
+			e.self:Say("The paladins are coming from the west, my lord. The come to destroy the dead that walk at night. Already, the undead generals plot their demise, but they are powerful. They approach soon. I am getting out of here.");
+			eq.spawn2(20293 ,0,0,1774,708,210,112); --Uglib Gaibido
+			eq.spawn2(20294 ,0,0,1859,741,219,296); -- Xotmidd Ferlop
+			eq.spawn2(20295 ,0,0,1856,686,219,472); --Jarnig Kilanid
+			eq.spawn2(20298 ,0,0,1839,669,217,40); --Tilminos Farondi
+			eq.spawn2(20297 ,0,0,1872,700,221,384); --Shressa Farondi
+			eq.spawn2(20296 ,0,0,1819,731,215,216); --Valinda Ergington
+			eq.depop_with_timer();
+		end
 	end
 end
 
@@ -18,5 +24,3 @@ function event_trade(e)
 	local item_lib = require("items");
 	item_lib.return_items(e.self, e.other, e.trade);
 end
-	
-	

--- a/lakerathe/#Kimm_McShannel.lua
+++ b/lakerathe/#Kimm_McShannel.lua
@@ -1,44 +1,51 @@
 --lakerathe/Kimm_McShannel.lua NPCID 51159
 --Shaman Epic 1.5
 -- items: 52922, 52926, 57600, 57088, 57560, 57614
+
+local epic_disabled = true; -- Disabling for omens (epics) cannot reference perl expansion vars from lua.
+
 function event_say(e)
 	local qglobals = eq.get_qglobals(e.other);
-	if(e.message:findi("elder spirit sent me") and qglobals["shaman_epic"] == "1") then
-		e.self:Say("Aye, well then. Watch yerself. Thar be a crazy fella over there. Been trying for days, I 'ave, to get 'im to make some sense about this megalodon creature 'e keeps prattling on about. I been a bit shy o' stepping in the lake to get some seaweed for the spirit's potion. Maybe you could go take a look. Somethin' usually comes by to snap 'em up when they grow, so ye may need to route around a tad out there. You think you are [" .. eq.say_link("up to it") .. "]?");
-	elseif(e.message:findi("up to it") and qglobals["shaman_epic"] == "1") then
-		e.self:Say("Very well, then, off you go in search of the seaweed.");
-		eq.unique_spawn(51160,0,0,2812,-771,-199,292); --Ancient Megalodon
-	elseif(e.message:findi("break down") and qglobals["shaman_epic"] == "5") then
-		e.self:Say("As most things, the process is not a simple one and we'll need some ingredients for a special potion. You must retrieve four items, which should not prove difficult for a shaman of your stature. They are very specific and I can tell you more about the [" .. eq.say_link("skin") .. "], the [" .. eq.say_link("powder") .. "], the [" .. eq.say_link("tooth") .. "], and the [" .. eq.say_link("goo") .. "]. When you have all of these things, use my medicine bag to create this potion and return it to me.");
-		e.other:SummonItem(52922); --Heyokah Medicine Bag
-	elseif(e.message:findi("skin") and qglobals["shaman_epic"] == "5") then
-		e.self:Say("First, you must find your way to Kuua for part of the potion. There you will find a foul hound of flesh with no fur and fangs. We need a perfect specimen of some of its skin for our potion. Three should do nicely.");
-	elseif(e.message:findi("powder") and qglobals["shaman_epic"] == "5") then
-		e.self:Say("The powder is very unique and can be difficult to obtain -- many have died trying as it's a coveted magic. There is an undead fiend that uses this powder to turn many creatures and darken them. It is a beast in a sickly plane which makes it that much more challenging, of course. This powder is needed so that we can use a pinch of it to attract the Spirit of Might close enough to us to have it turn its back on the path of the wasichu.");
-	elseif(e.message:findi("tooth") and qglobals["shaman_epic"] == "5") then
-		e.self:Say("In suffocating lands, there are a few revenants with a marrow that we need. It's a rather unpleasant task and I'm sure they won't cooperate. You must find four of their teeth.");
-	elseif(e.message:findi("goo") and qglobals["shaman_epic"] == "5") then
-		e.self:Say("The goo is very special and will provide a strong acidic base for the agent we are creating. You will find it deep where the spirits groan and drift, where it seems even the walls howl in agony. There is only one creature that produces this goo that we use to separate gem from metal. It is very deep within that place. You should try to obtain two samples of goo.");
+
+	if not epic_disabled and qglobals["shaman_epic"] ~= nil then
+		if(e.message:findi("elder spirit sent me") and qglobals["shaman_epic"] == "1") then
+			e.self:Say("Aye, well then. Watch yerself. Thar be a crazy fella over there. Been trying for days, I 'ave, to get 'im to make some sense about this megalodon creature 'e keeps prattling on about. I been a bit shy o' stepping in the lake to get some seaweed for the spirit's potion. Maybe you could go take a look. Somethin' usually comes by to snap 'em up when they grow, so ye may need to route around a tad out there. You think you are [" .. eq.say_link("up to it") .. "]?");
+		elseif(e.message:findi("up to it") and qglobals["shaman_epic"] == "1") then
+			e.self:Say("Very well, then, off you go in search of the seaweed.");
+			eq.unique_spawn(51160,0,0,2812,-771,-199,292); --Ancient Megalodon
+		elseif(e.message:findi("break down") and qglobals["shaman_epic"] == "5") then
+			e.self:Say("As most things, the process is not a simple one and we'll need some ingredients for a special potion. You must retrieve four items, which should not prove difficult for a shaman of your stature. They are very specific and I can tell you more about the [" .. eq.say_link("skin") .. "], the [" .. eq.say_link("powder") .. "], the [" .. eq.say_link("tooth") .. "], and the [" .. eq.say_link("goo") .. "]. When you have all of these things, use my medicine bag to create this potion and return it to me.");
+			e.other:SummonItem(52922); --Heyokah Medicine Bag
+		elseif(e.message:findi("skin") and qglobals["shaman_epic"] == "5") then
+			e.self:Say("First, you must find your way to Kuua for part of the potion. There you will find a foul hound of flesh with no fur and fangs. We need a perfect specimen of some of its skin for our potion. Three should do nicely.");
+		elseif(e.message:findi("powder") and qglobals["shaman_epic"] == "5") then
+			e.self:Say("The powder is very unique and can be difficult to obtain -- many have died trying as it's a coveted magic. There is an undead fiend that uses this powder to turn many creatures and darken them. It is a beast in a sickly plane which makes it that much more challenging, of course. This powder is needed so that we can use a pinch of it to attract the Spirit of Might close enough to us to have it turn its back on the path of the wasichu.");
+		elseif(e.message:findi("tooth") and qglobals["shaman_epic"] == "5") then
+			e.self:Say("In suffocating lands, there are a few revenants with a marrow that we need. It's a rather unpleasant task and I'm sure they won't cooperate. You must find four of their teeth.");
+		elseif(e.message:findi("goo") and qglobals["shaman_epic"] == "5") then
+			e.self:Say("The goo is very special and will provide a strong acidic base for the agent we are creating. You will find it deep where the spirits groan and drift, where it seems even the walls howl in agony. There is only one creature that produces this goo that we use to separate gem from metal. It is very deep within that place. You should try to obtain two samples of goo.");
+		end
 	end
 end
 
 function event_trade(e)
 	local qglobals = eq.get_qglobals(e.other);
 	local item_lib = require("items");
-	if(item_lib.check_turn_in(e.trade, {item1 = 52926})) then --hand in Lustrous Seaweed (looted from Ancient Megalodon)
-		e.self:Say("Well done! And ye got it off that great creature? Aye, it really exists. Guess that mad feller ain't so mad, now, is he? Ha! Well, we have a better chance at saving the spirit. Take this seaweed back. I've wrapped it for you. Now, get moving!");
-		e.other:SummonItem(57600); --Twine-wrapped Lustrous Seaweed
-	end
-	if(item_lib.check_turn_in(e.trade, {item1 = 57088})) then --hand in Gemmed Bangle of Enlightenment (From Elder Spirit of Enlightenment after previous step)
-		e.self:Say("Aye, so ye have returned. We have much to do here, me friend. The first thing we must do is [" .. eq.say_link("break down") .. "] this bangle into its gems and metal. This here bangle was very carefully made. First, the gems were blessed by the spirits, then the metal itself as it was forged. Aye, we need to carefully separate them. The two gems were blessed by the spirits of Wisdom and Patience, and the metal was strengthened by the Spirit of Might. We will use these to call them back to us.");
-		eq.set_global("shaman_epic","5",5,"F");
-	end
-	if(item_lib.check_turn_in(e.trade, {item1 = 57560})) then --hand in Shaman's Precious Diffusing Agent (made from combining various drops for this stage, recipe likely needs added to db)
-		e.self:Emote("nods at you and reaches into her pocket and takes out the gemmed bangle and puts it on the ground. She takes the vial and slowly lets a few drops fall on the platinum. It seems to coil and bend and pulls itself into a small globe and the gems lazily fall onto the ground.");
-		e.self:Say("Perfect! Now, you must return the gems and platinum to the Spirit of Enlightenment. I've put it in a purse to keep them safe. You truly are beginning to surpass all of our expectations, " .. e.other:GetName() .. ".");
-		e.other:SummonItem(57614); --Runed Purse of the McShannels
+
+	if not epic_disabled then
+		if(item_lib.check_turn_in(e.trade, {item1 = 52926})) then --hand in Lustrous Seaweed (looted from Ancient Megalodon)
+			e.self:Say("Well done! And ye got it off that great creature? Aye, it really exists. Guess that mad feller ain't so mad, now, is he? Ha! Well, we have a better chance at saving the spirit. Take this seaweed back. I've wrapped it for you. Now, get moving!");
+			e.other:SummonItem(57600); --Twine-wrapped Lustrous Seaweed
+		end
+		if(item_lib.check_turn_in(e.trade, {item1 = 57088})) then --hand in Gemmed Bangle of Enlightenment (From Elder Spirit of Enlightenment after previous step)
+			e.self:Say("Aye, so ye have returned. We have much to do here, me friend. The first thing we must do is [" .. eq.say_link("break down") .. "] this bangle into its gems and metal. This here bangle was very carefully made. First, the gems were blessed by the spirits, then the metal itself as it was forged. Aye, we need to carefully separate them. The two gems were blessed by the spirits of Wisdom and Patience, and the metal was strengthened by the Spirit of Might. We will use these to call them back to us.");
+			eq.set_global("shaman_epic","5",5,"F");
+		end
+		if(item_lib.check_turn_in(e.trade, {item1 = 57560})) then --hand in Shaman's Precious Diffusing Agent (made from combining various drops for this stage, recipe likely needs added to db)
+			e.self:Emote("nods at you and reaches into her pocket and takes out the gemmed bangle and puts it on the ground. She takes the vial and slowly lets a few drops fall on the platinum. It seems to coil and bend and pulls itself into a small globe and the gems lazily fall onto the ground.");
+			e.self:Say("Perfect! Now, you must return the gems and platinum to the Spirit of Enlightenment. I've put it in a purse to keep them safe. You truly are beginning to surpass all of our expectations, " .. e.other:GetName() .. ".");
+			e.other:SummonItem(57614); --Runed Purse of the McShannels
+		end
 	end
 	item_lib.return_items(e.self, e.other, e.trade);
 end
-	
-	

--- a/neriakb/Fleshweaver_T-soma.lua
+++ b/neriakb/Fleshweaver_T-soma.lua
@@ -28,7 +28,7 @@ function event_trade(e)
 		eq.set_global("tsoma", "2", 5, "F"); -- Completed tsoma Second Task
 	elseif qglobals["tsoma"] ~= nil and qglobals["tsoma"] == "3" and item_lib.check_turn_in(e.trade, {item1 = 63015}) then -- Item: Fleshless Heart and flag
 		e.self:Say("Apparently our ignorance exceeded our luck. Ah well, I'm sure the Prince of Hate will find some other punishment for our folly. Well, since you too chance his anger I suppose you deserve a reward. Here, take this...though I'm not sure how much use it will be against a god.");
-		if e.other:HasClass() == Class.WARRIOR or e.other:HasClass() == Class.PALADIN or e.other:HasClass() == Class.RANGER or e.other:HasClass() == Class.SHADOWKNIGHT or e.other:HasClass() == Class.BARD or e.other:HasClass() == Class.ROGUE then
+		if e.other:HasClass(Class.WARRIOR) or e.other:HasClass(Class.PALADIN) or e.other:HasClass(Class.RANGER) or e.other:HasClass(Class.SHADOWKNIGHT) or e.other:HasClass(Class.BARD) or e.other:HasClass(Class.ROGUE) then
 			e.other:SummonItem(63052); -- Item: Heartspike
 			e.other:Ding();
 			e.other:AddEXP(5000);

--- a/oot/Gubblegrot_Smashfist.lua
+++ b/oot/Gubblegrot_Smashfist.lua
@@ -1,17 +1,23 @@
 --oot/Gubblegrot_Smashfist.lua NPCID 69140
 --SK Epic 1.5
+
+local epic_disabled = true; -- Disabling for omens (epics) cannot reference perl expansion vars from lua.
+
 function event_say(e)
-	local qglobals = eq.get_qglobals(e.other);	
-	if(e.message:findi("hail")) then
-		if ( qglobals["shadowknight_epic"] == "6") then
-			e.self:Say("smasshh!");
-			e.self:SetSpecialAbility(19, 0);
-			e.self:SetSpecialAbility(20, 0);
-			e.self:SetSpecialAbility(24, 0);
-			e.self:SetSpecialAbility(25, 0);
-			e.self:SetSpecialAbility(35, 0);
-			e.self:SetLevel(66);
-			e.self:AddToHateList(e.other,1); 
+	local qglobals = eq.get_qglobals(e.other);
+
+	if not epic_disabled then
+		if e.message:findi("hail") then
+			if qglobals["shadowknight_epic"] ~= nil and qglobals["shadowknight_epic"] == "6" then
+				e.self:Say("smasshh!");
+				e.self:SetSpecialAbility(19, 0);
+				e.self:SetSpecialAbility(20, 0);
+				e.self:SetSpecialAbility(24, 0);
+				e.self:SetSpecialAbility(25, 0);
+				e.self:SetSpecialAbility(35, 0);
+				e.self:SetLevel(66);
+				e.self:AddToHateList(e.other,1);
+			end
 		end
 	end
 end
@@ -20,5 +26,3 @@ function event_trade(e)
 	local item_lib = require("items");
 	item_lib.return_items(e.self, e.other, e.trade);
 end
-	
-	

--- a/poknowledge/Gilina_Yilzior.lua
+++ b/poknowledge/Gilina_Yilzior.lua
@@ -1,55 +1,66 @@
 --poknowledge/Gilina_Yilzior.lua NPCID 202267
 --SK Epic 1.5 and 2.0
 -- items: 11407, 20899, 16813, 16793, 20079, 22199, 20904, 55901, 50003, 19098, 24612, 23489, 24632, 24584
+
+local epic_disabled = true; -- Disabling for omens (epics) cannot reference perl expansion vars from lua.
+
+
 function event_say(e)
 	local qglobals = eq.get_qglobals(e.other);
-	if(e.other:HasClass(Class.SHADOWKNIGHT)) then
-		if(e.message:findi("vision") and e.other:HasItem(50003)) then
-			if(qglobals["shadowknight_epic"] == nil or tonumber(qglobals["shadowknight_epic"]) < 9) then
-				eq.set_global("shadowknight_epic","9",5,"F");
-			end
-			e.self:Say("My recent vision was of Lhranc. Perhaps you remember him, perhaps not. In any case, his spirit has returned from the dead. He now seeks revenge on those who killed him. There is something sinister behind his return. What exactly is going on, I do not know at this time, but I fear the worst. You must find Lhranc and [" ..eq.say_link('destroy', false, 'destroy') .. "] him.");
-		elseif(e.message:findi("destroy") and qglobals["shadowknight_epic"] == "9") then
-			e.self:Say("'I sent a servant of mine named, Kilidna to the City of Mist to investigate Lhranc's reappearance but he has not returned. Go to the City of Mist and see if you can find him. Return to me if you find anything.");
-		elseif(e.message:findi("powerful beings") and qglobals["shadowknight_epic"] == "10") then
-			e.self:Say("Yes, what powerful beings? Out with it, head!' 'Well, master, one of these powerful beings has resurrected Lhranc from the dead! When I confronted him, he turned me into a mindless zombie! I overheard Lhranc talking about recovering the sword for himself. You are both in great danger! Lhranc cannot be defeated in his current form and he will surely be coming for the sword!' Gilina tosses Kilidna's head aside. 'Thank you, Kilidna. Your services are no longer required. Well it seems we have quite the [" ..eq.say_link('dilemma', false, 'dilemma') .. "] on our hands, wouldn't you say?");
-		elseif(e.message:findi("dilemma") and qglobals["shadowknight_epic"] == "10") then	
-			e.self:Say("Luckily, I have much knowledge of Lhranc, the first of the shadowknights. We must find a way to anchor him to this plane so that he will be vulnerable to our attacks. I believe if we recover some items of his from his former life, we may be able to accomplish this. First, you will need to find his pendant. Look for it in the City of Mist. Next, you will need to recover Lhranc's corroded bracer from Charasis. Lastly, you will need to find Lhranc's ring from the undead in the Kithicor Woods. Once you have all these items, return them to me.");	
-		end	
-	end	
+
+	if not epic_disabled then
+		if(e.other:HasClass(Class.SHADOWKNIGHT)) then
+			if(e.message:findi("vision") and e.other:HasItem(50003)) then
+				if(qglobals["shadowknight_epic"] == nil or tonumber(qglobals["shadowknight_epic"]) < 9) then
+					eq.set_global("shadowknight_epic","9",5,"F");
+				end
+				e.self:Say("My recent vision was of Lhranc. Perhaps you remember him, perhaps not. In any case, his spirit has returned from the dead. He now seeks revenge on those who killed him. There is something sinister behind his return. What exactly is going on, I do not know at this time, but I fear the worst. You must find Lhranc and [" ..eq.say_link('destroy', false, 'destroy') .. "] him.");
+			elseif(e.message:findi("destroy") and qglobals["shadowknight_epic"] == "9") then
+				e.self:Say("'I sent a servant of mine named, Kilidna to the City of Mist to investigate Lhranc's reappearance but he has not returned. Go to the City of Mist and see if you can find him. Return to me if you find anything.");
+			elseif(e.message:findi("powerful beings") and qglobals["shadowknight_epic"] == "10") then
+				e.self:Say("Yes, what powerful beings? Out with it, head!' 'Well, master, one of these powerful beings has resurrected Lhranc from the dead! When I confronted him, he turned me into a mindless zombie! I overheard Lhranc talking about recovering the sword for himself. You are both in great danger! Lhranc cannot be defeated in his current form and he will surely be coming for the sword!' Gilina tosses Kilidna's head aside. 'Thank you, Kilidna. Your services are no longer required. Well it seems we have quite the [" ..eq.say_link('dilemma', false, 'dilemma') .. "] on our hands, wouldn't you say?");
+			elseif(e.message:findi("dilemma") and qglobals["shadowknight_epic"] == "10") then	
+				e.self:Say("Luckily, I have much knowledge of Lhranc, the first of the shadowknights. We must find a way to anchor him to this plane so that he will be vulnerable to our attacks. I believe if we recover some items of his from his former life, we may be able to accomplish this. First, you will need to find his pendant. Look for it in the City of Mist. Next, you will need to recover Lhranc's corroded bracer from Charasis. Lastly, you will need to find Lhranc's ring from the undead in the Kithicor Woods. Once you have all these items, return them to me.");	
+			end	
+		end
+	end
 end
+
 function event_trade(e)
 	local qglobals = eq.get_qglobals(e.other);
 	local item_lib = require("items");
-	if(qglobals["shadowknight_epic"] == "5" and item_lib.check_turn_in(e.trade, {item1 = 11407})) then --hand in first version of Sheathed Innoruuk's Voice
-		e.self:Emote("looks at you with a cold stare.");
-		e.self:Say("The time has come. I have heard the dark blade's whispers. It wants to find a master, but before that can become a reality, a test must be passed. There are four other shadowknights who wish to become the sword's wielder. If you are up for the challenge, then seek out Silithis Sisnta in the Timorous Deep, Gubblegrot Smashfist in the Ocean of Tears, Skurza Slicekutt in the Swamp of No Hope, and Giligatabbus Igglebix in Iceclad Ocean. Return their heads to me and we shall see if the sword is satisfied with your progress.");
-		eq.set_global("shadowknight_epic","6",5,"F");
-	end
-	if(qglobals["shadowknight_epic"] == "6" and item_lib.check_turn_in(e.trade, {item1 = 20899, item2 = 16813, item3  = 16793, item4 = 20079})) then --hand in Silithis's Head (drops from Silithis Sisnta in Timorous Deep), Gubblegrot's Head (drops from Gubblegrot Smashfist in OoT), Skurza's Head (drops from Skurza Slicekutt in Swamp of No Hope), and Giligatabbus's Head (drops from Giligatabbus Igglebix in Iceclad Ocean)
-		e.self:Say("I can sense that the sword is pleased with your progress. However there is another task it wishes you to perform. I have learned through a contact of mine, that there is to be a ceremony in Kithicor Woods. Several paladins will be converging there to try to cleanse the undead from the forest, once and for all. The blade thirsts for the blood of these paladins. Before the blade will allow you to become its champion, you must kill as many of these paladins as you can, and bring me three samples of their blood. Take the Sheathed Innoruuk's Voice back and when you have three samples of paladin's blood, hand them to me along with the Sheathed Innoruuk's Voice so that I may perform the ceremony to sate the blade's thirst. Go now and find my contact in Kithicor. His name is Tarnamil. Take the sword back for safe keeping.");
-		e.other:SummonItem(22199); --2nd version of Sheathed Innoruuk's Voice
-		eq.set_global("shadowknight_epic","7",5,"F");
-	end
-	if(qglobals["shadowknight_epic"] == "7" and item_lib.check_turn_in(e.trade, {item1 = 20904, item2 = 20904, item3  = 20904, item4 = 22199})) then --hand in 3x Paladin Blood Sample (from Paladins in Kithicor Forest Event) and 2nd version of Sheathed Innoruuk's Voice (Received after last step)
-		e.self:Say("Well done.' Gilina takes the blood samples starts to pour them onto the blade of Innoruuk's Voice. The blade appears to become super-heated as the blood drops trickle down its surface. A thick black smoke begins to waft from the blade. 'The blade is now complete. Before I give the blade to you there is something else you must do. A mighty templar named Sir Elmonious Falmont has heard of your crimes against the paladins and seeks revenge. It is important that we let none get in the way of our goals. As we speak, he is making his way from the Western Wastes in the continent of Velious to kill us. Destroy him and return his holy symbol to me.");
-		eq.set_global("shadowknight_epic","8",5,"F");
-	end
-	if(qglobals["shadowknight_epic"] == "8" and item_lib.check_turn_in(e.trade, {item1 = 55901})) then --hand in Sir Elmonious's Holy Symbol (drops from Sir Elmonious Falmont in Western Wastes)
-		e.self:Say("You have performed well. The blade is yours to wield now, champion. You may be on your way, or stay to hear about a [" ..eq.say_link('vision', false, 'vision') .. "] I recently had.");
-		e.other:SummonItem(50003); --Innoruuk's Voice (Epic 1.5)
-		e.other:AddAAPoints(5);
-		e.other:Ding();
-		e.other:Message(15,'You have gained 5 ability points!');
-	end
-	if(qglobals["shadowknight_epic"] == "9" and item_lib.check_turn_in(e.trade, {item1 = 19098})) then --hand in Kilidna's Head (drops from Kilidna in City of Mist)
-		e.self:Emote("takes the head from you and holds it by the hair. Gilina casts a small spell and the head springs to life.  'Talk, Kilidna. What has happened to you?' Kilidna's head begins to sob. 'I am sorry, master. I was corrupted by evil magic! Now look at me! I dare say I will not be able to finish my studies any time soon.' Gilina scowls, 'What did you find out while in the city of mist? Tell me now!' 'Well master, it seems that when Innoruuk's Voice was summoned to this plane, it drew the attention of many [" ..eq.say_link('powerful beings', false, 'powerful beings') .. "].'");
-		eq.set_global("shadowknight_epic","10",5,"F");
-	end
-	if(qglobals["shadowknight_epic"] == "10" and item_lib.check_turn_in(e.trade, {item1 = 24612, item2 = 23489, item3 = 24632})) then --hand in Lhranc's Corroded Bracer (dropped from golems in Charasis), Lhranc's Pendant (dropped from black reavers in City of Mist), Lhranc's Ring (dropped from various undead in Kithicor)
-		e.self:Emote("takes the items from you and holds them before you in her hands. She mutters an incantation and the items meld into one.");
-		e.self:Say("This item will be used to help anchor Lhranc to this plane of existence. The anchor will not be enough however. In an area in the Realm of Discord known as Anguish, you will need to find a globe of discordant energy. This will be used to infuse the earthly anchor with the power of discord. When you have these two items, hand them to my contact, Filligno the Slayer. He has tracked down Lhranc in Dranik, the Ruined City in the Realm of Discord. He will need your help to get Lhranc's attention however.");
-		e.other:SummonItem(24584); --Lhranc's Earthly Anchor
+
+	if not epic_disabled then
+		if(qglobals["shadowknight_epic"] == "5" and item_lib.check_turn_in(e.trade, {item1 = 11407})) then --hand in first version of Sheathed Innoruuk's Voice
+			e.self:Emote("looks at you with a cold stare.");
+			e.self:Say("The time has come. I have heard the dark blade's whispers. It wants to find a master, but before that can become a reality, a test must be passed. There are four other shadowknights who wish to become the sword's wielder. If you are up for the challenge, then seek out Silithis Sisnta in the Timorous Deep, Gubblegrot Smashfist in the Ocean of Tears, Skurza Slicekutt in the Swamp of No Hope, and Giligatabbus Igglebix in Iceclad Ocean. Return their heads to me and we shall see if the sword is satisfied with your progress.");
+			eq.set_global("shadowknight_epic","6",5,"F");
+		end
+		if(qglobals["shadowknight_epic"] == "6" and item_lib.check_turn_in(e.trade, {item1 = 20899, item2 = 16813, item3  = 16793, item4 = 20079})) then --hand in Silithis's Head (drops from Silithis Sisnta in Timorous Deep), Gubblegrot's Head (drops from Gubblegrot Smashfist in OoT), Skurza's Head (drops from Skurza Slicekutt in Swamp of No Hope), and Giligatabbus's Head (drops from Giligatabbus Igglebix in Iceclad Ocean)
+			e.self:Say("I can sense that the sword is pleased with your progress. However there is another task it wishes you to perform. I have learned through a contact of mine, that there is to be a ceremony in Kithicor Woods. Several paladins will be converging there to try to cleanse the undead from the forest, once and for all. The blade thirsts for the blood of these paladins. Before the blade will allow you to become its champion, you must kill as many of these paladins as you can, and bring me three samples of their blood. Take the Sheathed Innoruuk's Voice back and when you have three samples of paladin's blood, hand them to me along with the Sheathed Innoruuk's Voice so that I may perform the ceremony to sate the blade's thirst. Go now and find my contact in Kithicor. His name is Tarnamil. Take the sword back for safe keeping.");
+			e.other:SummonItem(22199); --2nd version of Sheathed Innoruuk's Voice
+			eq.set_global("shadowknight_epic","7",5,"F");
+		end
+		if(qglobals["shadowknight_epic"] == "7" and item_lib.check_turn_in(e.trade, {item1 = 20904, item2 = 20904, item3  = 20904, item4 = 22199})) then --hand in 3x Paladin Blood Sample (from Paladins in Kithicor Forest Event) and 2nd version of Sheathed Innoruuk's Voice (Received after last step)
+			e.self:Say("Well done.' Gilina takes the blood samples starts to pour them onto the blade of Innoruuk's Voice. The blade appears to become super-heated as the blood drops trickle down its surface. A thick black smoke begins to waft from the blade. 'The blade is now complete. Before I give the blade to you there is something else you must do. A mighty templar named Sir Elmonious Falmont has heard of your crimes against the paladins and seeks revenge. It is important that we let none get in the way of our goals. As we speak, he is making his way from the Western Wastes in the continent of Velious to kill us. Destroy him and return his holy symbol to me.");
+			eq.set_global("shadowknight_epic","8",5,"F");
+		end
+		if(qglobals["shadowknight_epic"] == "8" and item_lib.check_turn_in(e.trade, {item1 = 55901})) then --hand in Sir Elmonious's Holy Symbol (drops from Sir Elmonious Falmont in Western Wastes)
+			e.self:Say("You have performed well. The blade is yours to wield now, champion. You may be on your way, or stay to hear about a [" ..eq.say_link('vision', false, 'vision') .. "] I recently had.");
+			e.other:SummonItem(50003); --Innoruuk's Voice (Epic 1.5)
+			e.other:AddAAPoints(5);
+			e.other:Ding();
+			e.other:Message(15,'You have gained 5 ability points!');
+		end
+		if(qglobals["shadowknight_epic"] == "9" and item_lib.check_turn_in(e.trade, {item1 = 19098})) then --hand in Kilidna's Head (drops from Kilidna in City of Mist)
+			e.self:Emote("takes the head from you and holds it by the hair. Gilina casts a small spell and the head springs to life.  'Talk, Kilidna. What has happened to you?' Kilidna's head begins to sob. 'I am sorry, master. I was corrupted by evil magic! Now look at me! I dare say I will not be able to finish my studies any time soon.' Gilina scowls, 'What did you find out while in the city of mist? Tell me now!' 'Well master, it seems that when Innoruuk's Voice was summoned to this plane, it drew the attention of many [" ..eq.say_link('powerful beings', false, 'powerful beings') .. "].'");
+			eq.set_global("shadowknight_epic","10",5,"F");
+		end
+		if(qglobals["shadowknight_epic"] == "10" and item_lib.check_turn_in(e.trade, {item1 = 24612, item2 = 23489, item3 = 24632})) then --hand in Lhranc's Corroded Bracer (dropped from golems in Charasis), Lhranc's Pendant (dropped from black reavers in City of Mist), Lhranc's Ring (dropped from various undead in Kithicor)
+			e.self:Emote("takes the items from you and holds them before you in her hands. She mutters an incantation and the items meld into one.");
+			e.self:Say("This item will be used to help anchor Lhranc to this plane of existence. The anchor will not be enough however. In an area in the Realm of Discord known as Anguish, you will need to find a globe of discordant energy. This will be used to infuse the earthly anchor with the power of discord. When you have these two items, hand them to my contact, Filligno the Slayer. He has tracked down Lhranc in Dranik, the Ruined City in the Realm of Discord. He will need your help to get Lhranc's attention however.");
+			e.other:SummonItem(24584); --Lhranc's Earthly Anchor
+		end
 	end
 	item_lib.return_items(e.self, e.other, e.trade);
 end

--- a/poknowledge/Sienn_Kastane.lua
+++ b/poknowledge/Sienn_Kastane.lua
@@ -1,57 +1,69 @@
 -- poknowledge\Sienn_Kastane.lua NPCID 202268 
 -- SK Epic 1.5
 -- items: 22944, 20520, 20426, 23492, 20497, 19025, 11407
+
+local epic_disabled = true; -- Disabling for omens (epics) cannot reference perl expansion vars from lua.
+
 function event_say(e)
 	local qglobals = eq.get_qglobals(e.other);
-	if(e.other:HasClass(Class.SHADOWKNIGHT)) then
-		if(e.message:findi("hail")) then
-			if(e.other:HasItem(14383) or qglobals["shadowknight_pre"] == "2") then --Have Epic 1.0 Innoruuk's Curse or Pre_quest Complete
-				if(qglobals["shadowknight_epic"] == nil) then
-					eq.set_global("shadowknight_epic","1",5,"F"); --Flagged to start epic
+
+	if not epic_disabled then
+		if(e.other:HasClass(Class.SHADOWKNIGHT)) then
+			if(e.message:findi("hail")) then
+				if(e.other:HasItem(14383) or qglobals["shadowknight_pre"] == "2") then --Have Epic 1.0 Innoruuk's Curse or Pre_quest Complete
+					if(qglobals["shadowknight_epic"] == nil) then
+						eq.set_global("shadowknight_epic","1",5,"F"); --Flagged to start epic
+					end
 				end
+				if(qglobals["shadowknight_epic"] == "1") then
+					e.self:Say("You. You are the one I have seen in my visions.' Sienn removes a dark blade from a scabbard. I have just obtained this sword from one of my apprentices. This blade may be the key to the very existence of the shadowknight. Are you familiar with what has [" ..eq.say_link('been transpiring', false, 'been transpiring') .. "]?");
+				end
+			elseif(e.message:findi("transpiring") and qglobals["shadowknight_epic"] == "1") then
+				e.self:Emote("places her hands upon your forehead. A gravelly voice that is clearly not Sienn's fills your mind.");
+				e.other:Message(0,"Do you feel it? I am sure you do. Innoruuk's voice is so distant now. His voice is merely a whisper. This disturbs me greatly. How will the evil ones do their master's bidding without his dark guidance? I fear the end is almost near for true champions of darkness such as yourself. We cannot let that happen! I believe I know of a way to slow down the diminishing of our master's voice. There is a sword of great evil. It is however not of this world. I believe I can summon it to this plane of existence, but I will need several [" ..eq.say_link('items', false, 'items') .. "] first. . .' The voice ends. 'That was the voice of Ritald, a luggald in the service of the dark lord, Innoruuk.");
+			elseif(e.message:findi("items") and qglobals["shadowknight_epic"] == "1") then
+				e.self:Say("Your first task is to find me a tome. The sword has told me of a tome that details its history. I do not know where this tome might be, but I suggest you talk to Grand Librarian Maelin here in the Plane of Knowledge. He may have more information of this tome. When you find it, return it to me.");
+			elseif(e.message:findi("mask the sword\'s presence") and qglobals["shadowknight_epic"] == "4") then
+				e.self:Say("In the Plane of Nightmare, there dwells a banshee known as the Wailing Sister. In her possession is a rune of great power. The sword's hatred has awoken from a deep slumber. The rune however is only part of what will be needed to help mask the sword's hatred. The rune is inactive until combined with the Wailing Sister's blood. Recover the rune and a sample of her blood and return them to me.");
 			end
-			if(qglobals["shadowknight_epic"] == "1") then
-				e.self:Say("You. You are the one I have seen in my visions.' Sienn removes a dark blade from a scabbard. I have just obtained this sword from one of my apprentices. This blade may be the key to the very existence of the shadowknight. Are you familiar with what has [" ..eq.say_link('been transpiring', false, 'been transpiring') .. "]?");
-			end
-		elseif(e.message:findi("transpiring") and qglobals["shadowknight_epic"] == "1") then
-			e.self:Emote("places her hands upon your forehead. A gravelly voice that is clearly not Sienn's fills your mind.");
-			e.other:Message(0,"Do you feel it? I am sure you do. Innoruuk's voice is so distant now. His voice is merely a whisper. This disturbs me greatly. How will the evil ones do their master's bidding without his dark guidance? I fear the end is almost near for true champions of darkness such as yourself. We cannot let that happen! I believe I know of a way to slow down the diminishing of our master's voice. There is a sword of great evil. It is however not of this world. I believe I can summon it to this plane of existence, but I will need several [" ..eq.say_link('items', false, 'items') .. "] first. . .' The voice ends. 'That was the voice of Ritald, a luggald in the service of the dark lord, Innoruuk.");
-		elseif(e.message:findi("items") and qglobals["shadowknight_epic"] == "1") then
-			e.self:Say("Your first task is to find me a tome. The sword has told me of a tome that details its history. I do not know where this tome might be, but I suggest you talk to Grand Librarian Maelin here in the Plane of Knowledge. He may have more information of this tome. When you find it, return it to me.");
-		elseif(e.message:findi("mask the sword\'s presence") and qglobals["shadowknight_epic"] == "4") then
-			e.self:Say("In the Plane of Nightmare, there dwells a banshee known as the Wailing Sister. In her possession is a rune of great power. The sword's hatred has awoken from a deep slumber. The rune however is only part of what will be needed to help mask the sword's hatred. The rune is inactive until combined with the Wailing Sister's blood. Recover the rune and a sample of her blood and return them to me.");
 		end
-	end	
+	end
 end
 
 function event_trade(e)
 	local qglobals = eq.get_qglobals(e.other);
 	local item_lib = require("items");
-	if(item_lib.check_turn_in(e.trade, {item1 = 22944})) then --hand in statless Innoruuk's Voice from prequest
-		if(qglobals["shadowknight_epic"] == nil) then
-			eq.set_global("shadowknight_epic","1",5,"F"); --Flagged to start epic
+
+	if not epic_disabled then
+		if(item_lib.check_turn_in(e.trade, {item1 = 22944})) then --hand in statless Innoruuk's Voice from prequest
+			if(qglobals["shadowknight_epic"] == nil) then
+				eq.set_global("shadowknight_epic","1",5,"F"); --Flagged to start epic
+			end
 		end
-	end
-	if(qglobals["shadowknight_epic"] == "1" and item_lib.check_turn_in(e.trade, {item1 = 20520})) then --hand in The Silent Gods (received from Grand Librarian Maelin)
-		e.self:Say("You have done well in acquiring this tome.' Sienn opens the tome and begins to read. 'It says that a sheath must be created to protect the sword. Unfortunately the instructions for making this sheath are a bit unclear. The only clues given to the items needed are, to gather a dark hide of a creature unmatched in its bleakness, a holy lock of hair from a fair creature unmatched in happiness, and a gem possessing the very essence of fear itself, held by a creature more fearsome. If you find these three items, combine them in a sewing kit and then hand the sheath to me. I await your return.");
-		eq.set_global("shadowknight_epic","2",5,"F");
-	end
-	if(qglobals["shadowknight_epic"] == "2" and item_lib.check_turn_in(e.trade, {item1 = 20426})) then --hand in Sheath of Darktidings (result of a combine, probably needs added to db)
-		e.self:Say("I admit that I did not think you could accomplish this task. Perhaps you really are meant to be the sword's champion. Our work here is not done however. There are those that wish the sword to be destroyed. One of these beings is a froglok paladin named Fraga. He was last seen in the Plane of Valor. Kill him and bring me any clues as to what his plans may be.");
-		eq.set_global("shadowknight_epic","3",5,"F");
-	end
-	if(qglobals["shadowknight_epic"] == "3" and item_lib.check_turn_in(e.trade, {item1 = 23492})) then --hand in Fraga's Parchment (drops from Fraga in PoValor)
-		e.self:Emote("begins to read the parchment. A worried look plays across her face.");
-		e.self:Say("The weapon is not safe. The forces of good strongly wish to have it destroyed. To make matters worse, the sword is emanating hate that can be felt by powerful beings, both good and evil, across all planes of existence. As it stands right now, I wouldn't be surprised if the forces of good are converging to have the sword destroyed and the forces of evil are conniving to take the sword for themselves. It is only a matter of time before they locate the sword and come for it themselves. I have been studying the tome while you were gone. The tome describes a way to [" ..eq.say_link('mask the sword\'s presence', false, 'mask the sword\'s presence') .. "].");
-		eq.set_global("shadowknight_epic","4",5,"F");
-	end
-	if(qglobals["shadowknight_epic"] == "4" and item_lib.check_turn_in(e.trade, {item1 = 20497, item2 = 19025})) then --hand in Wailing Sister Blood and Wailing Rune (both drop from The Wailing Sister in the Plane of Nightmare)
-		e.self:Emote("pours the blood on the rune. The rune begins to glow a bright red color and a horrifying wail fills your ears.");
-		e.self:Say("The rune has been activated.");
-		e.self:Emote("holds the rune against the sheath you created earlier. The rune instantaneously melts into the sheath.");
-		e.self:Say("The sword is safe for now, but I think it should be moved just in case. Do not lose the sheathed sword. If you do lose it somehow, come back to me and tell me you lost it and I will attempt to make you another one. I only have enough left of the items you brought me to make you one more though. Now, take the sword to a servant of mine, named Gilina Yilzior, here in the Plane of Knowledge. She is very knowledgeable and should be able to help you further.");
-		eq.set_global("shadowknight_epic","5",5,"F");
-		e.other:SummonItem(11407); -- first version of Sheathed Innoruuk's Voice
+
+		if qglobals["shadowknight_epic"] ~= nil then
+			if(qglobals["shadowknight_epic"] == "1" and item_lib.check_turn_in(e.trade, {item1 = 20520})) then --hand in The Silent Gods (received from Grand Librarian Maelin)
+				e.self:Say("You have done well in acquiring this tome.' Sienn opens the tome and begins to read. 'It says that a sheath must be created to protect the sword. Unfortunately the instructions for making this sheath are a bit unclear. The only clues given to the items needed are, to gather a dark hide of a creature unmatched in its bleakness, a holy lock of hair from a fair creature unmatched in happiness, and a gem possessing the very essence of fear itself, held by a creature more fearsome. If you find these three items, combine them in a sewing kit and then hand the sheath to me. I await your return.");
+				eq.set_global("shadowknight_epic","2",5,"F");
+			end
+			if(qglobals["shadowknight_epic"] == "2" and item_lib.check_turn_in(e.trade, {item1 = 20426})) then --hand in Sheath of Darktidings (result of a combine, probably needs added to db)
+				e.self:Say("I admit that I did not think you could accomplish this task. Perhaps you really are meant to be the sword's champion. Our work here is not done however. There are those that wish the sword to be destroyed. One of these beings is a froglok paladin named Fraga. He was last seen in the Plane of Valor. Kill him and bring me any clues as to what his plans may be.");
+				eq.set_global("shadowknight_epic","3",5,"F");
+			end
+			if(qglobals["shadowknight_epic"] == "3" and item_lib.check_turn_in(e.trade, {item1 = 23492})) then --hand in Fraga's Parchment (drops from Fraga in PoValor)
+				e.self:Emote("begins to read the parchment. A worried look plays across her face.");
+				e.self:Say("The weapon is not safe. The forces of good strongly wish to have it destroyed. To make matters worse, the sword is emanating hate that can be felt by powerful beings, both good and evil, across all planes of existence. As it stands right now, I wouldn't be surprised if the forces of good are converging to have the sword destroyed and the forces of evil are conniving to take the sword for themselves. It is only a matter of time before they locate the sword and come for it themselves. I have been studying the tome while you were gone. The tome describes a way to [" ..eq.say_link('mask the sword\'s presence', false, 'mask the sword\'s presence') .. "].");
+				eq.set_global("shadowknight_epic","4",5,"F");
+			end
+			if(qglobals["shadowknight_epic"] == "4" and item_lib.check_turn_in(e.trade, {item1 = 20497, item2 = 19025})) then --hand in Wailing Sister Blood and Wailing Rune (both drop from The Wailing Sister in the Plane of Nightmare)
+				e.self:Emote("pours the blood on the rune. The rune begins to glow a bright red color and a horrifying wail fills your ears.");
+				e.self:Say("The rune has been activated.");
+				e.self:Emote("holds the rune against the sheath you created earlier. The rune instantaneously melts into the sheath.");
+				e.self:Say("The sword is safe for now, but I think it should be moved just in case. Do not lose the sheathed sword. If you do lose it somehow, come back to me and tell me you lost it and I will attempt to make you another one. I only have enough left of the items you brought me to make you one more though. Now, take the sword to a servant of mine, named Gilina Yilzior, here in the Plane of Knowledge. She is very knowledgeable and should be able to help you further.");
+				eq.set_global("shadowknight_epic","5",5,"F");
+				e.other:SummonItem(11407); -- first version of Sheathed Innoruuk's Voice
+			end
+		end
 	end
 	item_lib.return_items(e.self, e.other, e.trade);
 end

--- a/qey2hh1/Mystik.lua
+++ b/qey2hh1/Mystik.lua
@@ -1,22 +1,27 @@
 -- Monk Epic 1.5/2.0 (Prequest)
 
+local epic_disabled = true; -- Disabling for omens (epics) cannot reference perl expansion vars from lua.
+
 function event_say(e)
   local qglobals = eq.get_qglobals(e.other)
   local mnk_pre = tonumber(qglobals["MnkPre"]);
-  if (mnk_pre == nil) then mnk_pre = 0; end
-    
-  if (mnk_pre == 1) then
-    if (e.message:findi("hail")) then
-      e.self:Say("I see you bear the Sign of Acceptance. So you believe you are strong enough to accomplish all that is asked of you? If you stand true during this [" .. eq.say_link("test") .. "] you will find all you seek.");
-    elseif(e.message:findi("test")) then
-      e.self:Say("In this test you will have to face me and prove that you have the heart to succeed. I hope you have brought strong allies to accompany you for you shall need them. We shall begin as soon as you are [" .. eq.say_link("ready to start") .. "].");
-    elseif(e.message:findi("ready to start")) then
-      e.self:Say("I didnt know slime could speak common.. go back to the sewer before I lose my temper.");
-      e.self:SetSpecialAbility(19,0);
-      e.self:SetSpecialAbility(20,0);
-      e.self:SetSpecialAbility(24,0);
-      e.self:SetSpecialAbility(25,0);
-      eq.attack(e.other:GetName());
+
+  if not epic_disabled then
+    if (mnk_pre == nil) then mnk_pre = 0; end
+      
+    if (mnk_pre == 1) then
+      if (e.message:findi("hail")) then
+        e.self:Say("I see you bear the Sign of Acceptance. So you believe you are strong enough to accomplish all that is asked of you? If you stand true during this [" .. eq.say_link("test") .. "] you will find all you seek.");
+      elseif(e.message:findi("test")) then
+        e.self:Say("In this test you will have to face me and prove that you have the heart to succeed. I hope you have brought strong allies to accompany you for you shall need them. We shall begin as soon as you are [" .. eq.say_link("ready to start") .. "].");
+      elseif(e.message:findi("ready to start")) then
+        e.self:Say("I didnt know slime could speak common.. go back to the sewer before I lose my temper.");
+        e.self:SetSpecialAbility(19,0);
+        e.self:SetSpecialAbility(20,0);
+        e.self:SetSpecialAbility(24,0);
+        e.self:SetSpecialAbility(25,0);
+        eq.attack(e.other:GetName());
+      end
     end
   end
 end

--- a/sebilis/encounters/desktop.ini
+++ b/sebilis/encounters/desktop.ini
@@ -1,2 +1,0 @@
-[.ShellClassInfo]
-IconResource=C:\Program Files\Google\Drive File Stream\72.0.3.0\GoogleDriveFS.exe,23

--- a/sebilis/script_init.lua
+++ b/sebilis/script_init.lua
@@ -1,1 +1,5 @@
-eq.load_encounter('berserkerepic_1_5');
+local epic_disabled = true; -- Disabling for omens (epics) cannot reference perl expansion vars from lua.
+
+if not epic_disabled then
+    eq.load_encounter('berserkerepic_1_5');
+end

--- a/swampofnohope/Skurza_Slicekutt.lua
+++ b/swampofnohope/Skurza_Slicekutt.lua
@@ -1,17 +1,23 @@
 --swampofnohope/Skurza_Slicekutt.lua NPCID 
 --SK Epic 1.5
+
+local epic_disabled = true; -- Disabling for omens (epics) cannot reference perl expansion vars from lua.
+
 function event_say(e)
 	local qglobals = eq.get_qglobals(e.other);	
-	if(e.message:findi("hail")) then
-		if ( qglobals["shadowknight_epic"] == "6") then
-			e.self:Say("bashhh!");
-			e.self:SetSpecialAbility(19, 0);
-			e.self:SetSpecialAbility(20, 0);
-			e.self:SetSpecialAbility(24, 0);
-			e.self:SetSpecialAbility(25, 0);
-			e.self:SetSpecialAbility(35, 0);
-			e.self:SetLevel(66);
-			e.self:AddToHateList(e.other,1);
+
+	if not epic_disabled then
+		if e.message:findi("hail") then
+			if qglobals["shadowknight_epic"] ~= nil and  qglobals["shadowknight_epic"] == "6" then
+				e.self:Say("bashhh!");
+				e.self:SetSpecialAbility(19, 0);
+				e.self:SetSpecialAbility(20, 0);
+				e.self:SetSpecialAbility(24, 0);
+				e.self:SetSpecialAbility(25, 0);
+				e.self:SetSpecialAbility(35, 0);
+				e.self:SetLevel(66);
+				e.self:AddToHateList(e.other,1);
+			end
 		end
 	end
 end
@@ -20,5 +26,3 @@ function event_trade(e)
 	local item_lib = require("items");
 	item_lib.return_items(e.self, e.other, e.trade);
 end
-	
-	

--- a/veksar/player.lua
+++ b/veksar/player.lua
@@ -1,22 +1,27 @@
 --veksar/player.lua  
 --Warrior Epic 1.5 subquest. When a warrior on this part of the quest zones
 --in, Decaying Lord Galuk Drek will spawn with a 1 hour lockout
+
+local epic_disabled = true; -- Disabling for omens (epics) cannot reference perl expansion vars from lua.
+
 function event_enter_zone(e)
 	local qglobals = eq.get_qglobals(e.self);
 	local el = eq.get_entity_list();
 
-	if(qglobals["warrior_epic_veksar"] == "1") then
-		if(qglobals["warrior_epic_gulak"] == "1") then	
-			e.self:Message(15,"You have less than one hour left before you will see the Decaying Lord Galuk Drek again.");
-		else
-			e.self:Message(15,"Decaying Lord Galuk Drek has sensed your presence. He's waiting for you... ");
-			eq.set_global("warrior_epic_gulak","1",3,"H1");
-			eq.spawn2(109906 ,0,0,-437,291,-22.9,356); --Decaying Lord Galuk Drek, not be in db yet
+	if not epic_disabled then
+		if(qglobals["warrior_epic_veksar"] == "1") then
+			if(qglobals["warrior_epic_gulak"] == "1") then	
+				e.self:Message(15,"You have less than one hour left before you will see the Decaying Lord Galuk Drek again.");
+			else
+				e.self:Message(15,"Decaying Lord Galuk Drek has sensed your presence. He's waiting for you... ");
+				eq.set_global("warrior_epic_gulak","1",3,"H1");
+				eq.spawn2(109906 ,0,0,-437,291,-22.9,356); --Decaying Lord Galuk Drek, not be in db yet
+			end
 		end
-	end
-	
-	if(qglobals["ranger_epic"] == "1" and qglobals["ranger_epic_veks"] == nil and el:IsMobSpawnedByNpcTypeID(109907) == false) then
-		eq.unique_spawn(109907,0,0,-347.25,-549.5,-17.15,468); -- NPC: an_asteatotic_highborn
-		eq.set_global("ranger_epic_veks","1",2,"H2");		
+		
+		if(qglobals["ranger_epic"] == "1" and qglobals["ranger_epic_veks"] == nil and el:IsMobSpawnedByNpcTypeID(109907) == false) then
+			eq.unique_spawn(109907,0,0,-347.25,-549.5,-17.15,468); -- NPC: an_asteatotic_highborn
+			eq.set_global("ranger_epic_veks","1",2,"H2");		
+		end
 	end
 end

--- a/warrens/#Wilslik_Gissu.lua
+++ b/warrens/#Wilslik_Gissu.lua
@@ -1,23 +1,32 @@
 --warrems/Wilslik_Gissu.lua NPCID 101133
 --Shaman Epic 1.5
 -- items: 57550, 57369, 52921
+
+local epic_disabled = true; -- Disabling for omens (epics) cannot reference perl expansion vars from lua.
+
 function event_say(e)
 	local qglobals = eq.get_qglobals(e.other);
-	if(e.message:findi("elder spirit sent me") and qglobals["shaman_epic"] == "1") then
-		e.self:Say("Greetingsss fair sage. It would seem that you have come to aid the spirit who fades like each breath we let pass through our lips. There is not [" .. eq.say_link("much time") .. "] to dawdle. We must get to work right away. As an alchemist yourself, I will tell you what you must do. You must first make some separate combinations. Do not attempt to do this if you are not a master. You will most certainly fail. Ready for instruction?");
-	elseif(e.message:findi("much time") and qglobals["shaman_epic"] == "1") then
-		e.self:Say("How shall I put this in termsss you will understand? Two of the rare items of nature's bounty will join because they live in darkness. The others will join because they share love of light. You must use the medicine bag given to you by my old friend -- and entrepreneur -- Wunshi. When you've successfully worked with those, tell me you have completed the first step.");
-	elseif(e.message:findi("first step") and qglobals["shaman_epic"] == "1" and e.other:HasItem(57369) and e.other:HasItem(57550)) then
-		e.self:Say("Nicely done, friend. You have done good work. Now, give me both of those pieces and I will fashion what you need to return to the spirit.");
+
+	if not epic_disabled and qglobals["shaman_epic"] ~= nil then
+		if(e.message:findi("elder spirit sent me") and qglobals["shaman_epic"] == "1") then
+			e.self:Say("Greetingsss fair sage. It would seem that you have come to aid the spirit who fades like each breath we let pass through our lips. There is not [" .. eq.say_link("much time") .. "] to dawdle. We must get to work right away. As an alchemist yourself, I will tell you what you must do. You must first make some separate combinations. Do not attempt to do this if you are not a master. You will most certainly fail. Ready for instruction?");
+		elseif(e.message:findi("much time") and qglobals["shaman_epic"] == "1") then
+			e.self:Say("How shall I put this in termsss you will understand? Two of the rare items of nature's bounty will join because they live in darkness. The others will join because they share love of light. You must use the medicine bag given to you by my old friend -- and entrepreneur -- Wunshi. When you've successfully worked with those, tell me you have completed the first step.");
+		elseif(e.message:findi("first step") and qglobals["shaman_epic"] == "1" and e.other:HasItem(57369) and e.other:HasItem(57550)) then
+			e.self:Say("Nicely done, friend. You have done good work. Now, give me both of those pieces and I will fashion what you need to return to the spirit.");
+		end
 	end
 end
 
 function event_trade(e)
 	local qglobals = eq.get_qglobals(e.other);
 	local item_lib = require("items");
-	if(qglobals["shaman_epic"] == "1" and item_lib.check_turn_in(e.trade, {item1 = 57550, item2 = 57369})) then -- hand in Shadowed Pulp and Brittle Twigs (both are result of combines of quest items gathered up to this point, recipes probably need to be added to db)
-		e.self:Say("Take these and return to the spirit!");
-		e.other:SummonItem(52921); --Distilled Potion of Endurance
+
+	if not epic_disabled then
+		if qglobals["shaman_epic"] ~= nil and qglobals["shaman_epic"] == "1" and item_lib.check_turn_in(e.trade, {item1 = 57550, item2 = 57369}) then -- hand in Shadowed Pulp and Brittle Twigs (both are result of combines of quest items gathered up to this point, recipes probably need to be added to db)
+			e.self:Say("Take these and return to the spirit!");
+			e.other:SummonItem(52921); --Distilled Potion of Endurance
+		end
 	end
 	item_lib.return_items(e.self, e.other, e.trade);
 end

--- a/westwastes/Sir_Elmonious_Falmont.lua
+++ b/westwastes/Sir_Elmonious_Falmont.lua
@@ -1,16 +1,22 @@
 --oot/Gubblegrot_Smashfist.lua NPCID 69140
 --SK Epic 1.5
+
+local epic_disabled = true; -- Disabling for omens (epics) cannot reference perl expansion vars from lua.
+
 function event_say(e)
 	local qglobals = eq.get_qglobals(e.other);	
-	if(e.message:findi("hail")) then
-		if ( qglobals["shadowknight_epic"] == "8") then
-			e.self:Say("I knew you would come. You will soon learn that evil does not pay!");
-			e.self:SetSpecialAbility(19, 0);
-			e.self:SetSpecialAbility(20, 0);
-			e.self:SetSpecialAbility(24, 0);
-			e.self:SetSpecialAbility(25, 0);
-			e.self:SetSpecialAbility(35, 0);
-			e.self:AddToHateList(e.other,1);
+
+	if not epic_disabled then
+		if(e.message:findi("hail")) then
+			if qglobals["shadowknight_epic"] ~= nil and qglobals["shadowknight_epic"] == "8" then
+				e.self:Say("I knew you would come. You will soon learn that evil does not pay!");
+				e.self:SetSpecialAbility(19, 0);
+				e.self:SetSpecialAbility(20, 0);
+				e.self:SetSpecialAbility(24, 0);
+				e.self:SetSpecialAbility(25, 0);
+				e.self:SetSpecialAbility(35, 0);
+				e.self:AddToHateList(e.other,1);
+			end
 		end
 	end
 end
@@ -19,4 +25,3 @@ function event_trade(e)
 	local item_lib = require("items");
 	item_lib.return_items(e.self, e.other, e.trade);
 end
-


### PR DESCRIPTION
Updated HasClass calls that were incorrect.

Updated most lua scripts with a `epic_disabled` which disabled Epic Pre 1.5/1.5/2.0 scripts. Use a replace all when you get to enabling omens/epics. Also fixed many qglobal checks that did not have nil checks.