### PR TITLE
Removing class check for spawning Jzil (Drakis Bloodcaster)

### DIFF
--- a/airplane/Drakis_Bloodcaster.lua
+++ b/airplane/Drakis_Bloodcaster.lua
@@ -2,7 +2,7 @@
 function event_say(e)
 	if e.message:findi("hail") then
 		e.self:Say("Greetings, " .. e.other:Race() .. ". Are you ready to begin?");
-	elseif e.message:findi("ready") and e.other:HasClass(Class.NECROMANCER) then
+	elseif e.message:findi("ready")  then
 		e.self:Say("Then choose, necromancer. Do you wish to be tested by Dugaas or Jzil?");
 	elseif e.message:findi("ready") then
 		e.self:Say("Do you take me for a fresh lich! Go away!");

--- a/airplane/Drakis_Bloodcaster.lua
+++ b/airplane/Drakis_Bloodcaster.lua
@@ -6,7 +6,7 @@ function event_say(e)
 		e.self:Say("Then choose, necromancer. Do you wish to be tested by Dugaas or Jzil?");
 	elseif e.message:findi("ready") then
 		e.self:Say("Do you take me for a fresh lich! Go away!");
-	elseif e.message:findi("jzil") and e.other:HasClass(Class.NECROMANCER) then
+	elseif e.message:findi("jzil") then
 		e.self:Say("Take this tome and read it.  When you are finished, return it to me and I will summon Jzil.");
 		e.other:SummonFixedItem(18536); -- Shadowy Thoughts
 	elseif e.message:findi("Dugaas") and e.other:HasClass(Class.NECROMANCER) then


### PR DESCRIPTION
There was still a class check when trying to get the book to spawn Jzil in posky for the cloak turn in.  Removed that class check only on the say phrase of "jzil"