### PR TITLE
[Hate's Fury] Fix attendant disappearing on non-respawning.

### DIFF
--- a/hatesfury/encounters/drunken_event.lua
+++ b/hatesfury/encounters/drunken_event.lua
@@ -25,7 +25,6 @@ function Controller_Signal(e)
 
         if is_private_instance and killed == private_trigger_amount then
             eq.unique_spawn(228111,0,0,431,1006,-607.4, 0); -- NPC: the_Drunken_Buccaneer
-            eq.depop(); -- No additional chance at respawn in private instance
         elseif not is_private_instance and killed == public_trigger_amount then
             eq.unique_spawn(228111,0,0,431,1006,-607.4, 0); -- NPC: the_Drunken_Buccaneer
             killed = 0; -- Reset


### PR DESCRIPTION
The 'depop' was causing the Attendant to despawn when the player spawned the Buccaneer in a non-respawning instance.  I've removed it since its redundant for two reasons:

1. There's only enough spawns in non-respawning to trigger the spawn once.
2. By not resetting 'killed' back to 0 we will not trigger the correct conditions to spawn it again.

Workaround for now is to simply switch to a respawning instance.