### PR TITLE
Add support for Coldain Ring 8 Quest/War

### DIFF
--- a/eastwastes/#Garadain_Glacierbane.pl
+++ b/eastwastes/#Garadain_Glacierbane.pl
@@ -8,7 +8,7 @@ sub EVENT_SPAWN {
 sub EVENT_ITEM {
   if (plugin::check_handin(\%itemcount, 1092 => 1)) {
     quest::say("Good work friend! The Dain will hear of this right away. We couldn't have defeated the Ry'gorr without your help. Take this ring as proof that you have served the Coldain well. You may wish to show it to the Seneschal should you ever stop in our fine city. Farewell, $name, it has been my pleasure knowing you.");
-    quest::summonitem(30164); # Item: Velium Coldain Insignia Ring
+    quest::summonfixeditem(2030164); # Item: Velium Coldain Insignia Ring
 #Factions: +Coldain, +Dain Frostreaver IV, -Kromrif, -Kromzek
     quest::faction(406,30); # Faction: Coldain
     quest::faction(405,30); # Faction: Dain Frostreaver IV
@@ -87,6 +87,7 @@ sub EVENT_TIMER {
   }
   elsif($timer == 37) {
     quest::stoptimer(37);
+    quest::modifynpcstat("runspeed", 2.25);
     $npc->ResumeWandering();
   }
   elsif($timer == 27) {

--- a/eastwastes/#Garadain_Glacierbane.pl
+++ b/eastwastes/#Garadain_Glacierbane.pl
@@ -1,4 +1,5 @@
 # items: 1092, 30164
+
 sub EVENT_SPAWN {
   quest::say("It is worse than I thought. Not only are they prepared for an attack, but they have the Kromrif here to help them. Our steel will be tested today. Be sure not to show the troops any fear.");
   quest::pause(2);
@@ -21,14 +22,19 @@ sub EVENT_ITEM {
 
 sub EVENT_WAYPOINT_ARRIVE {
   if ($wp == 1) {
-    quest::settimer(30,10);
-  }
-  elsif ($wp == 2) {
-    quest::pause(2);
-    quest::say("For the Glory of Thurgadin! CHARGE!!");
-    quest::settimer(27,600);
-    quest::settimer(37,65);
-    quest::pause(30);
+    # Give motivational speech
+    $npc->PauseWandering(0);
+    quest::settimer(30,2);
+  } elsif ($wp == 2) {
+    # Give the charge command
+    $npc->PauseWandering(0);
+    quest::settimer(35,2); # Message to player to follow him in battle
+    quest::settimer(36,5); # Tell others to charge
+    quest::settimer(37,20); # Begin moving toward the Chief
+  } elsif ($wp == 3) {
+    # This is the last waypoint.  Stop here, wait for turn in, depop in 5 minutes
+    $npc->PauseWandering(0);
+    quest::settimer(27,300);
   }
 }
 
@@ -36,6 +42,10 @@ sub EVENT_TIMER {
   if($timer == 30) {
     quest::stoptimer(30);
     quest::say("TROOPS! FALL IN!!");
+    quest::signalwith(116563, 1); # form wolves
+    quest::signalwith(116541, 1); # form priests
+    quest::signalwith(116555, 1); # form archers
+    quest::signalwith(116549, 1); # form paladins
     quest::settimer(31,10);
   }
   elsif($timer == 31) {
@@ -57,21 +67,27 @@ sub EVENT_TIMER {
     quest::stoptimer(34);
     quest::say("Today the Ry`gorr fall! Tomorrow the Kromrif!!");
     quest::say("Fall out men!!");
-    quest::settimer(35,20);
+    quest::signalwith(116563, 2); # march wolves
+    quest::signalwith(116541, 2); # march priests
+    quest::signalwith(116555, 2); # march archers
+    quest::signalwith(116549, 2); # march paladins
+    $npc->ResumeWandering();
   }
   elsif($timer == 35) {
     quest::stoptimer(35);
     quest::say("Stay back from the initial charge, my friend. We will go directly for the chief once the troops are engaged. Follow me closely!");
-    quest::settimer(36,10);
   }
   elsif($timer == 36) {
     quest::stoptimer(36);
     quest::say("For the Glory of Thurgadin! CHARGE!!");
-    quest::settimer(37,65);
+    quest::signalwith(116563, 3); # send in wolves
+    quest::signalwith(116541, 3); # send in priests
+    quest::signalwith(116555, 3); # send in archers
+    quest::signalwith(116549, 3); # send in paladins
   }
   elsif($timer == 37) {
     quest::stoptimer(37);
-    quest::pause(580);
+    $npc->ResumeWandering();
   }
   elsif($timer == 27) {
     quest::stoptimer(27);

--- a/eastwastes/Garadain_Glacierbane.pl
+++ b/eastwastes/Garadain_Glacierbane.pl
@@ -197,7 +197,8 @@ sub EVENT_ITEM {
 ###########################
 
   elsif (plugin::check_handin(\%itemcount, 1045 => 1, 18084 => 1, 30268 => 1)) {
-    quest::emote("lowers his head and mutters, 'At least there will be some closure for their families, thanks to you. The Ry`gorr will pay for this with their lives! I will ask you to help us in the invasion of Ry`gorr keep, but first I have a delicate [mission] I was hoping you'd handle.");
+    quest::emote("lowers his head and mutters");
+    quest::say("At least there will be some closure for their families, thanks to you. The Ry`gorr will pay for this with their lives! I will ask you to help us in the invasion of Ry`gorr keep, but first I have a delicate [mission] I was hoping you'd handle.");
     quest::summonitem(30162); # Item: Mithril Coldain Insignia Ring
 
 #   Factions: +Coldain, +Dain Frostreaver IV, -Kromrif, -Kromzek

--- a/eastwastes/Icefang.pl
+++ b/eastwastes/Icefang.pl
@@ -4,7 +4,7 @@ my $icefang;
 
 sub EVENT_SIGNAL {
   if ($signal == 1161101) {
-    quest::moveto(3213, -8064, 146);
+    quest::moveto(3241, -7897, 146);
     $icefang = 10;
   }
   elsif ($signal == 1161102) {

--- a/eastwastes/Paladin_of_Brell.pl
+++ b/eastwastes/Paladin_of_Brell.pl
@@ -1,34 +1,39 @@
 sub EVENT_SPAWN {
+  quest::modifynpcstat("runspeed", 0);
   quest::pause(2);
-  $paladin = undef;
 }
 
-sub EVENT_WAYPOINT_DEPART {
-  if($paladin < 8){
-    $paladin=$paladin+1;
-    quest::pause(273);
+sub EVENT_SIGNAL {
+  quest::debug("Paladin Received signal - " . $signal);
+  if ($signal == 1){
+    # Fall into formation
+    quest::modifynpcstat("runspeed", 2.25);
+  } elsif($signal == 2){
+    # Begin march to fort
+    quest::modifynpcstat("runspeed", 1.25);
+  } elsif($signal == 3){
+    # Charge into battle
+    quest::modifynpcstat("runspeed", 2.25);
   }
-  elsif($paladin == 8) {
-    $paladin=$paladin+1;
-  }
-  elsif($paladin > 8 && $paladin < 16) {
-    $paladin=$paladin+1;
-  }
-  elsif($paladin == 16) {
-    $paladin=$paladin+1;
-    quest::pause(155);
-    quest::modifynpcstat("runspeed",2.5);
-  }
-  elsif($paladin > 16 && $paladin < 23) {
-    $paladin=$paladin+1;
-    quest::pause(155);
-    quest::modifynpcstat("runspeed",2.5);
-    quest::settimer(7,755);
+}
+
+sub EVENT_WAYPOINT_ARRIVE {
+  if ($wp == 1){
+    # Stop for Garadain's speech
+    quest::modifynpcstat("runspeed", 0);
+  } elsif ($wp == 2){
+    # Stop briefly for the call to charge
+    quest::modifynpcstat("runspeed", 0);
+  } elsif ($wp == 3){
+    # Arrived at final waypoint.  Stop navigation
+    $npc->SetGrid(0);
+    quest::settimer(9,300); # depop after 5 minutes
   }
 }
 
 sub EVENT_TIMER {
-  if($timer == 7) {
+  if($timer == 9) {
+    quest::stoptimer(9);
     quest::depopall(116549);
   }
 }

--- a/eastwastes/Paladin_of_Brell.pl
+++ b/eastwastes/Paladin_of_Brell.pl
@@ -1,10 +1,6 @@
-sub EVENT_SPAWN {
-  quest::modifynpcstat("runspeed", 0);
-  quest::pause(2);
-}
-
 sub EVENT_SIGNAL {
-  quest::debug("Paladin Received signal - " . $signal);
+  quest::debug("Paladin of Brell Received signal - " . $signal);
+  $npc->ResumeWandering();
   if ($signal == 1){
     # Fall into formation
     quest::modifynpcstat("runspeed", 2.25);
@@ -18,15 +14,10 @@ sub EVENT_SIGNAL {
 }
 
 sub EVENT_WAYPOINT_ARRIVE {
-  if ($wp == 1){
-    # Stop for Garadain's speech
-    quest::modifynpcstat("runspeed", 0);
-  } elsif ($wp == 2){
-    # Stop briefly for the call to charge
-    quest::modifynpcstat("runspeed", 0);
-  } elsif ($wp == 3){
-    # Arrived at final waypoint.  Stop navigation
-    $npc->SetGrid(0);
+  # Pause our wandering at each of the waypoints
+  $npc->PauseWandering(0);
+  
+  if ($wp == 3){
     quest::settimer(9,300); # depop after 5 minutes
   }
 }

--- a/eastwastes/Priest_of_Brell.pl
+++ b/eastwastes/Priest_of_Brell.pl
@@ -1,10 +1,6 @@
-sub EVENT_SPAWN {
-  quest::modifynpcstat("runspeed", 0);
-  quest::pause(2);
-}
-
 sub EVENT_SIGNAL {
-  quest::debug("Priest received signal - " . $signal);
+  quest::debug("Priest of Brell received signal - " . $signal);
+  $npc->ResumeWandering();
   if ($signal == 1){
     # Fall into formation
     quest::modifynpcstat("runspeed", 2.25);
@@ -18,15 +14,11 @@ sub EVENT_SIGNAL {
 }
 
 sub EVENT_WAYPOINT_ARRIVE {
-  if ($wp == 1){
-    # Stop for Garadain's speech
-    quest::modifynpcstat("runspeed", 0);
-  } elsif ($wp == 2){
-    # Stop briefly for the call to charge
-    quest::modifynpcstat("runspeed", 0);
-  } elsif ($wp==3) {
+  # Pause our wandering at each of the waypoints
+  $npc->PauseWandering(0);
+
+  if ($wp==3) {
     # Arrived at final waypoint.  Stop navigation
-    $npc->SetGrid(0);
     quest::settimer(9,300);
   }
 }

--- a/eastwastes/Priest_of_Brell.pl
+++ b/eastwastes/Priest_of_Brell.pl
@@ -1,34 +1,39 @@
 sub EVENT_SPAWN {
+  quest::modifynpcstat("runspeed", 0);
   quest::pause(2);
-  $priest = undef;
 }
 
-sub EVENT_WAYPOINT_DEPART {
-  if($priest < 8){
-    quest::pause(273);
-    $priest=$priest+1;
+sub EVENT_SIGNAL {
+  quest::debug("Priest received signal - " . $signal);
+  if ($signal == 1){
+    # Fall into formation
+    quest::modifynpcstat("runspeed", 2.25);
+  } elsif ($signal == 2){
+    # Begin march to fort
+    quest::modifynpcstat("runspeed", 1.25);
+  } elsif ($signal == 3){
+    # Charge into battle
+    quest::modifynpcstat("runspeed", 2.25);
   }
-  elsif($priest == 8) {
-    $priest=$priest+1;
-  }
-  elsif($priest > 8 && $priest < 16) {
-    $priest=$priest+1;
-  }
-  elsif($priest == 16) {
-    $priest=$priest+1;
-    quest::pause(155);
-    quest::modifynpcstat("runspeed",2.5);
-  }
-  elsif($priest > 16 && $priest < 24) {
-    $priest=$priest+1;
-    quest::pause(155);
-    quest::modifynpcstat("runspeed",2.5);
-    quest::settimer(8,755);
+}
+
+sub EVENT_WAYPOINT_ARRIVE {
+  if ($wp == 1){
+    # Stop for Garadain's speech
+    quest::modifynpcstat("runspeed", 0);
+  } elsif ($wp == 2){
+    # Stop briefly for the call to charge
+    quest::modifynpcstat("runspeed", 0);
+  } elsif ($wp==3) {
+    # Arrived at final waypoint.  Stop navigation
+    $npc->SetGrid(0);
+    quest::settimer(9,300);
   }
 }
 
 sub EVENT_TIMER {
-  if($timer == 8) {
+  if($timer == 9) {
+    quest::stoptimer(9);
     quest::depopall(116541);
   }
 }

--- a/eastwastes/Royal_Archer.pl
+++ b/eastwastes/Royal_Archer.pl
@@ -1,10 +1,6 @@
-sub EVENT_SPAWN {
-  quest::modifynpcstat("runspeed", 0);
-  quest::pause(2);
-}
-
 sub EVENT_SIGNAL {
   quest::debug("Royal Archer Received signal - " . $signal);
+  $npc->ResumeWandering();
   if ($signal == 1){
     # Fall into formation
     quest::modifynpcstat("runspeed", 2.25);
@@ -18,15 +14,10 @@ sub EVENT_SIGNAL {
 }
 
 sub EVENT_WAYPOINT_ARRIVE {
-  if ($wp == 1){
-    # stop for Garadain's speech
-    quest::modifynpcstat("runspeed", 0);
-  } elsif($wp == 2){
-    # stop briefly for the call to charge
-    quest::modifynpcstat("runspeed", 0);
-  } elsif($wp == 3){
-    # arrived at final waypoint.  Stop navigation
-    $npc->SetGrid(0);
+  # Pause our wandering at each of the waypoints
+  $npc->PauseWandering(0);
+  
+  if($wp == 3){
     quest::settimer(9,300); # depop after 5 minutes
   }
 }

--- a/eastwastes/Royal_Archer.pl
+++ b/eastwastes/Royal_Archer.pl
@@ -1,34 +1,39 @@
 sub EVENT_SPAWN {
+  quest::modifynpcstat("runspeed", 0);
   quest::pause(2);
-  $archer = undef;
 }
 
-sub EVENT_WAYPOINT_DEPART {
-  if($archer < 8){
-    quest::pause(273);
-    $archer=$archer+1;
+sub EVENT_SIGNAL {
+  quest::debug("Royal Archer Received signal - " . $signal);
+  if ($signal == 1){
+    # Fall into formation
+    quest::modifynpcstat("runspeed", 2.25);
+  } elsif ($signal == 2){
+    # Begin march to fort
+    quest::modifynpcstat("runspeed", 1.25);
+  } elsif ($signal == 3){
+    # Charge into battle
+    quest::modifynpcstat("runspeed", 2.25);
   }
-  elsif($archer == 8) {
-    $archer=$archer+1;
-  }
-  elsif($archer > 8 && $archer < 16) {
-    $archer=$archer+1;
-  }
-  elsif($archer == 16) {
-    $archer=$archer+1;
-    quest::pause(155);
-    quest::modifynpcstat("runspeed",2.5);
-  }
-  elsif($archer > 16 && $archer < 24) {
-    $archer=$archer+1;
-    quest::pause(155);
-    quest::modifynpcstat("runspeed",2.5);
-    quest::settimer(9,755);
+}
+
+sub EVENT_WAYPOINT_ARRIVE {
+  if ($wp == 1){
+    # stop for Garadain's speech
+    quest::modifynpcstat("runspeed", 0);
+  } elsif($wp == 2){
+    # stop briefly for the call to charge
+    quest::modifynpcstat("runspeed", 0);
+  } elsif($wp == 3){
+    # arrived at final waypoint.  Stop navigation
+    $npc->SetGrid(0);
+    quest::settimer(9,300); # depop after 5 minutes
   }
 }
 
 sub EVENT_TIMER {
   if($timer == 9) {
+    quest::stoptimer(9);
     quest::depopall(116555);
   }
 }

--- a/eastwastes/Royal_Wolven_Guard.pl
+++ b/eastwastes/Royal_Wolven_Guard.pl
@@ -1,34 +1,41 @@
 sub EVENT_SPAWN {
+  quest::modifynpcstat("runspeed",0);
   quest::pause(2);
-  $wolf = undef;
 }
 
-sub EVENT_WAYPOINT_DEPART {
-  if($wolf < 8){
-    quest::pause(273);
-    $wolf=$wolf+1;
+sub EVENT_SIGNAL {
+  quest::debug("Received signal - " . $signal);
+  if ($signal == 1){
+    # Fall into formation
+    quest::modifynpcstat("runspeed", 2.25);
   }
-  elsif($wolf == 8) {
-    $wolf=$wolf+1;
+  if ($signal == 2){
+    # Begin march to fort
+    quest::modifynpcstat("runspeed", 1.25);
   }
-  elsif($wolf > 8 && $wolf < 16) {
-    $wolf=$wolf+1;
+  if ($signal == 3){
+    # Charge into battle
+    quest::modifynpcstat("runspeed", 2.25);
   }
-  elsif($wolf == 16) {
-    $wolf=$wolf+1;
-    quest::pause(155);
-    quest::modifynpcstat("runspeed",2.5);
-  }
-  elsif($wolf > 16 && $wolf < 24) {
-    $wolf=$wolf+1;
-    quest::pause(155);
-    quest::modifynpcstat("runspeed",2.5);
-    quest::settimer(10,755);
+}
+
+sub EVENT_WAYPOINT_ARRIVE {
+  if ($wp == 1){
+    # stop for Garadain's speech
+    quest::modifynpcstat("runspeed", 0);
+  } elsif ($wp == 2){
+    # stop briefly for the call to charge
+    quest::modifynpcstat("runspeed", 0);
+  } elsif ($wp == 3) {
+    # stop wandering and begin depop timer (5 minutes)
+    $npc->SetGrid(0);
+    quest::settimer(9,300);
   }
 }
 
 sub EVENT_TIMER {
-  if($timer == 10) {
+  if($timer == 9) {
+    quest::stoptimer(9);
     quest::depopall(116563);
   }
 }

--- a/eastwastes/Royal_Wolven_Guard.pl
+++ b/eastwastes/Royal_Wolven_Guard.pl
@@ -1,34 +1,24 @@
-sub EVENT_SPAWN {
-  quest::modifynpcstat("runspeed",0);
-  quest::pause(2);
-}
-
 sub EVENT_SIGNAL {
-  quest::debug("Received signal - " . $signal);
+  quest::debug("Royal Wolven Guard Received signal - " . $signal);
+  $npc->ResumeWandering();
   if ($signal == 1){
     # Fall into formation
     quest::modifynpcstat("runspeed", 2.25);
-  }
-  if ($signal == 2){
+  } elsif ($signal == 2){
     # Begin march to fort
     quest::modifynpcstat("runspeed", 1.25);
-  }
-  if ($signal == 3){
+  } elsif ($signal == 3){
     # Charge into battle
     quest::modifynpcstat("runspeed", 2.25);
   }
 }
 
 sub EVENT_WAYPOINT_ARRIVE {
-  if ($wp == 1){
-    # stop for Garadain's speech
-    quest::modifynpcstat("runspeed", 0);
-  } elsif ($wp == 2){
-    # stop briefly for the call to charge
-    quest::modifynpcstat("runspeed", 0);
-  } elsif ($wp == 3) {
+  # Pause our wandering at each of the waypoints
+  $npc->PauseWandering(0);
+
+  if ($wp == 3) {
     # stop wandering and begin depop timer (5 minutes)
-    $npc->SetGrid(0);
     quest::settimer(9,300);
   }
 }


### PR DESCRIPTION
The quest script changes are safe to accept, though there are some SQL database changes necessary for things to all work properly.  These changes will be provided directly to THJ server admins for coordinating the updates.

- Quest scripts to support cinematics of the war (move NPCs, speech, etc).
- Updated reward item to be the guaranteed legendary version of the ring.
- Removed many dependencies upon arbitrary timers and more towards event based triggers/signals and waypoints.
- Confirmed Garadain returns any non-expected quest items handed to him during the final turn in.
- Small fix for where Icefang roams to when interacting with Korrigan on ring 6.

Some minor or potential issues that are still in existence:
- There is a race condition that causes some of the military members (archers/wolves/priests/paladins) end up stopping at a previous waypoint instead of their final endpoint.  They will still despawn properly and shouldn't impact viability of the quest, but I don't have time to dig into why that's happening
- All of the giants/orcs spawn immediately after handing in the marching orders and are attackable.  A player could turn this in and just go wipe the fort and wait for the script to finish.  Not really an issue, though one idea is to update the script to make the NPCs attackable only at Garadain's call for charge.
- While I have done a lot of local testing, I have not tested this using the instances that THJ supports.  There shouldn't be any logic that flows between instances, but it is something I have not tested yet. 