### PR TITLE
Ring 9 quest script fixes

### DIFF
--- a/eastwastes/#Captain_Berradin.pl
+++ b/eastwastes/#Captain_Berradin.pl
@@ -1,4 +1,28 @@
 sub EVENT_SPAWN {
-quest::doanim(16);
-quest::say("uuugghh I dont feel so good...");
+  quest::doanim(16);
+  quest::say("Uhhh... I'm not feeling so good.  Someone call for a cleric.");
+}
+
+sub EVENT_AGGRO { # have all body guards attack
+  quest::say("Yer messin with the wrong Coldain, prepare ta meet yer ancestors!");
+  my $bgStoneberg = $entity_list->GetMobByNpcTypeID(116100);
+  my $bgNergan = $entity_list->GetMobByNpcTypeID(116059);
+  my $bgPersevil = $entity_list->GetMobByNpcTypeID(116061);
+  my $bgMarganel = $entity_list->GetMobByNpcTypeID(116060);
+
+  if ($bgStoneberg){
+    $bgStoneberg->AddToHateList($client, 1);
+  }
+
+  if ($bgNergan){
+    $bgNergan->AddToHateList($client, 1);
+  }
+
+  if ($bgPersevil){
+    $bgPersevil->AddToHateList($client, 1);
+  }
+
+  if ($bgMarganel){
+    $bgMarganel->AddToHateList($client, 1);
+  }
 }

--- a/eastwastes/Garadain_Glacierbane.pl
+++ b/eastwastes/Garadain_Glacierbane.pl
@@ -113,7 +113,7 @@ sub EVENT_ITEM {
 
   if (plugin::check_handin(\%itemcount, 30135 => 1)) {
     quest::say("Ahh, that'll do fine. Take this, it is but a trinket for now, but continue to serve the Coldain and it will grow in power. I must get some rest now, for I have been told my [nephew] has disappeared again and I will need to track him down tomorrow.");
-    quest::summonitem(30131); # Item: Copper Coldain Insignia Ring
+    quest::summonfixeditem(2030131); # Item: Copper Coldain Insignia Ring
 
 #   Factions: +Coldain, +Dain Frostreaver IV, -Kromrif, -Kromzek
     quest::faction(406, 30); # Faction: Coldain
@@ -130,7 +130,7 @@ sub EVENT_ITEM {
 
   elsif (plugin::check_handin(\%itemcount,30267 => 1, 30131 => 1)) {
     quest::say("Well done friend! My nephew is safe at home and his thirst for adventure is quenched for now. The beast will claim no more of our people. I couldn't have handled it better myself. Now I can get back to the business of [hunting].");
-    quest::summonitem(30133); # Item: Silver Coldain Insignia Ring
+    quest::summonfixeditem(2030133); # Item: Silver Coldain Insignia Ring
 
 #   Factions: +Coldain, +Dain Frostreaver IV, -Kromrif, -Kromzek
     quest::faction(406, 30); # Faction: Coldain
@@ -147,7 +147,7 @@ sub EVENT_ITEM {
 
   elsif (plugin::check_handin(\%itemcount, 30133 => 1, 30137 => 1)) {
     quest::say("Hrmm, not quite the work of a Coldain. Barely functional, in fact. I'll be needing to touch this up a bit. Fetch me a Coldain [smithing hammer] and I'll be sure to tell my associates in Thurgadin of your deeds.");
-    quest::summonitem(30132); # Item: Gold Coldain Insignia Ring
+    quest::summonfixeditem(2030132); # Item: Gold Coldain Insignia Ring
 
 #   Factions: +Coldain, +Dain Frostreaver IV, -Kromrif, -Kromzek
     quest::faction(406, 30); # Faction: Coldain
@@ -164,7 +164,7 @@ sub EVENT_ITEM {
 
   elsif (plugin::check_handin(\%itemcount, 30140 => 1, 30132 => 1)) {
     quest::say("Ahh, there we go now, that's more like it. It would be time to return to the hunt were it not for the [plans] our spies have discovered.");
-    quest::summonitem(30134); # Item: Platinum Coldain Insignia Ring
+    quest::summonfixeditem(2030134); # Item: Platinum Coldain Insignia Ring
 
 #   Factions: +Coldain, +Dain Frostreaver IV, -Kromrif, -Kromzek
     quest::faction(406, 30); # Faction: Coldain
@@ -181,7 +181,7 @@ sub EVENT_ITEM {
 
   elsif (plugin::check_handin(\%itemcount, 30141 => 1, 30134 => 1)) {
     quest::say("Without your assistance, we would have lost our camp and our lives. Again, I thank you. Now that you have proven your loyalty to the throne I have a special [favor] to ask of you.");
-    quest::summonitem(30268); # Item: Obsidian Coldain Insignia Ring
+    quest::summonfixeditem(2030268); # Item: Obsidian Coldain Insignia Ring
 
 #   Factions: +Coldain, +Dain Frostreaver IV, -Kromrif, -Kromzek
     quest::faction(406, 30); # Faction: Coldain
@@ -199,7 +199,7 @@ sub EVENT_ITEM {
   elsif (plugin::check_handin(\%itemcount, 1045 => 1, 18084 => 1, 30268 => 1)) {
     quest::emote("lowers his head and mutters");
     quest::say("At least there will be some closure for their families, thanks to you. The Ry`gorr will pay for this with their lives! I will ask you to help us in the invasion of Ry`gorr keep, but first I have a delicate [mission] I was hoping you'd handle.");
-    quest::summonitem(30162); # Item: Mithril Coldain Insignia Ring
+    quest::summonfixeditem(2030162); # Item: Mithril Coldain Insignia Ring
 
 #   Factions: +Coldain, +Dain Frostreaver IV, -Kromrif, -Kromzek
     quest::faction(406, 30); # Faction: Coldain
@@ -216,7 +216,7 @@ sub EVENT_ITEM {
 
   elsif (plugin::check_handin(\%itemcount, 1047 => 1)) {
     quest::say("Thank you, $name, your service to our people has been most helpful. The time has come for our people to make war with the Ry`gorr. They must pay for their transgressions against our people. We are just waiting on you. Prepare yourself for glorious battle and tell me when you are [ready].");
-    quest::summonitem(30163); # Item: Adamantium Coldain Insignia Ring
+    quest::summonfixeditem(2030163); # Item: Adamantium Coldain Insignia Ring
 
 #   Factions: +Coldain, +Dain Frostreaver IV, -Kromrif, -Kromzek
     quest::faction(406, 30); # Faction: Coldain

--- a/eastwastes/Korrigain.pl
+++ b/eastwastes/Korrigain.pl
@@ -9,7 +9,7 @@ sub EVENT_SAY {
 
 sub EVENT_ITEM { 
   if (plugin::check_handin(\%itemcount, 30268 => 1)) {
-    quest::summonfixeditem("30268");
+    quest::summonfixeditem("2030268");
 
 
     my $mobid = $entity_list->GetMobByNpcTypeID(116110);

--- a/greatdivide/118061.lua
+++ b/greatdivide/118061.lua
@@ -17,7 +17,7 @@ function event_enter(e)
 		lapker = eq.get_entity_list():GetMobByNpcTypeID(118075);
 		laima = eq.get_entity_list():GetMobByNpcTypeID(118073);
 		fomgrut = eq.get_entity_list():GetMobByNpcTypeID(118072);
-		herga = eq.get_entity_list():GetMobByNpcTypeID(118072);
+		herga = eq.get_entity_list():GetMobByNpcTypeID(118074);
 		e.self:Say("Good day my friends, it is good to see you all are alive and well.");
 		eq.set_timer("one",8000);
 	end

--- a/thurgadinb/#Councilor_Juliah_Lockheart.pl
+++ b/thurgadinb/#Councilor_Juliah_Lockheart.pl
@@ -1,0 +1,5 @@
+sub EVENT_SPAWN {
+  quest::say("FOOL!  You've ruined everything!");
+  quest::pause(1);
+  quest::say("You'll pay with your life for meddling in the affairs of others!");
+}

--- a/thurgadinb/#Dain_Frostreaver_IV.pl
+++ b/thurgadinb/#Dain_Frostreaver_IV.pl
@@ -1,4 +1,7 @@
 # items: 1567, 1500, 30164, 30369, 1465, 30516, 30502, 1199, 8895, 8896, 8886, 8898, 8897
+
+my $ring_9_bucket_key = "-dain-ring-9-box-status"; # we will set this back to 0 once the player hands in the box of traitor heads
+
 sub EVENT_SIGNAL {
 	if($signal==1) {
 		quest::moveto(6,777,66,256,1);
@@ -60,6 +63,7 @@ sub EVENT_ITEM {
     quest::faction(419,-50); #Kromrif
     quest::faction(448,-50); #Kromzek
     quest::exp(4000000);
+    quest::set_data($client->CharacterID() . $ring_9_bucket_key, "0"); # the player will no longer be able to get a box from Seneschal unless they show the 8th ring to him again.
   }
   #Tormax's head
   elsif($faction <= 4 && plugin::check_handin(\%itemcount, 30516 => 1)) {

--- a/thurgadinb/#Dain_Frostreaver_IV.pl
+++ b/thurgadinb/#Dain_Frostreaver_IV.pl
@@ -44,9 +44,10 @@ sub EVENT_SAY {
     quest::say("I fear that spies lurk in every corner. You may need to help the General reach the gnomish camp if the Kromrif have gotten word of our efforts. You should call on any allies that you have to assist in case they ambush you. Brell bless you $name, good luck.");
   }
   if ($text=~/count/i && plugin::check_hasitem($client, 1465)) {
-    if ($faction <= 5 || $faction >= 8) {
-      quest::say("Several of our greatest officers, including a few veterans from the war of Yesterwinter are assembling just outside our city. Gather your army at once and give this parchment and the ninth ring to Sentry Badian. I will remain inside the city with a few of my troops to defend it against any who might penetrate your defense. May Brell be with you, $name.");
-	  quest::summonitem(1567); #Declaration of War
+    if ($faction <= 5 || $faction >= 8) { # ring 10 war has not been tested.  Blocking this functionality until it can be fully tested.
+	    #      quest::say("Several of our greatest officers, including a few veterans from the war of Yesterwinter are assembling just outside our city. Gather your army at once and give this parchment and the ninth ring to Sentry Badian. I will remain inside the city with a few of my troops to defend it against any who might penetrate your defense. May Brell be with you, $name.");
+	    #quest::summonitem(1567); #Declaration of War
+	    quest::say("We have much work to do before we can declare war upon the giants.  Come back later once we are prepared".);
     }
   }
 }
@@ -76,7 +77,7 @@ sub EVENT_ITEM {
   }
 #Dirk handin for the 10th ring
   elsif($faction == 1 && plugin::check_handin(\%itemcount, 1465 => 1)) {
-    quest::say("My good $name, you have served me well. You have flushed out all who sought to oppose me and my people. I am afraid I need to call upon you and your friends one final time. The dissention and treason ran deeper than I had anticipated. Our population has been cleansed, but we lost a full third of our army to the poisonous words of those rebels. In retaliation for your deeds, the Kromrif have made plans to attack us in this, our weakest hour. Can I count on your help outlander?");
+    quest::say("My good $name, you have served me well. You have flushed out all who sought to oppose me and my people. I am afraid I need to call upon you and your friends one final time. The dissention and treason ran deeper than I had anticipated. Our population has been cleansed, but we lost a full third of our army to the poisonous words of those rebels. In retaliation for your deeds, the Kromrif have made plans to attack us in this, our weakest hour. Can I [count] on your help outlander?");
     quest::summonitem(1465); # Item: Dirk of the Dain
   }
   # Runed Coldain Prayer Shawl (7th shawl)

--- a/thurgadinb/#Dain_Frostreaver_IV.pl
+++ b/thurgadinb/#Dain_Frostreaver_IV.pl
@@ -5,7 +5,7 @@ sub EVENT_SIGNAL {
 		
 	}
 	if($signal==2) {
-		quest::moveto(4,690,69,256,1);
+		quest::moveto(5,692,69,256,1);
 		
 	}
 }

--- a/thurgadinb/Councilor_Juliah_Lockheart.pl
+++ b/thurgadinb/Councilor_Juliah_Lockheart.pl
@@ -14,7 +14,10 @@ sub EVENT_ITEM {
     my $x = $npc->GetX(); 
     my $y = $npc->GetY(); 
     my $z = $npc->GetZ(); 
-    quest::spawn2(129063,0,0,$x,$y,$z,$h); # NPC: #Councilor_Juliah_Lockheart
+    $mymobid = quest::spawn2(129063,0,0,$x,$y,$z,$h); # NPC: #Councilor_Juliah_Lockheart
+    $mymob = $entity_list->GetMobID($mymobid);
+    $mymobNPC = $mymob->CastToNPC();
+    $mymobNPC->AddToHateList($client, 1);
     quest::depop_withtimer(); 
   } 
   plugin::return_items(\%itemcount); 

--- a/thurgadinb/Seneschal_Aldikar.pl
+++ b/thurgadinb/Seneschal_Aldikar.pl
@@ -1,74 +1,114 @@
-#my $x = npc->GetX();
-#my $y = npc->GetY();
-#my $z = npc->GetZ();
 # items: 17055, 30164
 
+# bucket status values for bucket "CharacterID-dain-ring-9-status"
+# empty = player has not shown the ring to Seneschal yet.  Will not be able to use the say phrase to get a box
+# 1 = player has shown the ring, will be able to use the say phrase to get the box while Seneschal is in his bedroom
+
+
+my $bucket_key = "-dain-ring-9-box-status";
+my $moving = 0; # used to prevent speaking while moving
+my $sayStatus = 0; # used to force a player to listen to our story before rushing to the say statement
+
 sub EVENT_SIGNAL {
-	if($signal==1) {
-		quest::moveto(5,780,38,260,1);
-	}
-	if($signal==2) {
-		quest::moveto(-3,693,69,252,1);
-	}
+  if($signal==1) {
+    quest::debug("Seneschal is leaving location: x=" . $npc->GetX() . " y=" . $npc->GetY() . " z=" . $npc->GetZ());
+    quest::moveto(5,780,38,260,1); # move to the bedroom
+    $moving = 1;
+    quest::settimer(98,1);
+  }elsif($signal==2) {
+    quest::debug("Seneschal is leaving location: x=" . $npc->GetX() . " y=" . $npc->GetY() . " z=" . $npc->GetZ());
+    quest::moveto(-3,693,69,252,1); # move up to the throne room
+    $moving = 1;
+    quest::settimer(99,1);
+  }
 }
 
-#sub EVENT_SPAWN {
-#  quest::settimer("thurgdaynight",5);
-#  my $dainring = undefined;
-#}
-
 sub EVENT_SAY{
-  if($text=~/I will accept this task/i){
-    quest::say("In this box, place the accursed dirk of the fallen Rodrick. With it combine the heads of every traitor you dispose of. When this is done give the box and the velium insignia ring to the Dain directly. On behalf of the crown and all good Coldain, I thank you ... May Brell be with you.");
-    quest::summonitem("17055"); 
-#    $dainring = undefined;
-#    quest::settimer("thurgdaynight",5);
+  if ($moving == 0 && $sayStatus == 1){ # don't allow syntax while moving or telling our story
+    if($text=~/accept this task/i){
+      if(quest::get_data($client->CharacterID() . $bucket_key)=="1"){ # they have shown the ring to Seneschal
+        if (!plugin::check_hasitem($client,17055) && !plugin::check_hasitem($client,1500)){ # Issue the quest item if they don't have it or the resulting item already
+          quest::say("In this box, place the accursed dirk of the fallen Rodrick. With it combine the heads of every traitor you dispose of. When this is done give the box and the velium insignia ring to the Dain directly. On behalf of the crown and all good Coldain, I thank you ... May Brell be with you.");
+          quest::summonitem("17055");
+	  quest::settimer(97, 5); # We have issued the box.  Wait 5 seconds and say Farewell before patrolling back to the throne room
+        } else {
+          quest::say("Go get the heads of the traitors and return them to me in the box I provided you.");
+        }
+      } else {
+        quest::say("I must speak to the Dain before I instruct you further.  Please speak to me while the royal court is in session.");
+      } 
+    }
   }
 }
 
 sub EVENT_ITEM {
-#  if(plugin::check_handin(\%itemcount, 30164 => 1) && $x == -3 && $y == 693 && $z == 68.5) {
-#    quest::say("Well done %t, I have heard of your victory over the Ry'Gorr. If you are willing to assist the crown further please follow me.");
-#    quest::summonitem(30164);
-#    quest::stoptimer("thurgdaynight");
-#    quest::settimer(10,1);
-#  }
-#  elsif(plugin::check_handin(\%itemcount, 30164 => 1) && $x == 3.25 && $y == 773.25 && $z == 35) {
-#    quest::say("I must speak to the Dain before I instruct you further. Please speak to me while the royal court is in session.");
-#    quest::summonitem(30164);
-#  }
-#  else {
+  my $npcX = $npc->GetX();
+  my $npcY = $npc->GetY();
+
+  if(plugin::check_handin(\%itemcount, 30164 => 1)) {  # Showing us the 8th ring.  Get the current position of the NPC and progress if in throne room.  Else, tell them to wait until morning
+    if($npcX == -3 && $npcY == 693) { # Throne Room
+      quest::say("Well done %t, I have heard of your victory over the Ry'Gorr. If you are willing to assist the crown further please follow me.");
+      $npc->SignalNPC(1); # move to the bedroom 
+      quest::set_data($client->CharacterID() . $bucket_key, "1"); # update player data bucket
+      quest::settimer(10,1); # start the timer to allow time to path to the bedroom
+    }
+    else {
+      quest::say("I must speak to the Dain before I instruct you further. Please speak to me while the royal court is in session.");
+    }
+    quest::summonitem(2030164); # give the ring back to the player.  We assume it will already be the legendary version
+  }
+  else {
     plugin::return_items(\%itemcount);
-#  }
+  }
 }
 
-#sub EVENT_TIMER {
-#  elsif($timer == 10 && $x == 3.25 && $y == 773.25 && $z == 35) {
-#    quest::stoptimer(10);
-#    quest::pause(100);
-#    quest::say("Please, shut the door behind you. What I am about to share with you must not be overheard.");
-#    quest::settimer(11,10);
-#  }
-#  elsif($timer == 11) {
-#    quest::stoptimer(11);
-#    quest::say("My army stands prepared to launch an assault on Kael itself, but one task must be completed before this can happen.");
-#    quest::settimer(12,10);
-#  }
-#  elsif($timer == 12) {
-#    quest::stoptimer(12);
-#    quest::say("It seems Rodrick was not alone in his treachery. There is a faction of Coldain who believe that a treaty should be signed with the Kromrif, ending our hostilities with them. This, of course, is impossible. If there is one thing our history here has taught us it is that the Kromrif simply cannot be trusted.");
-#    quest::settimer(13);
-#  }
-#  elsif($timer == 13) {
-#    quest::stoptimer(13);
-#    quest::say("These traitors are poisoning the minds of our citizens, promising great rewards to those who will betry the Dain. It will take the unbiased eye of an outlander to flush out the masterminds behind this plan. Once again we turn to you.");
-#    quest::settimer(14);
-#  }
-#  elsif($timer == 14) {
-#    quest::stoptimer(14);
-#    quest::say("Will you accept this task outlander?");
-#    $dainring = 1;
-#  }
-#}
+sub EVENT_TIMER {
+  if($timer == 10 && $x == 5 && $y == 780) {
+     quest::stoptimer(10);
+     quest::pause(100);
+     quest::say("Please, shut the door behind you. What I am about to share with you must not be overheard.");
+     quest::settimer(11,10);
+     $moving = 0;
+  }
+  elsif($timer == 11) {
+    quest::stoptimer(11);
+    quest::say("My army stands prepared to launch an assault on Kael itself, but one task must be completed before this can happen.");
+    quest::settimer(12,10);
+  }
+  elsif($timer == 12) {
+    quest::stoptimer(12);
+    quest::say("It seems Rodrick was not alone in his treachery. There is a faction of Coldain who believe that a treaty should be signed with the Kromrif, ending our hostilities with them. This, of course, is impossible. If there is one thing our history here has taught us it is that the Kromrif simply cannot be trusted.");
+    quest::settimer(13,10);
+  }
+  elsif($timer == 13) {
+    quest::stoptimer(13);
+    quest::say("These traitors are poisoning the minds of our citizens, promising great rewards to those who will betry the Dain. It will take the unbiased eye of an outlander to flush out the masterminds behind this plan. Once again we turn to you.");
+    quest::settimer(14,10);
+  }
+  elsif($timer == 14) {
+    quest::stoptimer(14);
+    quest::say("Will you [accept this task] outlander?");
+    $sayStatus=1;
+  }
+  elsif($timer == 97) { # Have given the box to the player, say farewell and move back up to the throne room
+    quest::stoptimer(97);
+    quest::say("Farewell");
+    $sayStatus=0;
+    quest::pause(1);
+    $npc->SignalNPC(2);
+  }
+  elsif($timer == 98) { # Change moving status once we're in bedroom
+    if($npc->GetX() == 5 && $npc->GetY() == 780){
+      quest::stoptimer(98);
+      $moving=0;
+    }
+  }
+  elsif($timer == 99) { # Change moving status once we're in throne room
+    if($npc->GetX() == -3 && $npc->GetY() == 693){
+      quest::stoptimer(99);
+      $moving=0;
+    }
+  }
+}
 
 #END of FILE Zone:thurgadinb  ID:Not_Found -- Seneschal_Aldikar 


### PR DESCRIPTION
- Fixed Seneschal social interaction and pathing.  He will not give the box for the 9th ring quest until you show him the 8th ring, follow him to his room, listen to his speech, and say the proper text.  He will walk back up to the throne room after you accept the box from him.  He will not speak to the player while he is moving.
- Fixed Captain Berradin fight so bodyguards properly attack you
- Fixed Korrigan and Garadain quest scripts so that rings are awarded or handed back to you as legendary (item ID + 2 million and used summonfixeditem())
- Fixed the Murdrick quest script to fix an issue where one of his buddies was not attacking due to incorrect ID.  Players do not need to be invisible nor do they need to wait for him to finish his speech.  They can kill him and just ignore the lore if they want to (but who would want to?!)
- Corrected Dain's move to location so he's more central to his throne.  The king must be centered!
- Fixed Councilor Juliah Lockheart's quest script so she properly attacks the player now (though her faction needs to be removed so other dwarves don't assist her)
- Dain will not hand out the declaration of war item, which blocks the 10th ring war from being started until we can complete testing.
