### PR TITLE
Adjust script to match Bristlebane's original delay.

### DIFF
--- a/mischiefplane/Bristlebane_the_King_of_Thieves.pl
+++ b/mischiefplane/Bristlebane_the_King_of_Thieves.pl
@@ -7,7 +7,7 @@ sub EVENT_COMBAT {
 	if($combat_state == 0) {
 		$npc->SetHP(685000);
   		quest::setnexthpevent(90);
-		quest::modifynpcstat("attack_delay", "12");
+		quest::modifynpcstat("attack_delay", "30");
   		quest::modifynpcstat("max_hit", "1904");
 		quest::modifynpcstat("min_hit", "680");	
 
@@ -90,7 +90,7 @@ sub EVENT_HP {  # adds does not aggro unless within aggro range
 		quest::setnexthpevent(20);
 		quest::emote("shakes with laughter and says, 'You are much stronger than I thought. Looks like I'm gonna have to use all the tricks of the trade!' He then shouts a string of mystical words and is suddenly surrounded by a magical glowing aura and his attacks become a blur as he launches into a quickened attack routine.");
 		quest::modifynpcstat("ac", "1087");
-		quest::modifynpcstat("attack_delay", "8");
+		quest::modifynpcstat("attack_delay", "20");
 		quest::modifynpcstat("mr", "500");
 		quest::modifynpcstat("pr", "500");
 		quest::modifynpcstat("pr", "500");
@@ -105,7 +105,7 @@ sub EVENT_HP {  # adds does not aggro unless within aggro range
 		quest::spawn2(126377,0,0,-110,840,178,0); # a_dazed_guardian_jester
 		quest::spawn2(126375,0,0,-127,840,178,0); # a_devious_guardian_jokester
 		quest::emote("shakes with laughter and says, 'You are much stronger than I thought. Looks like I'm gonna have to use all the tricks of the trade!' He then shouts a string of mystical words and is suddenly surrounded by a magical glowing aura and his muscles bulge with incomprehensible strength. ");
-		quest::modifynpcstat("attack_delay", "12");
+		quest::modifynpcstat("attack_delay", "30");
 		quest::modifynpcstat("max_hit", "1950");
 		quest::modifynpcstat("min_hit", "715");	
 	}


### PR DESCRIPTION
### Problem

When re-engaging Bristlebane on live his behavior did not seem to match the first attempt.  Based on the raw data I found at [(https://www.thjdi.cc/npc/126373)](https://www.thjdi.cc/npc/126373) it appears his attack_delay is set to 30 on THJ but the script was written against an attack delay of 12 (which is what you would see in a ProjectEQ database snapshot).

The end result is when combat ends instead of getting reset to a delay of 30 he is set to a delay of 12 which will be notably faster the next time you attempt to kill him.

### Change

I've assumed that anywhere in the script that used delay '12' meant it was resetting him back to his original delay.  In those cases I changed it to 30 to match the original value being pulled from the database.

Additionally, I've changed the delay change at 30% hp from '8' to '20'.  Assuming the 8 was originally chosen based off an original delay of 12 I've applied the same math adjusted for a starting delay of 30.  In other words 8/12 = 20/30.  I'm not sure if this was the correct approach, I'm just assuming that if the original delay was changed from 12 to 30 to make the encounter easier then adjusting this value as well would be appropriate.