### PR TITLE
[Bug Fix] Adjust weapon charms for THJ Multiclass

### DIFF
--- a/airplane/Drakis_Bloodcaster.lua
+++ b/airplane/Drakis_Bloodcaster.lua
@@ -1,7 +1,7 @@
 -- Necromancer Epic NPC -- Drakis_Bloodcaster
 function event_say(e)
 	if e.message:findi("hail") then
-		e.self:Say("Greetings, " .. e.other:Race() .. ". Are you ready to begin?");
+		e.self:Say("Greetings, " .. e.other:GetRaceName() .. ". Are you ready to begin?");
 	elseif e.message:findi("ready")  then
 		e.self:Say("Then choose, necromancer. Do you wish to be tested by Dugaas or Jzil?");
 	elseif e.message:findi("ready") then

--- a/global/items/CHRMCasterWeapon.lua
+++ b/global/items/CHRMCasterWeapon.lua
@@ -26,16 +26,28 @@ function event_scale_calc(e)
                              [16] = {14,51,80}
     }
 
+    local class_id  = 0;
+
+    if e.owner:HasClass(Class.NECROMANCER) then
+        class_id = Class.NECROMANCER;
+    elseif e.owner:HasClass(Class.WIZARD) then
+        class_id = Class.WIZARD;
+    elseif e.owner:HasClass(Class.MAGICIAN) then
+        class_id = Class.MAGICIAN;
+    elseif e.owner:HasClass(Class.ENCHANTER) then
+        class_id = Class.ENCHANTER;
+    end
+
     for id, v in pairs(skill_matrix) do
-        if ( e.owner:GetClass() == v[1]) then
-            if(e.owner:GetSkill(v[2]) >= v[3]) then
+        if class_id == v[1] then
+            if e.owner:GetSkill(v[2]) >= v[3] then
                 max_skills = max_skills + 1;
             end
             total_count = total_count + 1;
         end
     end
 
-    if(total_count <= 0) then
+    if total_count <= 0 then
         total_count = 0.1; -- to avoid NAN
     end
 

--- a/global/items/CHRMLightMeleeWeap.lua
+++ b/global/items/CHRMLightMeleeWeap.lua
@@ -32,9 +32,21 @@ function event_scale_calc(e)
                              [22] = {15,51,180}
     }
 
+    local class_id  = 0;
+
+    if e.owner:HasClass(Class.RANGER) then
+        class_id = Class.RANGER;
+    elseif e.owner:HasClass(Class.MONK) then
+        class_id = Class.MONK;
+    elseif e.owner:HasClass(Class.ROGUE) then
+        class_id = Class.ROGUE;
+    elseif e.owner:HasClass(Class.BEASTLORD) then
+        class_id = Class.BEASTLORD;
+    end
+
     for id, v in pairs(skill_matrix) do
-        if ( e.owner:GetClass() == v[1]) then
-            if(e.owner:GetSkill(v[2]) >= v[3]) then
+        if class_id == v[1] then
+            if e.owner:GetSkill(v[2]) >= v[3] then
                 max_skills = max_skills + 1;
             end
             total_count = total_count + 1;

--- a/global/items/CHRMPlateWeapon.lua
+++ b/global/items/CHRMPlateWeapon.lua
@@ -5,8 +5,8 @@
 
 function event_scale_calc(e)
 
-    local max_skills = 0;
-    local total_count = 0;
+    local max_skills    = 0;
+    local total_count   = 0;
 
     local skill_matrix = {   [1] = {1,0,250},
                              [2] = {1,1,250},
@@ -31,18 +31,30 @@ function event_scale_calc(e)
                              [21] = {8,1,270},
                              [22] = {8,36,270},
                              [23] = {8,51,120}
-    }
+    };
+
+    local class_id  = 0;
+
+    if e.owner:HasClass(Class.WARRIOR) then
+        class_id = Class.WARRIOR;
+    elseif e.owner:HasClass(Class.PALADIN) then
+        class_id = Class.PALADIN;
+    elseif e.owner:HasClass(Class.SHADOWKNIGHT) then
+        class_id = Class.SHADOWKNIGHT;
+    elseif e.owner:HasClass(Class.SHADOWKNIGHT) then
+        class_id = Class.SHADOWKNIGHT;
+    end
 
     for id, v in pairs(skill_matrix) do
-        if ( e.owner:GetClass() == v[1]) then
-            if(e.owner:GetSkill(v[2]) >= v[3]) then
+        if class_id == v[1] then
+            if e.owner:GetSkill(v[2]) >= v[3] then
                 max_skills = max_skills + 1;
             end
             total_count = total_count + 1;
         end
     end
 
-    if(total_count <= 0) then
+    if total_count <= 0 then
         total_count = 0.1; -- to avoid NAN
     end
 

--- a/global/items/CHRMPriestWeapon.lua
+++ b/global/items/CHRMPriestWeapon.lua
@@ -5,8 +5,8 @@
 
 function event_scale_calc(e)
 
-    local max_skills = 0;
-    local total_count = 0;
+    local max_skills    = 0;
+    local total_count   = 0;
 
     local skill_matrix = {   [1] = {2,0,190},
                              [2] = {2,2,190},
@@ -17,18 +17,28 @@ function event_scale_calc(e)
                              [7] = {10,0,200},
                              [8] = {10,2,200},
                              [9] = {10,36,200}
-    }
+    };
+
+    local class_id  = 0;
+
+    if e.owner:HasClass(Class.CLERIC) then
+        class_id = Class.CLERIC;
+    elseif e.owner:HasClass(Class.DRUID) then
+        class_id = Class.DRUID;
+    elseif e.owner:HasClass(Class.SHAMAN) then
+        class_id = Class.SHAMAN;
+    end
 
     for id, v in pairs(skill_matrix) do
-        if ( e.owner:GetClass() == v[1]) then
-            if(e.owner:GetSkill(v[2]) >= v[3]) then
+        if class_id == v[1] then
+            if e.owner:GetSkill(v[2]) >= v[3] then
                 max_skills = max_skills + 1;
             end
             total_count = total_count + 1;
         end
     end
 
-    if(total_count <= 0) then
+    if total_count <= 0 then
         total_count = 0.1; -- to avoid NAN
     end
 

--- a/paineel/Taralani_Rahnta.lua
+++ b/paineel/Taralani_Rahnta.lua
@@ -1,0 +1,19 @@
+function event_say(e)
+	if e.message:findi("hail") then
+		e.self:Say("Greetings. " .. e.other:GetCleanName() .. ".  You have found the only place to purchase liquor in this fine city.  It seems that many of my countrymen do not appreciate liquor as I do.  Fear not if you spill. I have plenty of [skeletal servants] to clean up the mess.");
+	elseif e.message:findi("skeletal servants") then
+		e.self:Say("Can't you see. child?  These dead servants of mine are bussing tables and dancing!  They work incredibly cheaply.  Heh.  Don't try to harm them. though. they don't like that very much. Say. would you like to see something interesting?");
+	elseif e.message:findi("interest") then
+		e.self:Emote("removes a satchel from under the counter. He opens it up to reveal a collection of strange looking tools.  You have never seen their likeness anywhere on Norrath. The Bartender says, 'A traveling merchant sold these to me a while ago. They belonged to one of the ancient Vah'Shir before they were.. removed. They're worth thousands of platinum based on their historical significance alone, but I'll part with them for only 1000. Some collector's item, eh?'");
+	end
+end
+
+function event_trade(e)
+	local item_lib = require("items");
+
+	if item_lib.check_turn_in(e.trade, {platinum = 1000}) then
+		e.self:Emote("beams the brightest smile you've ever seen in this dark place at you when you tell him you accept his offer. He quickly hands you the satchel and takes the platinum eagerly. As you leave, you swear you hear chuckle at something.");
+		e.other:QuestReward(e.self,0,0,0,0,17062); -- Item: Kejekan Tool Kit
+	end
+	item_lib.return_items(e.self, e.other, e.trade)
+end

--- a/paineel/Taralani_Rahnta.pl
+++ b/paineel/Taralani_Rahnta.pl
@@ -1,9 +1,0 @@
-sub EVENT_SAY { 
-if($text=~/Hail/i){
-quest::say("Greetings. $name.  You have found the only place to purchase liquor in this fine city.  It seems that many of my countrymen do not appreciate liquor as I do.  Fear not if you spill. I have plenty of [skeletal servants] to clean up the mess.");
-}
-if($text=~/what skeletal servants/i){
-quest::say("Can't you see. child?  These dead servants of mine are bussing tables and dancing!  They work incredibly cheaply.  Heh.  Don't try to harm them. though. they don't like that very much. Say. would you like to see something interesting?"); }
-}
-#END of FILE Zone:paineel  ID:75095 -- Taralani_Rahnta 
-

--- a/skyshrine/#Oglard.lua
+++ b/skyshrine/#Oglard.lua
@@ -2,7 +2,7 @@
 function event_say(e)
 	if(e.other:GetFaction(e.self) < 2) then
 		if(e.message:findi("hail")) then
-			e.self:Say("Greetings, young " .. e.other:Race() .. ". Very few of your kind has ever seen the halls you now walk through. You must have provided a great service to our kin for them to allow you passage into this inner sanctum. We welcome you to our ancient home.");
+			e.self:Say("Greetings, young " .. e.other:GetRaceName() .. ". Very few of your kind has ever seen the halls you now walk through. You must have provided a great service to our kin for them to allow you passage into this inner sanctum. We welcome you to our ancient home.");
 		elseif(e.message:findi("thank you")) then
 			e.self:Say("Might, wisdom, and manners? Quite a surprise to see all of these traits in one of the younger races. I am impressed. I see you are a noble creature, one who would treat another creature of nobility with respect... 'Oglard's eyes suddenly begin to shine with a magical golden light. He looks down upon you as if in judgement and asks, 'Tell me, " .. e.other:GetCleanName() .. ", have you done battle with dragons?'");
 		elseif(e.message:findi("no I have not")) then


### PR DESCRIPTION
- This will use the lowest id class the player has for the skill check.

Example:

if you are a Necromancer, Wizard, Magician combo (weird flex). You would be bound to the skill checks for the Necromancer as it is the lowest class id.