### PR TITLE
[Bug Fix] Necromancer Skull Cap

### DIFF
--- a/cabwest/Harbinger_Glosk.lua
+++ b/cabwest/Harbinger_Glosk.lua
@@ -11,28 +11,39 @@ function event_enter(e)
 end
 
 function event_say(e)
-	local qglobals = eq.get_qglobals(e.self,e.other);
+	local faction = e.other:GetFaction(e.self) <= 4
+
 	if e.message:findi("hail") then
 		e.self:Emote("halts his chanting. 'You dare to interrupt me? You had best have a good reason. I care not for small talk.'");
 	elseif e.message:findi("keepers grotto") then
 		e.self:Say("Keepers Grotto is where you shall find the Keepers. They study and scribe the spells of our dark circle. The grotto is not far from here, near the arena called the Gauntlet.");
-	elseif e.message:findi("new revenant") then
-		e.self:Emote("Harbinger Glosk ceases his chanting and gazes into your mind. 'Yes. You are. You shall do as I command. Take this. It is incomplete and must be ready for the emperor within the half season. You must find the [four missing gems]. When you have them, you will have to quest for the [" .. eq.say_link("forge of dalnir",false,"Grand Forge of Dalnir") .. "]. Within its fire, all shall combine. Return the sceptre to me with your revenant skullcap. Go.'")
-		e.other:SummonItem(12873); -- Item; Unfinished Sceptre
-	elseif e.message:findi("forge of dalnir") then
-		e.self:Emote("scratches his chin. 'I know little of it other than that it once belonged to the ancient Haggle Baron, Dalnir. From what I have read, its fires require no skill, but will melt any common forge hammer used. Dalnir was said to have called upon the ancients for a hammer which could tolerate the magical flames.'");
-	elseif qglobals.necskullquest ~= nil and tonumber(qglobals.necskullquest) >= 9 then
-		if e.message:findi("gem of reflection") then
-			e.self:Say("I have not been asked that in ages but I can recall the last person that asked me. If you are in league with that scoundrel Ixpacan, I will slay you where you stand! But if you are not, you will not mind ridding your kin of a [menace] as of late.");
-		elseif e.message:findi("menace") then
-			e.self:Say("It seems as though a rogue marauder in a jungle near here has attacked several of our trade suppliers. If you can bring me back his head I will gladly share the information you have asked for.");
+	elseif faction then
+		if e.other:GetBucket("Skull_Cap") == "6" then
+			if e.message:findi("new revenant") then
+				e.self:Emote("Harbinger Glosk ceases his chanting and gazes into your mind. 'Yes. You are. You shall do as I command. Take this. It is incomplete and must be ready for the emperor within the half season. You must find the [four missing gems]. When you have them, you will have to quest for the [" .. eq.say_link("forge of dalnir",false,"Grand Forge of Dalnir") .. "]. Within its fire, all shall combine. Return the sceptre to me with your revenant skullcap. Go.'")
+				if not e.other:HasItem(12873) then	-- Don't allow hoarding
+					e.other:SummonItem(12873);		-- Item: Unfinished Sceptre
+				end
+			elseif e.message:findi("four missing gems") then
+				e.self:Say("The missing sceptre gems are: an Eye of Rokgus, a Gem of Yet to Come, a Heart of Torsis and the Crown Jewel of Ganak.");
+			elseif e.message:findi("forge of dalnir") then
+				e.self:Emote("scratches his chin. 'I know little of it other than that it once belonged to the ancient Haggle Baron, Dalnir. From what I have read, its fires require no skill, but will melt any common forge hammer used. Dalnir was said to have called upon the ancients for a hammer which could tolerate the magical flames.'");
+			end
+		elseif e.other:GetBucket("Skull_Cap") == "9" then
+			if e.message:findi("gem of reflection") then
+				e.self:Say("I have not been asked that in ages but I can recall the last person that asked me. If you are in league with that scoundrel Ixpacan, I will slay you where you stand! But if you are not, you will not mind ridding your kin of a [menace] as of late.");
+			elseif e.message:findi("menace") then
+				e.self:Say("It seems as though a rogue marauder in a jungle near here has attacked several of our trade suppliers. If you can bring me back his head I will gladly share the information you have asked for.");
+			end
 		end
+	else
+		e.self:Say("When you have shown more devotion to the Brood of Kotiz, we can discuss such things.");
 	end
 end
 
 function event_trade(e)
-	local item_lib = require("items");
-	local qglobals = eq.get_qglobals(e.self,e.other);
+	local item_lib	= require("items");
+	local faction	= e.other:GetFaction(e.self) <= 4
 
 	if item_lib.check_turn_in(e.trade, {item1 = 18207}) then -- Item: Guild Summons
 		e.self:Say("Another apprentice has reached rebirth. You now have become one with the Brood of Kotiz. We study the ancient writing of Kotiz. Through his writing we have found the power of the dark circles. Listen well to the scholars within this tower and seek the [" .. eq.say_link("Keepers Grotto") .. "] for knowledge of our spells. This drape shall be the sign to all Iksar that you walk with the Brood. Now go speak with Xydoz.");
@@ -40,12 +51,16 @@ function event_trade(e)
 		e.other:SummonItem(12407);	-- Item: Drape of the Brood
 		e.other:Faction(443,100);	-- Faction: Brood of Kotiz
 		e.other:Faction(441,25);	-- Faction: Legion of Cabilis
-	elseif item_lib.check_turn_in(e.trade, {item1 = 12874, item2 = 4265}) then -- Items: Sceptre of Emperor Vekin and Revenant Skullcap
+	elseif faction and e.other:GetBucket("Skull_Cap") == "6" and item_lib.check_turn_in(e.trade, {item1 = 12874, item2 = 4265}) then -- Items: Sceptre of Emperor Vekin and Revenant Skullcap
 		e.self:Emote("presents to you a glowing skullcap. 'This is the treasured cap of the sorcerers of this tower. Let all gaze upon you in awe. You are what others aspire to be. I look forward to reading of your adventures, Sorceror " .. e.other:GetName() .. ".'");
 		e.other:QuestReward(e.self,{exp = 10000, platinum = 2});
-		e.other:SummonItem(4266);	-- Item: Sorcerer Skullcap
-		e.other:Faction(443,10);	-- Faction: Brood of Kotiz
-		e.other:Faction(441,2);		-- Faction: Legion of Cabilis
+		e.other:SummonItem(4266);				-- Item: Sorcerer Skullcap
+		e.other:Faction(443,10);				-- Faction: Brood of Kotiz
+		e.other:Faction(441,2);					-- Faction: Legion of Cabilis
+		e.other:SetBucket("Skull_Cap", "7");	-- Skullcap 7 is completed.
+	elseif faction and e.other:GetBucket("Skull_Cap") == "9" and item_lib.check_turn_in(e.trade, {item1 = 48037}) then -- Item: Rogue Marauder's Head
+		e.self:Say("You have done well in doing what I have asked. To make a gem of reflection you will need some Mt Death mineral salts, a green goblin skin, spiroc bone dust, essence of rathe, blue slumber fungus, and a vial of pure essence. Combine all of these in this container and you will have what it is you seek.");
+		e.other:SummonItem(48039);	-- Item: Glosk's Sack
 	elseif item_lib.check_turn_in(e.trade, {item1 = 14794}) then -- Item: Illegible Note: Boots
 		e.self:Emote("hisses and says venomously, 'And I am disturbed yet again. I hope for your sake it is important.'");
 		e.self:Emote("The gaunt necromancer looks down at the paper in his hands and after reading a few lines gasps, then falls into a violent coughing fit. After recovering he takes a deep breath, puffs his chest out and hands the paper back to you. With his head held high, he says in a raspy voice, 'Show this to Rixiz. He will test you.'");
@@ -54,9 +69,6 @@ function event_trade(e)
 		e.self:Emote("snatches the note out of your hands, obviously irritated. After reading a few lines, he glances up at you, his brow furrowed, then looks down again to continue reading. When he's finished, he hands the note back to you and takes a deep breath, shuddering slightly. He then says, 'Xydoz. Take this to Xydoz. He will test you.'");
 		e.self:Emote("watches you carefully as you leave.");
 		e.other:SummonItem(14793);	-- Item: Illegible Note: Greaves
-	elseif qglobals.necskullquest ~= nil and tonumber(qglobals.necskullquest) >= 9 and item_lib.check_turn_in(e.trade, {item1 = 48037}) then -- Item: Rogue Marauder's Head
-		e.self:Say("You have done well in doing what I have asked. To make a gem of reflection you will need some Mt Death mineral salts, a green goblin skin, spiroc bone dust, essence of rathe, blue slumber fungus, and a vial of pure essence. Combine all of these in this container and you will have what it is you seek.");
-		e.other:SummonItem(48039);	-- Item: Glosk's Sack
 	end
 	item_lib.return_items(e.self, e.other, e.trade);
 end

--- a/cabwest/Keeper_Rott.lua
+++ b/cabwest/Keeper_Rott.lua
@@ -1,21 +1,26 @@
 function event_say(e)
+	local faction = e.other:GetFaction(e.self) <= 4
+
 	if e.message:findi("Hail") then
 		e.self:Emote("bows before you. His eyes are kept wide by the pins which distort his eyelids.");
 		e.self:Say("Greetings! You have stumbled upon the cave of the Keepers. We record the arcane secrets of the Brood of Kotiz. We have scribed many spells and make them available to all those who are deserving. Please, have a look.");
-	elseif e.message:findi("chosen occultist") then
-		e.self:Emote("kneels before you abjectly.");
-		e.self:Say("Oh, great occultist! I am glad you have arrived, but I do not have the artifacts Kyvix seeks. You will have to seek out the sarnak revenants who still hold the precious stem and base. Get them and take them with your occultist skullcap back to Master Kyvix. Since you are headed in the general direction, I also have an [additional mission], if you do not mind.");
-	elseif e.message:findi("additional mission") then
-		e.self:Emote("grabs a fist full of scribbled notes and throws them into the air in a rage.");
-		e.self:Say("All these notes are useless to me without the first four note pages! While I ventured through the fields of the drixies, I was assaulted by a band of gobs. They were shamans. I heard them calling spirits. They took the first two pages before I escaped. Then I lost the [second two pages] the next day!! Blast!!");
-	elseif e.message:findi("second two pages") then
-		e.self:Emote("begins to curse. Luckily, you do not understand the language, but you feel a bit of spittle strike your face.");
-		e.self:Say("...and then there I was, almost home and the legion expedition leader decided we should explore a bit more near the lake. Then I find myself up against the same type of gobs from the fields. I just ran for the exit an never looked back, but they still managed to swipe pages 3 and 4!!");
+	elseif faction and tonumber(e.other:GetBucket("Skull_Cap")) >= 5 then
+		if e.message:findi("chosen occultist") then
+			e.self:Emote("kneels before you abjectly.");
+			e.self:Say("Oh, great occultist! I am glad you have arrived, but I do not have the artifacts Kyvix seeks. You will have to seek out the sarnak revenants who still hold the precious stem and base. Get them and take them with your occultist skullcap back to Master Kyvix. Since you are headed in the general direction, I also have an [additional mission], if you do not mind.");
+		elseif e.message:findi("additional mission") then
+			e.self:Emote("grabs a fist full of scribbled notes and throws them into the air in a rage.");
+			e.self:Say("All these notes are useless to me without the first four note pages! While I ventured through the fields of the drixies, I was assaulted by a band of gobs. They were shamans. I heard them calling spirits. They took the first two pages before I escaped. Then I lost the [second two pages] the next day!! Blast!!");
+		elseif e.message:findi("second two pages") then
+			e.self:Emote("begins to curse. Luckily, you do not understand the language, but you feel a bit of spittle strike your face.");
+			e.self:Say("...and then there I was, almost home and the legion expedition leader decided we should explore a bit more near the lake. Then I find myself up against the same type of gobs from the fields. I just ran for the exit an never looked back, but they still managed to swipe pages 3 and 4!!");
+		end
 	end
 end
 
 function event_trade(e)
 	local item_lib = require("items");
+	local faction = e.other:GetFaction(e.self) <= 4
 
 	if item_lib.check_turn_in(e.trade, {item1 = 12854, item2 = 12855, item3 = 12856, item4 = 12857}) then -- Items: An Illegible Note (Notepage 1 Of Rott), (Notepage 2 Of Rott), (Notepage 3 Of Rott) and (Notepage 4 Of Rott)
 		e.self:Say("Oh, great necromancer, how can I repay you?!! I know. Here is a spell I recently researched. It should help you increase the strength of a summoned pet. Learn it well.");

--- a/cabwest/Master_Kyvix.lua
+++ b/cabwest/Master_Kyvix.lua
@@ -1,42 +1,56 @@
 function event_say(e)
-	if e.message:findi("hail") and e.other:HasItem(4264) then -- Item: Occultist Skullcap
-		e.self:Say("So you are expecting to earn your way to rank of revenant, eh? You shall when I have the base and stem of the candle your occultist skullcap.");
-	elseif e.message:findi("hail") then
-		e.self:Say("Quite busy!! Quite busy!! Things must be done. [New components] to be collected!!");
-	elseif e.message:findi("New components") then
-		e.self:Say("Yes, yes!! I will need components from beyond the gates. I must find an [apprentice of the third rank].");
-	elseif e.message:findi("apprentice of the third rank") then
-		e.self:Say("If you truly be an apprentice of the third circle, then there is a Dark Binder skullcap to be earned. Take this sack and fill it with a creeper cabbage, a heartsting telson with venom, brutling choppers and a scalebone femur. When they are combined within the sack, you may return it to me with your third rank skullcap and and we shall bid farewell to the title, apprentice.");
-		e.other:SummonItem(17024); -- Item: Brood Sack
-	elseif e.message:findi("true mission") then
-		e.self:Say("I have been waiting for a Nihilist to return. His name was Ryx and I fear his love of ale and the high seas has kept him from his mission. All I want you to do is find him. He should be disguised as a worker and he will give you a tome to bring to me. Return it with your Dark Binder Cap. I am sure that is simple enough for one as simple as you. Be sure to give him this.");
-		e.other:SummonItem(12848); -- Item: A Spectacle
-	elseif e.message:findi("Kor Sha Candlestick") then
-		e.self:Say("I need the foot and stem of my candlestick. The Stem comes from Sarnaks. The foot has been stolen by Gripe, in East Cabilis.");
+	local faction = e.other:GetFaction(e.self) <= 4
+
+	if faction and e.other:GetBucket("Skull_Cap") == "3" then
+		if e.message:findi("hail") then
+			e.self:Say("Quite busy!! Quite busy!! Things must be done. [New components] to be collected!!");
+		elseif e.message:findi("New components") then
+			e.self:Say("Yes, yes!! I will need components from beyond the gates. I must find an [apprentice of the third rank].");
+		elseif e.message:findi("apprentice of the third rank") then
+			e.self:Say("If you truly be an apprentice of the third circle, then there is a Dark Binder skullcap to be earned. Take this sack and fill it with a creeper cabbage, a heartsting telson with venom, brutling choppers and a scalebone femur. When they are combined within the sack, you may return it to me with your third rank skullcap and and we shall bid farewell to the title, apprentice.");
+			if not e.other:HasItem(17024) then	-- Don't allow hoarding
+				e.other:SummonItem(17024);		-- Item: Brood Sack
+			end
+		end
+	elseif faction and e.other:GetBucket("Skull_Cap") == "4" then
+		if e.message:findi("true mission") then
+			e.self:Say("I have been waiting for a Nihilist to return. His name was Ryx and I fear his love of ale and the high seas has kept him from his mission. All I want you to do is find him. He should be disguised as a worker and he will give you a tome to bring to me. Return it with your Dark Binder Cap. I am sure that is simple enough for one as simple as you. Be sure to give him this.");
+			if not e.other:HasItem(12848) then	-- Don't allow hoarding
+				e.other:SummonItem(12848);		-- Item: A Spectacle
+			end
+		end
+	elseif faction and e.other:GetBucket("Skull_Cap") == "5" then
+		if e.message:findi("hail") then
+			e.self:Say("I did not expect you to return. You have made me lose a bet with one of the other scholars. Seeing as you have delivered the tome, I shall not harm you, but rather welcome you into the rank of occultist. Now go see Keeper Rott and tell him you are [the chosen occultist]");
+		end
 	end
 end
 
 function event_trade(e)
-	local item_lib = require("items");
-	if item_lib.check_turn_in(e.trade, {item1 = 12420, item2 = 4262}) then -- Items: full component sack, apprentice skullcap
-		e.self:Say("Well done, here's your fourth rank skull cap. You can now start your [true mission].");
+	local item_lib	= require("items");
+	local faction	= e.other:GetFaction(e.self) <= 4
+	if faction and e.other:GetBucket("Skull_Cap") == "3" and item_lib.check_turn_in(e.trade, {item1 = 12420, item2 = 4262}) then -- Items: full component sack, apprentice skullcap
+		e.self:Say("You have taken far too long!! Already another apprentice has performed this task. You will still be rewarded with the Dark Binder skullcap, but now you must aid in a [true mission].");
 		e.other:QuestReward(e.self,{exp = 200, gold = 15});
-		e.other:SummonItem(4263);	-- Item: Dark Binder Skullcap
-		e.other:Faction(441,2);		-- Faction: Legion of Cabilis
-		e.other:Faction(443,10);	-- Faction: Brood of Kotiz
-	elseif item_lib.check_turn_in(e.trade, {item1 = 18065, item2 = 4263}) then -- Items: a journal and dark binder skullcap
-		e.self:Say("Well done, here's your fifth rank skull cap. You can now track down the [Kor Sha Candlestick].");
+		e.other:SummonItem(4263);				-- Item: Dark Binder Skullcap
+		e.other:Faction(441,2);					-- Faction: Legion of Cabilis
+		e.other:Faction(443,10);				-- Faction: Brood of Kotiz
+		e.other:SetBucket("Skull_Cap", "4");	-- Skullcap 4 is completed.
+	elseif faction and e.other:GetBucket("Skull_Cap") == "4" and item_lib.check_turn_in(e.trade, {item1 = 18065, item2 = 4263}) then -- Items: a journal and dark binder skullcap
+		e.self:Say("I did not expect you to return. You have made me lose a bet with one of the other scholars. Seeing as you have delivered the tome, I shall not harm you, but rather welcome you into the rank of occultist. Now go see Keeper Rott and tell him you are [the chosen occultist]");
 		e.other:QuestReward(e.self,{exp = 200, gold = 20});
-		e.other:SummonItem(4264);	-- Item: Occultist Skullcap
-		e.other:Faction(441,2);		-- Faction: Legion of Cabilis
-		e.other:Faction(443,10);	-- Faction: Brood of Kotiz
-	elseif item_lib.check_turn_in(e.trade, {item1 = 12853, item2 = 12852, item3 = 4264}) then -- Items: Stem of Candlestick, Foot of Candlestick, occultist skullcap
+		e.other:SummonItem(4264);				-- Item: Occultist Skullcap
+		e.other:Faction(441,2);					-- Faction: Legion of Cabilis
+		e.other:Faction(443,10);				-- Faction: Brood of Kotiz
+		e.other:SetBucket("Skull_Cap", "5");	-- Skullcap 5 is completed.
+	elseif faction and e.other:GetBucket("Skull_Cap") == "5" and item_lib.check_turn_in(e.trade, {item1 = 12853, item2 = 12852, item3 = 4264}) then -- Items: Stem of Candlestick, Foot of Candlestick, occultist skullcap
 		e.self:Emote("grabs the candle parts and puts them in an odd pouch, then takes your cap which disintegrates in his palm. He hands you another cap.");
 		e.self:Say("Welcome, Revenant " .. e.other:GetName() .. ". You have done well. The Harbinger awaits you. He seeks a [new revenant].");
 		e.other:QuestReward(e.self,{exp = 200, gold = 6});
-		e.other:SummonItem(4265);	-- Item: Revenant Skullcap
-		e.other:Faction(441,2);		-- Faction: Legion of Cabilis
-		e.other:Faction(443,10);	-- Faction: Brood of Kotiz
+		e.other:SummonItem(4265);				-- Item: Revenant Skullcap
+		e.other:Faction(441,2);					-- Faction: Legion of Cabilis
+		e.other:Faction(443,10);				-- Faction: Brood of Kotiz
+		e.other:SetBucket("Skull_Cap", "6");	-- Skullcap 6 is completed.
 	end
 	item_lib.return_items(e.self, e.other, e.trade)
 end

--- a/cabwest/Master_Rixiz.lua
+++ b/cabwest/Master_Rixiz.lua
@@ -1,27 +1,36 @@
 function event_say(e)
-	if e.message:findi("hail") then
-		e.self:Say("You are on the grounds of the Brood of Kotiz. If you do not belong, you must leave at once. There shall be no [third rank skullcap] for you.");
-	elseif e.message:findi("third rank skullcap") then
-		e.self:Say("I offer the third rank apprentice skullcap to those who wear the second. If that is you, then you will do the [bidding of the tower].");
-	elseif e.message:findi("bidding of the tower") then
-		e.self:Say("Take this glass canopic. Within it you shall place a brain for me. The brain I seek is that of a sarnak crypt raider. Any shall do. The ones we seek should be near the Lake of Ill Omen. When you obtain the brain, you must quickly put it into the glass canopic with [embalming fluid]. When these are combined, the canopic shall seal and if you return it to me with your second rank skullcap, I shall hand you the next and final skullcap.");
-		e.other:SummonItem(17023); -- Item: Brood Canopic
-		e.self:Say("You shall get no skullcap until I have the preserved raider brain and your second circle apprentice skullcap.");
-	elseif e.message:findi("embalming fluid") then
-		e.self:Say("Embalming fluid is created through brewing, but do not drink it!! You can learn about the process of brewing on our grounds.");
-	elseif e.message:findi("speak to the dead") then
-		e.self:Say("How dare you ask of such a thing! I am a Master of the Necromantic Arts. If you wish to have me conjure this spirit you must first seek out a traitor to our cause. His name is Ixzec. He can be found roaming with a group of renegades in a jungle not far from here. Return with his head and some items from the soul you want summoned and I will aid you in your request.");
+	local faction = e.other:GetFaction(e.self) <= 4
+
+	if faction and e.other:GetBucket("Skull_Cap") == "2" then
+		if e.message:findi("hail") then
+			e.self:Say("You are on the grounds of the Brood of Kotiz. If you do not belong, you must leave at once. There shall be no [third rank skullcap] for you.");
+		elseif e.message:findi("third rank skullcap") then
+			e.self:Say("I offer the third rank apprentice skullcap to those who wear the second. If that is you, then you will do the [bidding of the tower].");
+		elseif e.message:findi("bidding of the tower") then
+			e.self:Say("Take this glass canopic. Within it you shall place a brain for me. The brain I seek is that of a sarnak crypt raider. Any shall do. The ones we seek should be near the Lake of Ill Omen. When you obtain the brain, you must quickly put it into the glass canopic with [embalming fluid]. When these are combined, the canopic shall seal and if you return it to me with your second rank skullcap, I shall hand you the next and final skullcap.");
+			if not e.other:HasItem(17023) then	-- Don't allow hoarding
+				e.other:SummonItem(17023);		-- Item: Brood Canopic
+			end
+			e.self:Say("You shall get no skullcap until I have the preserved raider brain and your second circle apprentice skullcap.");
+		elseif e.message:findi("embalming fluid") then
+			e.self:Say("Embalming fluid is created through brewing, but do not drink it!! You can learn about the process of brewing on our grounds.");
+		elseif e.message:findi("speak to the dead") then
+			e.self:Say("How dare you ask of such a thing! I am a Master of the Necromantic Arts. If you wish to have me conjure this spirit you must first seek out a traitor to our cause. His name is Ixzec. He can be found roaming with a group of renegades in a jungle not far from here. Return with his head and some items from the soul you want summoned and I will aid you in your request.");
+		end
 	end
 end
 
 function event_trade(e)
-	local item_lib = require("items");
-	if item_lib.check_turn_in(e.trade, {item1 = 12411, item2 = 4261}) then -- Items: Preserved Sarnak Brain and Apprentice Skullcap - 2nd Rank
+	local item_lib	= require("items");
+	local faction	= e.other:GetFaction(e.self) <= 4
+
+	if faction and e.other:GetBucket("Skull_Cap") == "2" and item_lib.check_turn_in(e.trade, {item1 = 12411, item2 = 4261}) then -- Items: Preserved Sarnak Brain and Apprentice Skullcap - 2nd Rank
 		e.self:Say("You have done well. Here is your final apprentice skullcap.");
 		e.other:QuestReward(e.self,{exp = 150, gold = 10});
-		e.other:SummonItem(4262);	-- Item: Apprentice Skullcap - 3rd Rank
-		e.other:Faction(441,2);		-- Faction: Legion of Cabilis
-		e.other:Faction(443,10);	-- Faction: Brood of Kotiz
+		e.other:SummonItem(4262);				-- Item: Apprentice Skullcap - 3rd Rank
+		e.other:Faction(441,2);					-- Faction: Legion of Cabilis
+		e.other:Faction(443,10);				-- Faction: Brood of Kotiz
+		e.other:SetBucket("Skull_Cap", "3");	-- Skullcap 3 is completed.
 	elseif item_lib.check_turn_in(e.trade, {item1 = 14794}) then -- Item: Illegible Note: Boots
 		e.self:Emote("takes the note and after reading a few lines opens his eyes wide in astonishment. He looks up at you and stares at you a while before he says,");
 		e.self:Say("You spoke to the Brothers? A common soldier such as yourself interested in silly stories to frighten broodlings? Fine, then. You shall know confidence, if you live. If you have the strength to stride into a lair, go before the owner, and kill that thing in its own home, you will acquire a small part of the virtue we as necromancers must master to ply our art. In the Frontier Mountains lives a unit of the troublesome burynai. Invade their home and destroy their leader. Bring me proof and two fire emeralds.");

--- a/cabwest/Master_Xydoz.lua
+++ b/cabwest/Master_Xydoz.lua
@@ -1,31 +1,43 @@
 function event_say(e)
-	if e.message:findi("hail") then
-		e.self:Say("What is it you seek within the tower? Could it be that you are a new apprentice? If so, you are required to don the [apprentice skullcap]");
-	elseif e.message:findi("apprentice") then
-		e.self:Say("All new members of the Brood of Kotiz are required to don the apprentice skullcap. To earn one, a new apprentice is required to fetch four brains for further experiments. Not just any four brains, mind you, but the brains of [sarnak] hatchlings.");
-	elseif e.message:findi("sarnak") then
-		e.self:Say("Sarnak ? Do not speak loudly, that name. If you seek information on the sarnak, read the tome of this tower. The tower librarian should be found within.");
-	elseif e.message:findi("second rank skullcap") then
-		e.self:Say("Looking for the second rank skullcap ? Look no further, but be prepared to earn it. I seek a [faded tapestry]. Now, too, so do you.");
-	elseif e.message:findi("faded tapestry") then
-		e.self:Say("I have heard reports of such a thing found upon Sarnak hatchlings. They must have scampered from the safety of their dwelling with their master's property. I would like to see this tapestry, but only when it has been mended. I need find a necromancer who is [adept at tailoring].");
-	elseif e.message:findi("adept at tailoring") then
-		e.self:Say("If you are a member of the Brood and wish to assist you may seek out this tapestry. Find the Torn and Ripped pieces and take them both to a sewing kit. Return with the mended tapestry and your first rank skullcap and I shall see that you are rewarded with coin and a second rank skullcap");
+	local faction = e.other:GetFaction(e.self) <= 4
+
+	if faction then
+		if e.message:findi("hail") then
+			e.self:Say("What is it you seek within the tower? Could it be that you are a new apprentice? If so, you are required to don the [apprentice skullcap]");
+		elseif e.message:findi("apprentice") then
+			e.self:Say("All new members of the Brood of Kotiz are required to don the apprentice skullcap. To earn one, a new apprentice is required to fetch four brains for further experiments. Not just any four brains, mind you, but the brains of [sarnak] hatchlings.");
+		elseif e.message:findi("sarnak") then
+			e.self:Say("Sarnak ? Do not speak loudly, that name. If you seek information on the sarnak, read the tome of this tower. The tower librarian should be found within.");
+		elseif e.other:GetBucket("Skull_Cap") == "1" then
+			if e.message:findi("second rank skullcap") then
+				e.self:Say("Looking for the second rank skullcap ? Look no further, but be prepared to earn it. I seek a [faded tapestry]. Now, too, so do you.");
+			elseif e.message:findi("faded tapestry") then
+				e.self:Say("I have heard reports of such a thing found upon Sarnak hatchlings. They must have scampered from the safety of their dwelling with their master's property. I would like to see this tapestry, but only when it has been mended. I need find a necromancer who is [adept at tailoring].");
+			elseif e.message:findi("adept at tailoring") then
+				e.self:Say("If you are a member of the Brood and wish to assist you may seek out this tapestry. Find the Torn and Ripped pieces and take them both to a sewing kit. Return with the mended tapestry and your first rank skullcap and I shall see that you are rewarded with coin and a second rank skullcap");
+			end
+		end
+	else
+		e.self:Say("When you have shown more devotion to the Brood of Kotiz, we can discuss such things.");
 	end
 end
 
 function event_trade(e)
 	local item_lib = require("items");
-	if e.other:GetFaction(e.self) <= 4 and item_lib.check_turn_in(e.trade, {item1 = 12408, item2 = 12408, item3 = 12408, item4 = 12408}) then -- Amiable or Better and Items: 4x Sarnak Hatchling Brain
+	local faction = e.other:GetFaction(e.self) <= 4
+
+	if faction and item_lib.check_turn_in(e.trade, {item1 = 12408, item2 = 12408, item3 = 12408, item4 = 12408}) then -- Amiable or Better and Items: 4x Sarnak Hatchling Brain
 		e.self:Say("Good work, my young apprentice. You will make a fine addition to our ranks. Here is your first apprentice skullcap. Wear it as a sign of our circle. Do not lose it. Someday you shall wear a necromancer skullcap, but next shall come the [second rank skullcap].");
 		e.other:QuestReward(e.self,{exp = 100});
-		e.other:SummonItem(4260);	-- Item: Apprentice Skullcap - 1st Rank
-	elseif e.other:GetFaction(e.self) <= 4 and item_lib.check_turn_in(e.trade, {item1 = 4260, item2 = 18208}) then -- Apprentice Skullcap - 1st Rank and Item: Mended Tapestry
+		e.other:SummonItem(4260);				-- Item: Apprentice Skullcap - 1st Rank
+		e.other:SetBucket("Skull_Cap", "1");	-- Skullcap 1 is completed.
+	elseif faction and e.other:GetBucket("Skull_Cap") == "1" and item_lib.check_turn_in(e.trade, {item1 = 4260, item2 = 18208}) then -- Apprentice Skullcap - 1st Rank and Item: Mended Tapestry
 		e.self:Say("A job well done, apprentice. Your fine service shall earn you the second circle apprentice skullcap. I would advise you to forget this tapestry, it is nothing more than an ancient rug of no importance.");
 		e.other:QuestReward(e.self,{exp = 120, copper = 10, gold = 1});
-		e.other:SummonItem(4261);	-- Item: Apprentice Skullcap - 2nd Rank
-		e.other:Faction(441,2);		-- Faction: Legion of Cabilis
-		e.other:Faction(443,10);	-- Faction: Brood of Kotiz
+		e.other:SummonItem(4261);				-- Item: Apprentice Skullcap - 2nd Rank
+		e.other:Faction(441,2);					-- Faction: Legion of Cabilis
+		e.other:Faction(443,10);				-- Faction: Brood of Kotiz
+		e.other:SetBucket("Skull_Cap", "2");	-- Skullcap 2 is completed.
 	elseif item_lib.check_turn_in(e.trade, {item1 = 14793}) then -- Item: Illegible Note: Greaves
 		e.self:Emote("snatches the paper from your hand and hisses in anger. Without even looking at the paper he growls");
 		e.self:Say("WHAT?! What is this tra... He stares down at the paper, mouth hanging open wide in disbelief. He finally continues, saying, Very well, then. If you wish to know confidence I have a task for you. Our hated enemies, the sarnak, have a tome we have sought to return to our libraries for centuries. At this point, we believe it to be found in a small fortress they maintain near the Great Lake. One of their scholars will most likely have it on their person. Bring it to me along with two star rubies.");

--- a/cabwest/an_Iksar_hermit.lua
+++ b/cabwest/an_Iksar_hermit.lua
@@ -1,28 +1,36 @@
 function event_say(e)
-	if e.message:findi("Hail") then
-		e.self:Say("I am looking for a [great sorcerer]. Are you such a person?");
-	elseif e.message:findi("great sorcerer") and e.other:HasItem(4266) and e.other:GetLevel() > 34 then
-		e.self:Say("Are we now? Well then take this. See if you can finish this project that I started so many years ago. It still requires a [whip], a [tassel], and a [lock]. Go and find these items and return to me with what you have already learned and I shall reward you.");
-		e.other:SummonItem(17195); -- Item: A Flaxen Hilt
-	elseif e.message:findi("whip") then
-		e.self:Say("Many years ago in Dreadlans a drovarg came and ravaged my camp and stole a whip that was given to me by my master. With the loss of the whip I became an outcast to the dark arts.");
-	elseif e.message:findi("tassel") then
-		e.self:Say("You should find a large ghostly tassel, I was on my way to Kaesora to learn about this tassel but my age has hindered this adventure. You should go there and see what you can find.");
-	elseif e.message:findi("lock") then
-		e.self:Say("Only a goblins hair is strong enough to hold this together. Go and slay them till you find a lock of hair strong enough for this.");
+	local faction = e.other:GetFaction(e.self) <= 4
+
+	if faction and e.other:GetBucket("Skull_Cap") == "7" then
+		if e.message:findi("Hail") then
+			e.self:Say("I am looking for a [great sorcerer]. Are you such a person?");
+		elseif e.message:findi("great sorcerer") and e.other:HasItem(4266) and e.other:GetLevel() > 34 then
+			e.self:Say("Are we now? Well then take this. See if you can finish this project that I started so many years ago. It still requires a [whip], a [tassel], and a [lock]. Go and find these items and return to me with what you have already learned and I shall reward you.");
+			if not e.other:HasItem(17195) then	-- Don't allow hoarding
+				e.other:SummonItem(17195);		-- Item: A Flaxen Hilt
+			end
+		elseif e.message:findi("whip") then
+			e.self:Say("Many years ago in Dreadlans a drovarg came and ravaged my camp and stole a whip that was given to me by my master. With the loss of the whip I became an outcast to the dark arts.");
+		elseif e.message:findi("tassel") then
+			e.self:Say("You should find a large ghostly tassel, I was on my way to Kaesora to learn about this tassel but my age has hindered this adventure. You should go there and see what you can find.");
+		elseif e.message:findi("lock") then
+			e.self:Say("Only a goblins hair is strong enough to hold this together. Go and slay them till you find a lock of hair strong enough for this.");
+		end
 	else
 		e.self:Say("You have many more deeds yet to accomplish.");
 	end
 end
 
 function event_trade(e)
-	local item_lib = require("items");
-	if item_lib.check_turn_in(e.trade, {item1 = 12886, item2 = 4266}) then -- Items: Barbed Scaled Whip and Sorcerer Skullcap
+	local item_lib	= require("items");
+	local faction	= e.other:GetFaction(e.self) <= 4
+	if faction and e.other:GetBucket("Skull_Cap") == "7" and item_lib.check_turn_in(e.trade, {item1 = 12886, item2 = 4266}) then -- Items: Barbed Scaled Whip and Sorcerer Skullcap
 		e.self:Emote("takes the flail and vanishes with a brilliant flash!! Within your hands appears a skullcap. You hear a voice echo through the cave. Well done. You are a formidable necromancer. We thank you.");
 		e.other:QuestReward(e.self,{exp = 10000, platinum = 2});
-		e.other:SummonItem(4267);	-- Item: Necromancer Skullcap
-		e.other:Faction(443,10);	-- Faction: Brood of Kotiz
-		e.other:Faction(441,2);		-- Faction: Legion of Cabilis
+		e.other:SummonItem(4267);				-- Item: Necromancer Skullcap
+		e.other:Faction(443,10);				-- Faction: Brood of Kotiz
+		e.other:Faction(441,2);					-- Faction: Legion of Cabilis
+		e.other:SetBucket("Skull_Cap", "8");	-- Skullcap 8 is completed.
 		eq.depop_with_timer();
 	else
 		e.self:Say("All is not complete. A cap and the rest, which was asked for, is required.");

--- a/overthere/93182.lua
+++ b/overthere/93182.lua
@@ -2,10 +2,11 @@
 
 function event_trade(e)
 	local item_lib = require("items");
-	if e.other:GetLevel() >= 20 and item_lib.check_turn_in(e.trade, {item1 = 12848, item2 = 12850, item3 = 12851, item4 = 12610}) then
+	if e.other:GetLevel() >= 20 and e.other:GetBucket("Skull_Cap") == "4" and item_lib.check_turn_in(e.trade, {item1 = 12848, item2 = 12850, item3 = 12851, item4 = 12610}) then
+		e.self:Emote(" takes your hand and guides it into his ribcage. You feel something odd. It is a metal key!");
 		e.other:QuestReward(e.self,{exp = 2000});
 		e.other:SummonItem(12849);	-- Item: A metal key
-	elseif item_lib.check_turn_in(e.trade, {item1 = 12848}) then	-- Item: A Spectacle
+	elseif e.other:GetBucket("Skull_Cap") == "4" and item_lib.check_turn_in(e.trade, {item1 = 12848}) then	-- Item: A Spectacle
 		e.self:Emote(" stops working and begins to open his creaking jaw. 'I live to study and quench my thirst. I live to Bash the Faces of Pariah and entangle myself in the ivy of evergreen. I live. I want to remember.'");
 		e.other:QuestReward(e.self,0,0,0,0,12848);	-- Item: A Spectacle
 	end

--- a/overthere/Ixpacan.lua
+++ b/overthere/Ixpacan.lua
@@ -1,43 +1,50 @@
 function event_say(e)
-	local qglobals = eq.get_qglobals(e.self,e.other);
+	local faction = e.other:GetFaction(e.self) <= 4
 
-	if e.message:findi("hail") then
-		e.self:Say("Hmm... is there something I can help you with? I am far too [busy] to listen to your problems though so I take that back.");
-	elseif e.message:findi("busy") then
-		e.self:Say("It is none of your concern unless you are truly gifted in the dark art of necromancy. If so, you will have some form of proof to show me.");
-	elseif e.message:findi("wish to hear") and tonumber(qglobals.necskullquest) == 9 then
-		e.self:Say("I have recently found a volume on summoning a great minion from the Great Library of Charasis but I can't find all of the needed items. Being as I am one of the [sages of Cabilis], I request you go and [collect these items] for me.")
-	elseif e.message:findi("sages of Cabilis") and tonumber(qglobals.necskullquest) == 9 then
-		e.self:Say("Ah, they are all but a memory now. We used to be welcome within the city of Cabilis but our quest for greater power led to our exile. No matter now, go retrieve the items and you will be one of the chosen to walk beside greatness")
-	elseif e.message:findi("collect these items") and tonumber(qglobals.necskullquest) == 9 then
-		e.self:Say("As you should broodling. The the first is a brittle bone, which was once used for reincarnations. The second item is a poisoned soul, this is from an iksar that died a cruel and twisted death. The death was so awful, it's spirit still roams around angry. The third you will find in the burning heat. The final item is a gem of reflection. I have yet to find someone that knows how to create one. Even those fools in Cabilis probably wouldn't know. Maybe you can locate that one yourself. Bring all of these items back to me and I shall do the rest.")
-		e.other:SummonItem(48041); -- Item: Ixpacan's Tome
+	if faction and e.other:GetBucket("Skull_Cap") == "8" then
+		if e.message:findi("hail") then
+			e.self:Say("Hmm... is there something I can help you with? I am far too [busy] to listen to your problems though so I take that back.");
+		elseif e.message:findi("busy") then
+			e.self:Say("It is none of your concern unless you are truly gifted in the dark art of necromancy. If so, you will have some form of proof to show me.");
+		end
+	elseif faction and e.other:GetBucket("Skull_Cap") == "9" then -- Started 9 not completed as completing will remove the bucket
+		if e.message:findi("wish to hear") then
+			e.self:Say("I have recently found a volume on summoning a great minion from the Great Library of Charasis but I can't find all of the needed items. Being as I am one of the [sages of Cabilis], I request you go and [collect these items] for me.")
+		elseif e.message:findi("sages of Cabilis") then
+			e.self:Say("Ah, they are all but a memory now. We used to be welcome within the city of Cabilis but our quest for greater power led to our exile. No matter now, go retrieve the items and you will be one of the chosen to walk beside greatness")
+		elseif e.message:findi("collect these items") then
+			e.self:Say("As you should broodling. The the first is a brittle bone, which was once used for reincarnations. The second item is a poisoned soul, this is from an iksar that died a cruel and twisted death. The death was so awful, it's spirit still roams around angry. The third you will find in the burning heat. The final item is a gem of reflection. I have yet to find someone that knows how to create one. Even those fools in Cabilis probably wouldn't know. Maybe you can locate that one yourself. Bring all of these items back to me and I shall do the rest.")
+			if not e.other:HasItem(48041) then
+				e.other:SummonItem(48041); -- Item: Ixpacan's Tome
+			end
+		end
+	else
+		e.self:Say("Go away, I am far too busy to speak to the likes of you.");
 	end
 end
 
 function event_trade(e)
-	local item_lib = require("items");
-	local qglobals = eq.get_qglobals(e.self,e.other);
+	local item_lib	= require("items");
+	local faction	= e.other:GetFaction(e.self) <= 4
 
-	if tonumber(qglobals.necskullquest) == 9  then
-		if item_lib.check_turn_in(e.trade, {item1 = 48044, item2 = 4267}) then -- Items: Child of Charasis Remains, Necromancer Skullcap
-			e.self:Say("I see now that I lack the skill necessary to control the Dark Arts. Maybe it would be wiser to allow another such as yourself to continue forward. Please accept this token as a reward in your mastering of the Dark Arts.");
-			eq.delete_global("necskullquest");	-- Removed 8th cap and global, must do quest again from cap 1
-			e.other:SummonItem(48043);			-- Item: Demi Lich Skullcap
-		elseif item_lib.check_turn_in(e.trade, {item1 = 48042}) then -- Item: Ixpacan's Tome (Tome-Full)
+	if faction and e.other:GetBucket("Skull_Cap") == "8" and item_lib.check_turn_in(e.trade, {item1 = 4267}) then -- Item: Necromancer Skullcap
+		e.self:Say("Oh, I see you are truly gifted in the dark arts. Well I will explain my dilemma to you now if you [wish to hear].");
+		e.other:SummonItem(4267); -- Item: Necromancer Skullcap
+		e.other:SetBucket("Skull_Cap", "9"); -- Skullcap 9 is started.
+	elseif faction and e.other:GetBucket("Skull_Cap") == "9" then
+		if item_lib.check_turn_in(e.trade, {item1 = 48042}) then -- Item: Ixpacan's Tome (Tome-Full)
 			e.self:Say("Wonderful! You have brought all of the items I have asked for. Your future seems very bright with the rest of the Sages. Step back now as I conjure the child of Charasis.");
 			eq.local_emote({e.self:GetX(), e.self:GetY(), e.self:GetZ()}, MT.LightGray, 150, "As Ixpacan starts his incantations, you can see an image begin to appear from the shadows.");
 			e.self:Say("It's out of my control! Defeat it before it destroys us both!");
 			eq.spawn2(93189,0,0,e.self:GetX() + 5,e.self:GetY(),e.self:GetZ(),e.self:GetHeading()); -- NPC: child_of_Charasis
+		elseif item_lib.check_turn_in(e.trade, {item1 = 48044, item2 = 4267}) then -- Items: Child of Charasis Remains, Necromancer Skullcap
+			e.self:Say("I see now that I lack the skill necessary to control the Dark Arts. Maybe it would be wiser to allow another such as yourself to continue forward. Please accept this token as a reward in your mastering of the Dark Arts.");
+			e.other:DeleteBucket("Skull_Cap");	-- Removed 8th cap and bucket, must do quest again from cap 1
+			e.other:SummonItem(48043);			-- Item: Demi Lich Skullcap
 		elseif item_lib.check_turn_in(e.trade, {item1 = 48044}) then -- Item: Child of Charasis Remains
 			e.self:Say("I don't have the power to process these remains, aid me with your Necromancer Skullcap and provide me the remains and cap!")
 			e.other:SummonItem(48044);	-- Item: Child of Charasis Remains
 		end
-	elseif item_lib.check_turn_in(e.trade, {item1 = 4267}) then -- Item: Necromancer Skullcap
-		eq.set_global("necskullquest", "9", 5,"F"); -- Completed Skullcap Quest 9.1
-		e.self:Say("Oh, I see you are truly gifted in the dark arts. Well I will explain my dilemma to you now if you [wish to hear].");
-		e.other:SummonItem(4267); -- Item: Necromancer Skullcap
 	end
-
 	item_lib.return_items(e.self, e.other, e.trade)
 end

--- a/overthere/Tin_Banker_Assistant.lua
+++ b/overthere/Tin_Banker_Assistant.lua
@@ -8,8 +8,8 @@ end
 
 function event_trade(e)
 	local item_lib = require("items");
-	if item_lib.check_turn_in(e.trade, {item1 = 12849}) then -- Item: A Metal Key
-		e.self:Say("*Whirrrr*");
+	if e.other:GetBucket("Skull_Cap") == "4" and item_lib.check_turn_in(e.trade, {item1 = 12849}) then -- Item: A Metal Key
+		e.self:Emote(" shudders and begins to clang. You hear the sound of an ocean of coins. A small door pops open and a book pops out. A few coins also manage to escape.");
 		e.other:QuestReward(e.self,0,0,0,0,18065); -- Item: Journal
 	end
 end


### PR DESCRIPTION
- Converted each step to its own databucket for tracking. This will prevent step skipping.
- Added missing faction checks
- Added missing flavor text to a few npc's.

NOTE: Players mid way will either need to start over or petition for their progress to be updated as the tracking buckets/globals did not exist prior.