### PR TITLE
Add option for plugin::NPCTell to not send tells

### DIFF
--- a/bazaar/Tearel.pl
+++ b/bazaar/Tearel.pl
@@ -20,8 +20,12 @@ sub EVENT_SAY {
       $rebind_text = "";
     }
 
+    my tell_msg = "[not use tells]";
+    if ($client->GetBucket("no-npc-tell") == 1) {
+      $tell_msg = "[use tells]";
+    }
     plugin::NPCTell("Greetings, $name. I am Tearel, the Keeper of the Map. I can [attune the map] to any rune circles you have previously discovered. If you are part of 
-                    [an expedition] I can also help you return to the heat of the battle.". $group_flg . $rebind_text);
+                    [an expedition] I can also help you return to the heat of the battle. I can also ". $tell_msg . ".". $group_flg . $rebind_text);
 
     return;
   }
@@ -31,6 +35,18 @@ sub EVENT_SAY {
     $client->SetBucket("baz_and_back_bind", $zonesn);
     return;
   }
+  if ($text =~ /not use tells/i) {
+    $client->SetBucket("no-npc-tell", 1);
+    plugin::NPCTell("Very well, I will not use tells with you.");
+    return;
+  }
+  if ($text =~ /use tells/i) {
+    $client->SetBucket("no-npc-tell", 0);
+    plugin::NPCTell("Very well, I will use tells with you.");
+    return;
+  }
+
+
 
   if ($text =~ /attune the map/i) {
       # Get eligible continent names

--- a/ecommons/Son_of_Tearel.pl
+++ b/ecommons/Son_of_Tearel.pl
@@ -20,8 +20,13 @@ sub EVENT_SAY {
       $rebind_text = "";
     }
 
+    my tell_msg = "[not use tells]";
+    if ($client->GetBucket("no-npc-tell") == 1) {
+      $tell_msg = "[use tells]";
+    }
+
     plugin::NPCTell("Greetings, $name. I am Timmy, Son of Tearel, the Keeper of the Other Map. I can [attune the map] to any rune circles you have previously discovered. If you are part of 
-                    [an expedition] I can also help you return to the heat of the battle.". $group_flg . $rebind_text);
+                    [an expedition] I can also help you return to the heat of the battle. I can also" . $tell_msg . "." . $group_flg . $rebind_text);
 
     return;
   }
@@ -29,6 +34,17 @@ sub EVENT_SAY {
   if ($text =~ /attune your Bazaar and Back/i) {
     plugin::NPCTell("Excellent! You will now return to this vicinity whenever you use your Bazaar and Back ability!");
     $client->SetBucket("baz_and_back_bind", $zonesn);
+    return;
+  }
+
+  if ($text =~ /not use tells/i) {
+    $client->SetBucket("no-npc-tell", 1);
+    plugin::NPCTell("Very well, I will not use tells with you.");
+    return;
+  }
+  if ($text =~ /use tells/i) {
+    $client->SetBucket("no-npc-tell", 0);
+    plugin::NPCTell("Very well, I will use tells with you.");
     return;
   }
 

--- a/plugins/cata_general.pl
+++ b/plugins/cata_general.pl
@@ -37,7 +37,10 @@ sub NPCTell {
 
 	my $NPCName = $npc->GetCleanName();
     my $tellColor = 257;
-	
+	if ($client->GetBucket("no-npc-tell") == 1) {
+        YellowText($message, $client);
+        return;
+    }
     $client->Message($tellColor, "$NPCName tells you, '" . $message . "'");
 }
 


### PR DESCRIPTION
This unlocks an option on tearel/son of tearel to allow you to not send tells anymore for NPCs.

When this bucket is set, NPCs will use yellowtext similar to instancing when enabled.