### PR TITLE
[Mischief] Scaling Bristlebane encounter.

### DIFF
--- a/mischiefplane/encounters/Bristlebane_the_King_of_Thieves.lua
+++ b/mischiefplane/encounters/Bristlebane_the_King_of_Thieves.lua
@@ -19,9 +19,29 @@ local event_stat_stages		= {
 	[100]					= {548	,544	,1523	,18	,144	,96		,96		,96		,96		,"You dare try to trick me!"} -- Base Stats
 };
 
+-- Scaling Variables
+local enable_scaling = true;
+local counter_max = 10;         -- How many kills to reach maximum effect
+local counter_min = -10;
+local max_hit_adjust = -200;    -- Maximum amount max attack can be lowered
+local min_hit_adjust = 381;
+local max_hit_adjust2 = -200;   -- Maximum amount min attack can be lowered
+local min_hit_adjust2 = 132;
+local max_delay_adjust = 10;    -- Maximum amount delay can be increased
+local min_delay_adjust = -6;
+local max_resist_adjust = -200; -- Maximum amount resists can be lowered
+local min_resist_adjust = 0;
+local upsidedown_mobs = {126067,126075,126076,126066,126073,126074,126069,126070,126071,126065,126072,126077,126068,126372};
+local alice_mobs = {126023,126052,126046,126048,126050,126047,126049,126051,126040,126042,126043,126037,126039,126041,126038,126044,126045,126309,126307,126308};
+local chess_mobs = {126053,126054,126055,126056,126057,126058,126059,126159,126167,126264};
+local bw_mobs = {126060,126061,126062,126063,126064};
+local theater_mobs = {126029,126100,126101,126102,126103,126104,126105,126106,126107,126108,126109,126110,126111,126112,126113,126114,126115,126116,126117,126118,126119,126120,126121,126122,126123,126124,126125,126126,126304,126305};
+local hardmode_mobs = {126312}; -- white stallion in northwest corner of entry forest
+
 -- Event
 function evt_bristlebane_spawn(e)
 	next_hp_event = 90;
+	set_phase(e, 100);
 	eq.set_next_hp_event(next_hp_event);
 	eq.set_timer("despawn", 2 * 60 * 60 * 1000); -- 2 Hours
 end
@@ -44,19 +64,33 @@ function evt_bristlebane_hp(e)
 		next_hp_event = next_hp_event - 10;
 		eq.set_next_hp_event(next_hp_event);
 
+		local scale_adds = false;
+		if enable_scaling then
+			local add_counter = increment_get_scale_data("adds", 0);
+			if add_counter > 0 and counter_max > 0 and add_counter / counter_max > 0.5 then
+				scale_adds = true;
+			end
+		end
+
 		if e.hp_event == 80 then
 			eq.spawn2(126375,0,0,-88,886,178,384):AddToHateList(e.self:GetHateRandom(),1);	-- NPC: a_devious_guardian_jokester
-			eq.spawn2(126376,0,0,-157,886,178,128):AddToHateList(e.self:GetHateRandom(),1);	-- NPC: a_tricky_guardian_jester 
+			if not scale_adds then
+				eq.spawn2(126376,0,0,-157,886,178,128):AddToHateList(e.self:GetHateRandom(),1);	-- NPC: a_tricky_guardian_jester 
+			end
 		elseif e.hp_event == 50 then
 			eq.spawn2(126375,0,0,-88,886,178,384):AddToHateList(e.self:GetHateRandom(),1);	-- NPC: a_devious_guardian_jokester
 			eq.spawn2(126378,0,0,-157,886,178,128):AddToHateList(e.self:GetHateRandom(),1);	-- NPC: a_charming_guardian_jester
-			eq.spawn2(126377,0,0,-127,840,178,0):AddToHateList(e.self:GetHateRandom(),1);	-- NPC: a_dazed_guardian_jester
+			if not scale_adds then
+				eq.spawn2(126377,0,0,-127,840,178,0):AddToHateList(e.self:GetHateRandom(),1);	-- NPC: a_dazed_guardian_jester
+			end
 		elseif e.hp_event == 20 then
 			eq.spawn2(126377,0,0,-88,886,178,384):AddToHateList(e.self:GetHateRandom(),1);	-- NPC: a_dazed_guardian_jester
 			eq.spawn2(126378,0,0,-157,886,178,128):AddToHateList(e.self:GetHateRandom(),1);	-- NPC: a_charming_guardian_jester
 			eq.spawn2(126377,0,0,-146,840,178,0):AddToHateList(e.self:GetHateRandom(),1);	-- NPC: a_dazed_guardian_jester
-			eq.spawn2(126377,0,0,-110,840,178,0):AddToHateList(e.self:GetHateRandom(),1);	-- NPC: a_dazed_guardian_jester
-			eq.spawn2(126375,0,0,-127,840,178,0):AddToHateList(e.self:GetHateRandom(),1);	-- NPC: a_devious_guardian_jokester
+			if not scale_adds then
+				eq.spawn2(126377,0,0,-110,840,178,0):AddToHateList(e.self:GetHateRandom(),1);	-- NPC: a_dazed_guardian_jester
+				eq.spawn2(126375,0,0,-127,840,178,0):AddToHateList(e.self:GetHateRandom(),1);	-- NPC: a_devious_guardian_jokester
+			end
 		end
 	end
 end
@@ -90,15 +124,22 @@ function reset_event(e)
 end
 
 function set_phase(e, hp_event)
+	local hit_counter, delay_counter, resist_counter = 0, 0, 0;
+	if enable_scaling then
+		hit_counter = increment_get_scale_data("hit", 0);
+		delay_counter = increment_get_scale_data("delay", 0);
+		resist_counter = increment_get_scale_data("resist", 0);
+	end
+
 	e.self:ModifyNPCStat("ac",				tostring(event_stat_stages[hp_event][1]));
-	e.self:ModifyNPCStat("min_hit",			tostring(event_stat_stages[hp_event][2]));
-	e.self:ModifyNPCStat("max_hit",			tostring(event_stat_stages[hp_event][3]));
-	e.self:ModifyNPCStat("attack_delay",	tostring(event_stat_stages[hp_event][4]));
-	e.self:ModifyNPCStat("mr",				tostring(event_stat_stages[hp_event][5]));
-	e.self:ModifyNPCStat("cr",				tostring(event_stat_stages[hp_event][6]));
-	e.self:ModifyNPCStat("fr",				tostring(event_stat_stages[hp_event][7]));
-	e.self:ModifyNPCStat("pr",				tostring(event_stat_stages[hp_event][8]));
-	e.self:ModifyNPCStat("dr",				tostring(event_stat_stages[hp_event][9]));
+	e.self:ModifyNPCStat("min_hit",			tostring(scale_value(event_stat_stages[hp_event][2], hit_counter, max_hit_adjust2, min_hit_adjust2)));
+	e.self:ModifyNPCStat("max_hit",			tostring(scale_value(event_stat_stages[hp_event][3], hit_counter, max_hit_adjust, min_hit_adjust)));
+	e.self:ModifyNPCStat("attack_delay",	tostring(scale_value(event_stat_stages[hp_event][4], delay_counter, max_delay_adjust, min_delay_adjust)));
+	e.self:ModifyNPCStat("mr",				tostring(scale_value(event_stat_stages[hp_event][5], resist_counter, max_resist_adjust, min_resist_adjust)));
+	e.self:ModifyNPCStat("cr",				tostring(scale_value(event_stat_stages[hp_event][6], resist_counter, max_resist_adjust, min_resist_adjust)));
+	e.self:ModifyNPCStat("fr",				tostring(scale_value(event_stat_stages[hp_event][7], resist_counter, max_resist_adjust, min_resist_adjust)));
+	e.self:ModifyNPCStat("pr",				tostring(scale_value(event_stat_stages[hp_event][8], resist_counter, max_resist_adjust, min_resist_adjust)));
+	e.self:ModifyNPCStat("dr",				tostring(scale_value(event_stat_stages[hp_event][9], resist_counter, max_resist_adjust, min_resist_adjust)));
 
 	eq.local_emote({e.self:GetX(), e.self:GetY(), e.self:GetZ()},MT.LightBlue,500,event_stat_stages[hp_event][10]);
 end
@@ -142,6 +183,114 @@ function evt_jester_death(e)
 	eq.zone_emote(MT.Yellow, "Merry laughter echoes throughout the castle and a cheerful voice is heard saying, 'Come on then if you seek the King of Thieves you must choose wisely! Hurry up lads and lasses!")
 end
 
+function get_bucket_key(suffix)
+	return string.format("%d_bb_scale_%s", eq.get_expedition():GetInstanceID(), suffix);
+end
+
+function increment_get_scale_data(suffix, amount)
+	local key = get_bucket_key(suffix);
+
+	local data_str = eq.get_data(key);
+	if data_str == nil then
+		data_str = "0";
+	end
+
+	local data = tonumber(data_str);
+	if data == nil then
+		data = 0;
+	end
+
+	if amount == 0 then
+		return data;
+	end
+
+	data = data + amount;
+
+	eq.set_data(key, tostring(data), "14h");
+
+	--eq.debug(string.format("%s - %d", suffix, data));
+
+	return data;
+end
+
+function scale_resist()
+	local val = increment_get_scale_data("resist", 1);
+	if val == 1 then
+		eq.zone_emote(MT.Yellow, "The walls of the palace rumble as the minions of mischief dwindle.")
+	end
+end
+
+function scale_hit()
+	local val = increment_get_scale_data("hit", 1);
+	if val == 1 then
+		eq.zone_emote(MT.Yellow, "The air thickens as the minions of mischief dwindle.")
+	end
+end
+
+function scale_delay()
+	local val = increment_get_scale_data("delay", 1);
+	if val == 1 then
+		eq.zone_emote(MT.Yellow, "Time seems to move faster as the minions of mischief dwindle.")
+	end
+end
+
+function scale_adds()
+	local val = increment_get_scale_data("adds", 1);
+	if val == 1 then
+		eq.zone_emote(MT.Yellow, "Order descends upon the castle as the minions of mischief dwindle.")
+	end
+end
+
+function scale_hardmode()
+	increment_get_scale_data("hit", counter_min);
+	increment_get_scale_data("delay", counter_min);
+	increment_get_scale_data("resist", counter_min);
+	eq.zone_emote(MT.Yellow, "A booming voice echos from the depths of the castle, 'Some lines must never be crossed in the pursuit of mischief!'")
+	--Don't need to adjust adds since they remain unchanged between versions
+end
+
+function scale_all()
+	increment_get_scale_data("adds", 1);
+	increment_get_scale_data("hit", 1);
+	increment_get_scale_data("delay", 1);
+	increment_get_scale_data("resist", 1);
+end
+
+function scale_value(initial, counter, max_effect, min_effect)
+	if counter == 0 then
+		return initial;
+	end
+
+	if counter > counter_max then
+		counter = counter_max;
+	end
+
+	if counter < counter_min then
+		counter = counter_min;
+	end
+
+	local effect_to_use = max_effect;
+	local max_counters = counter_max;
+	if counter < 0 then
+		effect_to_use = min_effect;
+		max_counters = counter_min;
+	end
+
+	if max_counters == 0 then
+		return initial;
+	end
+
+	local percent = counter / max_counters;
+	local adjust_amount = math.ceil(percent * effect_to_use);
+
+	local retVal = initial + adjust_amount;
+	if retVal < 0 then
+		return 0;
+	end
+
+	return retVal;
+end
+
 function event_encounter_load(e)
 	eq.register_npc_event(Event.spawn,			bristlebane_id, evt_bristlebane_spawn);
 	eq.register_npc_event(Event.combat,			bristlebane_id, evt_bristlebane_combat);
@@ -156,4 +305,182 @@ function event_encounter_load(e)
 	end
 
 	eq.register_npc_event(Event.death_complete,	mischievous_jester_id, evt_jester_death);
+
+	if not enable_scaling then
+		return
+	end
+
+	local expedition = eq.get_expedition()
+	if not expedition.valid or expedition:GetName() ~= "The Plane of Mischief (Non-Respawning)" then
+		return
+	end
+
+	eq.set_data(get_bucket_key("resist"), "0", "14h");
+	eq.set_data(get_bucket_key("delay"), "0", "14h");
+	eq.set_data(get_bucket_key("hit"), "0", "14h");
+	eq.set_data(get_bucket_key("adds"), "0", "14h");
+
+	for i = 1, #bw_mobs do
+		eq.register_npc_event(Event.death_complete, bw_mobs[i], scale_adds);
+	end
+
+	for i = 1, #chess_mobs do
+		eq.register_npc_event(Event.death_complete, chess_mobs[i], scale_hit);
+	end
+
+	for i = 1, #upsidedown_mobs do
+		eq.register_npc_event(Event.death_complete, upsidedown_mobs[i], scale_delay);
+	end
+
+	for i = 1, #alice_mobs do
+		eq.register_npc_event(Event.death_complete, alice_mobs[i], scale_resist);
+	end
+
+	for i = 1, #hardmode_mobs do
+		eq.register_npc_event(Event.death_complete, hardmode_mobs[i], scale_hardmode);
+	end
+
+	--For simple testing
+	--for i = 1, #theater_mobs do
+	--	eq.register_npc_event(Event.death_complete, theater_mobs[i], scale_all);
+	--end
+	
+	--run_tests();
+end
+
+function run_tests()
+	local orig_max = counter_max;
+	local orig_min = counter_min;
+
+	counter_max = 10;
+	counter_min = -10;
+
+	-- Basic scale test
+	local test_result = scale_value(1560, 10, -200, 200);
+	if test_result ~= 1360 then
+		eq.debug(string.format("Test 1 failed: %d != 1360", test_result));
+	else
+		eq.debug("Test 1 passed");
+	end
+
+	-- Testing what happens if we go over the counter limit
+	test_result = scale_value(1560, 20, -200, 200);
+	if test_result ~= 1360 then
+		eq.debug(string.format("Test 2 failed: %d != 1360", test_result));
+	else
+		eq.debug("Test 2 passed");
+	end
+
+	-- Testing negative effects
+	test_result = scale_value(1560, -10, -200, 200);
+	if test_result ~= 1760 then
+		eq.debug(string.format("Test 3 failed: %d != 1760", test_result));
+	else
+		eq.debug("Test 3 passed");
+	end
+
+	-- Testing counter limit on negative values
+	test_result = scale_value(1560, -20, -200, 200);
+	if test_result ~= 1760 then
+		eq.debug(string.format("Test 4 failed: %d != 1760", test_result));
+	else
+		eq.debug("Test 4 passed");
+	end
+
+	-- Testing when counter hasn't been incremented
+	test_result = scale_value(1560, 0, -200, 200);
+	if test_result ~= 1560 then
+		eq.debug(string.format("Test 5 failed: %d != 1560", test_resuilt));
+	else
+		eq.debug("Test 5 passed");
+	end
+
+	-- Making sure no effect is applied when limit is set to 0
+	test_result = scale_value(1560, 10, 0, 200);
+	if test_result ~= 1560 then
+		eq.debug(string.format("Test 6 failed: %d != 1560", test_resuilt));
+	else
+		eq.debug("Test 6 passed");
+	end
+
+	test_result = scale_value(1560, -10, -200, 0);
+	if test_result ~= 1560 then
+		eq.debug(string.format("Test 7 failed: %d != 1560", test_resuilt));
+	else
+		eq.debug("Test 7 passed");
+	end
+
+	-- Making sure we cant scale into a negative number
+	test_result = scale_value(100, 10, -200, 200);
+	if test_result ~= 0 then
+		eq.debug(string.format("Test 8 failed: %d != 0", test_result));
+	else
+		eq.debug("Test 8 passed");
+	end
+
+	-- Testing divide-by-zero protections
+	counter_max = 0;
+	test_result = scale_value(1560, 10, -200, 200);
+	if test_result ~= 1560 then
+		eq.debug(string.format("Test 9 failed: %d != 1560", test_resuilt));
+	else
+		eq.debug("Test 9 passed");
+	end
+
+	counter_min = 0;
+	test_result = scale_value(1560, -10, -200, 200);
+	if test_result ~= 1560 then
+		eq.debug(string.format("Test 10 failed: %d != 1560", test_resuilt));
+	else
+		eq.debug("Test 10 passed");
+	end
+
+	counter_max = 10;
+	counter_min = -10;
+
+	-- Following tests are verifying the adjust globals are configured properly
+	test_result = scale_value(1560, 10, max_hit_adjust, min_hit_adjust);
+	if test_result > 1560 then
+		eq.debug("Test 11 failed.  Expected result to be lower than original amount");
+	else
+		eq.debug("Test 11 passed");
+	end
+
+	test_result = scale_value(1560, -10, max_hit_adjust, min_hit_adjust);
+	if test_result < 1560 then
+		eq.debug("Test 12 failed.  Expected result to be greater than original amount");
+	else
+		eq.debug("Test 12 passed");
+	end
+
+	test_result = scale_value(18, 10, max_delay_adjust, min_delay_adjust);
+	if test_result < 18 then
+		eq.debug("Test 13 failed.  Expected result to be greater than original amount");
+	else
+		eq.debug("Test 13 passed");
+	end
+
+	test_result = scale_value(18, -10, max_delay_adjust, min_delay_adjust);
+	if test_result > 18 then
+		eq.debug("Test 14 failed.  Expected result to be lower than original amount");
+	else
+		eq.debug("Test 14 passed");
+	end
+
+	test_result = scale_value(500, 10, max_resist_adjust, min_resist_adjust);
+	if test_result > 500 then
+		eq.debug("Test 15 failed.  Expected result to be lower than original amount");
+	else
+		eq.debug("Test 15 passed");
+	end
+
+	test_result = scale_value(500, -10, max_resist_adjust, min_resist_adjust);
+	if test_result < 500 then
+		eq.debug(string.format("Test 16 failed.  Expected result to be greater than original amount: %d", test_result));
+	else
+		eq.debug("Test 16 passed");
+	end
+
+	counter_max = orig_max;
+	counter_min = orig_min;
 end


### PR DESCRIPTION
Throwing this into the void with zero expectations.  Feel free to ignore/delete/whatever.

### Intro

I think PoM is a fun zone but due to being out of the way, events not working and lacking a lot of notable loot there is not much driving players to the zone, much less exploring it.

Considering we're also in a kind of awkward catch-22 with Bristlebane balancing I'm throwing out these changes as a potential solution to both problems.

### Changes

In a non-respawning instance players will be able to scale down BB's behavior by killing enemies in various parts of the zone.

By default, a player can zone in and run/clear straight to BB and fight him unmodified.  I've avoided using any mobs they would encounter on the way to BB to prevent accidentally scaling down the encounter when they may not want that.  (This assumes they are aware of the BB port located behind the theater).

For players struggling with the fight they have the following options:

- Kill enemies in the black/white room to reduce adds that can spawn.
- Kill enemies in the upside-down area to slow down his attack rate.
- Kill enemies in the alice area to lower his resists.
- Kill enemies in the chess area to lower his min/max hits.

For players who want more challenge:

- Killing the white stallion in the entry courtyard will scale BB back to roughly the original values of the encounter before the recent tuning.  They can 'undo' this to some extent by killing enemies but it will take 10 enemies in each area to get back to original values.

### Finer details

The following can be easily adjusted by editing values at the top of the script.  The scaling behavior can also be entirely disabled via a boolean at the top of the script.

Number of enemies to kill in each area to receive max benefit: 10
Max reduction to max_hit: -200
Max reduction to min_hit: -200
Max delay adjustment: 10
Max resist adjustment: -200

Tuning add spawns takes a bit more work but as it sits they need to kill at least half of the expected number of enemies (so 5) to achieve the 'max' benefit.  This will remove 1-2 adds from each spawn cycle resulting in total of 6 adds spawned (originally 10).

### Testing

Tested on a local akk-stack modified to run THJ code/quests.

Test Cases
- Openworld - Unaffected
- Respawning - Unaffected
- Boolean set to false - Unaffected
- Non-respawning with nothing killed - Unaffected
- Resist scaling working
- Min/Max hit scaling working
- Delay scaling working
- Add spawn behavior verified
- Hardmode behavior verified
- Zone emote behavior verified

Testing typically involved spawning BB and cycling through his phases by performing #damage 75570 to knock off 11% of his HP at a time and then verifying the stats via the GM inspect window.