### PR TITLE
DRAFT/WIP- [Feature] Add var to disable respawn instances

### DIFF
--- a/airplane/Echo_of_the_Past.pl
+++ b/airplane/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Plane of Sky";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "airplane";
+my $disable_respawn = "true";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/akheva/Echo_of_the_Past.pl
+++ b/akheva/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "The Ruins of Ka Vethan";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "akheva";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/barindu/Echo_of_the_Past.pl
+++ b/barindu/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Barindu, Hanging Gardens";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "barindu";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/befallen/Echo_of_the_Past.pl
+++ b/befallen/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Befallen";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "befallen";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/blackburrow/Echo_of_the_Past.pl
+++ b/blackburrow/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Blackburrow";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "blackburrow";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/bothunder/Echo_of_the_Past.pl
+++ b/bothunder/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Torden, The Bastion of Thunder";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "bothunder";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/burningwood/Echo_of_the_Past.pl
+++ b/burningwood/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "burningwood";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "burningwood";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/cazicthule/Echo_of_the_Past.pl
+++ b/cazicthule/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Cazic Thule";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "cazicthule";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/charasis/Echo_of_the_Past.pl
+++ b/charasis/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "The Howling Stones";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "charasis";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/chardok/Echo_of_the_Past.pl
+++ b/chardok/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Chardok";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "chardok";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/chardokb/Echo_of_the_Past.pl
+++ b/chardokb/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Halls of Betrayal";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "chardokb";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/citymist/Echo_of_the_Past.pl
+++ b/citymist/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "City of Mist";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "citymist";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/cobaltscar/Echo_of_the_Past.pl
+++ b/cobaltscar/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Cobalt Scar";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "cobaltscar";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/codecay/Echo_of_the_Past.pl
+++ b/codecay/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "The Crypt of Decay";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "codecay";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/crushbone/Echo_of_the_Past.pl
+++ b/crushbone/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Crushbone";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "crushbone";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/crystal/Echo_of_the_Past.pl
+++ b/crystal/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Crystal Caverns";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "crystal";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/dreadlands/Echo_of_the_Past.pl
+++ b/dreadlands/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Dreadlands";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "dreadlands";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/droga/Echo_of_the_Past.pl
+++ b/droga/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Droga";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "droga";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/droga/v0/Echo_of_the_Past.pl
+++ b/droga/v0/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Droga";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "droga";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/droga/v1/Echo_of_the_Past.pl
+++ b/droga/v1/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Droga";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "droga";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/dulak/Echo_of_the_Past.pl
+++ b/dulak/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Dulak's Harbor";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "dulak";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/eastwastes/Echo_of_the_Past.pl
+++ b/eastwastes/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Eastern Wastes";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "eastwastes";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/emeraldjungle/Echo_of_the_Past.pl
+++ b/emeraldjungle/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Emerald Jungle";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "emeraldjungle";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/everfrost/Echo_of_the_Past.pl
+++ b/everfrost/Echo_of_the_Past.pl
@@ -2,8 +2,8 @@ my $expedition_name = "Permafrost";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "permafrost";
-
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/fearplane/Echo_of_the_Past.pl
+++ b/fearplane/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "The Plane of Fear";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "fearplane";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/feerrott/Echo_of_the_Past.pl
+++ b/feerrott/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "The Plane of Fear";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "fearplane";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/ferubi/Echo_of_the_Past.pl
+++ b/ferubi/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Ferubi, Forgotten Temple of Taelosia";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "ferubi";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/frontiermtns/Echo_of_the_Past.pl
+++ b/frontiermtns/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Frontier Mountains";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "frontiermtns";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/frozenshadow/Echo_of_the_Past.pl
+++ b/frozenshadow/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Tower of Frozen Shadow";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "frozenshadow";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/greatdivide/Echo_of_the_Past.pl
+++ b/greatdivide/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Velketor's Labyrinth";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "velketor";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/griegsend/Echo_of_the_Past.pl
+++ b/griegsend/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Grieg's End";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "griegsend";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/grimling/Echo_of_the_Past.pl
+++ b/grimling/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Acrylia Caverns";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "acrylia";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/growthplane/Echo_of_the_Past.pl
+++ b/growthplane/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Plane of Growth";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "growthplane";
+my $disable_respawn = "true";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/gukbottom/Echo_of_the_Past.pl
+++ b/gukbottom/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Lower Guk";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "gukbottom";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/guktop/Echo_of_the_Past.pl
+++ b/guktop/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Upper Guk";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "guktop";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/hateplane/Echo_of_the_Past.pl
+++ b/hateplane/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "The Plane of Hate";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "hateplaneb";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/hateplaneb/Echo_of_the_Past.pl
+++ b/hateplaneb/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "The Plane of Hate";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "hateplaneb";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/hatesfury/Echo_of_the_Past.pl
+++ b/hatesfury/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Hate's Fury";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "hatesfury";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/highpasshold/Echo_of_the_Past.pl
+++ b/highpasshold/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Highpass Hold";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "highpasshold";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/hohonora/Echo_of_the_Past.pl
+++ b/hohonora/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Halls of Honor";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "hohonora";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/hohonorb/Echo_of_the_Past.pl
+++ b/hohonorb/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "The Temple of Marr";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "hohonorb";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/hole/Echo_of_the_Past.pl
+++ b/hole/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "The Ruins of Old Paineel";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "hole";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/iceclad/Echo_of_the_Past.pl
+++ b/iceclad/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "The Iceclad Ocean";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "iceclad";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/kael/Echo_of_the_Past.pl
+++ b/kael/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Kael Drakkel";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "kael";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/kaesora/Echo_of_the_Past.pl
+++ b/kaesora/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Kaesora";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "kaesora";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/karnor/Echo_of_the_Past.pl
+++ b/karnor/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Karnor's Castle";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "karnor";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/katta/Echo_of_the_Past.pl
+++ b/katta/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Katta Castellum";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "katta";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/kedge/Echo_of_the_Past.pl
+++ b/kedge/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Kedge Keep";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "kedge";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/kithicor/Echo_of_the_Past.pl
+++ b/kithicor/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Kithicor";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "kithicor";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/kodtaz/Echo_of_the_Past.pl
+++ b/kodtaz/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Kodtaz, Broken Trial Grounds";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "kodtaz";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/kurn/Echo_of_the_Past.pl
+++ b/kurn/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Kurn's Tower";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "kurn";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/lakeofillomen/Echo_of_the_Past.pl
+++ b/lakeofillomen/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Lake of Ill Omen";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "lakeofillomen";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/lakerathe/Echo_of_the_Past.pl
+++ b/lakerathe/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Lake Rathetear";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "lakerathe";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/lavastorm/Echo_of_the_Past.pl
+++ b/lavastorm/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Nagafen's Lair";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "soldungb";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/mischiefplane/Echo_of_the_Past.pl
+++ b/mischiefplane/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "The Plane of Mischief";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "mischiefplane";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/mistmoore/Echo_of_the_Past.pl
+++ b/mistmoore/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Castle Mistmoore";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "mistmoore";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/nadox/Echo_of_the_Past.pl
+++ b/nadox/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Crypt of Nadox";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "nadox";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/najena/Echo_of_the_Past.pl
+++ b/najena/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Najena";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "najena";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/natimbi/Echo_of_the_Past.pl
+++ b/natimbi/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Natimbi, the Broken Shores";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "natimbi";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/necropolis/Echo_of_the_Past.pl
+++ b/necropolis/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Dragon Necropolis";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "necropolis";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/nightmareb/Echo_of_the_Past.pl
+++ b/nightmareb/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Lair of Terris-Thule";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "nightmareb";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/nurga/Echo_of_the_Past.pl
+++ b/nurga/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Nurga";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "nurga";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/oasis/Echo_of_the_Past.pl
+++ b/oasis/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "The Plane of Hate";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "hateplaneb";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/oot/Echo_of_the_Past.pl
+++ b/oot/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Ocean of Tears";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "oot";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/overthere/Echo_of_the_Past.pl
+++ b/overthere/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "The Overthere";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "overthere";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/plugins/cata_instance_utils.pl
+++ b/plugins/cata_instance_utils.pl
@@ -31,7 +31,9 @@ sub OfferStandardInstance {
       if (plugin::IsTHJ()) {
         plugin::YellowText("Notice: Instances will become more difficult for each player in your group beyond the second.");
         plugin::YellowText("[". quest::saylink('Non-Respawning',1). "] will not repopulate over time, and the most powerful enemies may be found within.");
-        plugin::YellowText("[". quest::saylink('Respawning', 1). "] will repopulate over time, but many rare enemies may not be found inside.");
+        if ($disable_respawn eq "false") {
+          plugin::YellowText("[". quest::saylink('Respawning', 1). "] will repopulate over time, but many rare enemies may not be found inside.");
+        }
       } else {
         plugin::YellowText("You can select from [". quest::saylink('Respawning', 1). "] or [".quest::saylink('Non-Respawning',1). "] versions.");
       }
@@ -43,8 +45,13 @@ sub OfferStandardInstance {
       $dz_version = quest::get_rule("Custom:StaticInstanceVersion") || 100;
       $expedition_name = $expedition_name . " (Non-Respawning)";
     } else {
-      $dz_version = quest::get_rule("Custom:FarmingInstanceVersion") || 100;
-      $expedition_name = $expedition_name . " (Respawning)";
+      if ($disable_respawn eq "false") {
+        $dz_version = quest::get_rule("Custom:FarmingInstanceVersion") || 100;
+        $expedition_name = $expedition_name . " (Respawning)";
+      } else {
+        plugin::RedText("Notice: This zone is not approved for a respawning instance.");
+        return;
+      }
     }
     
     my $dz = $client->CreateExpedition($dz_zone, $dz_version, $dz_lifetime, $expedition_name, $min_players, $max_players);

--- a/poair/Echo_of_the_Past.pl
+++ b/poair/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Eryslai, the Kingdom of Wind";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "poair";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/podisease/Echo_of_the_Past.pl
+++ b/podisease/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "The Plane of Disease";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "podisease";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/poeartha/Echo_of_the_Past.pl
+++ b/poeartha/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Vegarlson, the Earthen Badlands";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "poeartha";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/poearthb/Echo_of_the_Past.pl
+++ b/poearthb/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Ragrax, Stronghold of the Twelve";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "poearthb";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/pofire/Echo_of_the_Past.pl
+++ b/pofire/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Doomfire, the Burning Lands";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "pofire";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/poinnovation/Echo_of_the_Past.pl
+++ b/poinnovation/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "The Plane of Innovation";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "poinnovation";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/pojustice/Echo_of_the_Past.pl
+++ b/pojustice/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "The Plane of Justice";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "pojustice";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/ponightmare/Echo_of_the_Past.pl
+++ b/ponightmare/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "The Plane of Nightmare";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "ponightmare";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/postorms/Echo_of_the_Past.pl
+++ b/postorms/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Plane of Storms";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "postorms";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/potactics/Echo_of_the_Past.pl
+++ b/potactics/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "The Plane of Tactics";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "potactics";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/potorment/Echo_of_the_Past.pl
+++ b/potorment/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "The Plane of Torment";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "potorment";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/povalor/Echo_of_the_Past.pl
+++ b/povalor/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "The Plane of Valor";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "povalor";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/powater/Echo_of_the_Past.pl
+++ b/powater/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Reef of Coirnav";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "powater";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/qinimi/Echo_of_the_Past.pl
+++ b/qinimi/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Qinimi, Court of Nihilia";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "qinimi";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/qvic/Echo_of_the_Past.pl
+++ b/qvic/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Qvic, Prayer Grounds of Calling";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "qvic";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/rathemtn/Echo_of_the_Past.pl
+++ b/rathemtn/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Rathe Mountains";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "rathemtn";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/riwwi/Echo_of_the_Past.pl
+++ b/riwwi/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Riwwi, Coliseum of Games";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "riwwi";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/runnyeye/Echo_of_the_Past.pl
+++ b/runnyeye/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Runnyeye";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "runnyeye";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/sebilis/Echo_of_the_Past.pl
+++ b/sebilis/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "The Ruins of Old Sebilis";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "sebilis";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/sirens/Echo_of_the_Past.pl
+++ b/sirens/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Siren's Grotto";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "sirens";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/skyfire/Echo_of_the_Past.pl
+++ b/skyfire/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Skyfire Mountains";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "skyfire";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/skyshrine/Echo_of_the_Past.pl
+++ b/skyshrine/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Skyshrine";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "skyshrine";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/sleeper/Echo_of_the_Past.pl
+++ b/sleeper/Echo_of_the_Past.pl
@@ -2,9 +2,10 @@ my $expedition_name = "Sleeper's Tomb";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "sleeper";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }
 
 sub EVENT_SPAWN() {

--- a/soldunga/Echo_of_the_Past.pl
+++ b/soldunga/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Sol A";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "soldunga";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/solrotower/Echo_of_the_Past.pl
+++ b/solrotower/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "The Tower of Solusek Ro";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "solrotower";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/southkarana/Echo_of_the_Past.pl
+++ b/southkarana/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "South Karana";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "southkarana";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/sseru/Echo_of_the_Past.pl
+++ b/sseru/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Sanctus Seru";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "sseru";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/ssratemple/Echo_of_the_Past.pl
+++ b/ssratemple/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Ssraeshza Temple";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "ssratemple";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/templeveeshan/Echo_of_the_Past.pl
+++ b/templeveeshan/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "The Temple of Veeshan";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "templeveeshan";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/thedeep/Echo_of_the_Past.pl
+++ b/thedeep/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "The Deep";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "thedeep";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/thurgadinb/Echo_of_the_Past.pl
+++ b/thurgadinb/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Icewell Keep";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "thurgadinb";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/timorous/Echo_of_the_Past.pl
+++ b/timorous/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Timorous Deep";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "timorous";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/torgiran/Echo_of_the_Past.pl
+++ b/torgiran/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "The Mines of Torgiran";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "torgiran";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/txevu/Echo_of_the_Past.pl
+++ b/txevu/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Txevu, Lair of the Elite";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "txevu";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/unrest/Echo_of_the_Past.pl
+++ b/unrest/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Unrest";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "unrest";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/veeshan/Echo_of_the_Past.pl
+++ b/veeshan/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Veeshan's Peak'";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "veeshan";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/veksar/Echo_of_the_Past.pl
+++ b/veksar/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Veksar";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "veksar";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/vexthal/Echo_of_the_Past.pl
+++ b/vexthal/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Vex Thal";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "vexthal";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/wakening/Echo_of_the_Past.pl
+++ b/wakening/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "The Wakening Land";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "wakening";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/warrens/Echo_of_the_Past.pl
+++ b/warrens/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "The Warrens";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "warrens";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/warslikswood/Echo_of_the_Past.pl
+++ b/warslikswood/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Warskliks Wood";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "warslikswood";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/westwastes/Echo_of_the_Past.pl
+++ b/westwastes/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Western Wastes";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "westwastes";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }

--- a/yxtta/Echo_of_the_Past.pl
+++ b/yxtta/Echo_of_the_Past.pl
@@ -2,7 +2,8 @@ my $expedition_name = "Yxtta, Pulpit of Exiles";
 my $min_players     = 1;
 my $max_players     = 72;
 my $dz_zone         = "yxtta";
+my $disable_respawn = "false";
 
 sub EVENT_SAY {
-  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone);
+  plugin::OfferStandardInstance($expedition_name, $min_players, $max_players, $dz_zone, $disable_respawn);
 }


### PR DESCRIPTION
This is a Draft/WIP - I am not as familiar with perl, but rather than maintaining a table of zones that should not have access to respawning instances, I added a variable to pass through the OfferStandardInstance.

This should exclude the respawning option when set to "True" and do a hard return with a message if someone tries to bypass the hail.

This has NOT been tested and should be reviewed by @Catapultam prior to being accepted as he may have other ideas for the design.