### PR TITLE
Add more leeway to Zunmuram Kvxe Pirik

### DIFF
--- a/tacvi/encounters/zmkp.lua
+++ b/tacvi/encounters/zmkp.lua
@@ -226,8 +226,8 @@ function ZMKP_Hp_Balance(e)
 			rage_balanced = true;
 		end
 		eq.get_entity_list():MessageClose(e.self, false, 120, MT.Yellow, e.self:GetCleanName() .. " seems to be tipping in your favor.");
-		eq.set_next_hp_event(target_hp - 3)
-	elseif e.hp_event == (target_hp - 3) then
+		eq.set_next_hp_event(target_hp - 20) --Changed from 3%
+	elseif e.hp_event == (target_hp - 20) then
 		local id = e.self:GetNPCTypeID();
 		if id == 298125 then
 			speed_balanced = false;


### PR DESCRIPTION
Current Zun'muram Kvxe Pirik will fall out of balance if the balancers are +/- 3% of the health of ZMKP.  Due to high burst damage potential on almost any attack, this changes the negative balance to -20%, giving players a chance to stop damage in time.