### PR TITLE
Tacvi

### DIFF
--- a/tacvi/encounters/zmkp.lua
+++ b/tacvi/encounters/zmkp.lua
@@ -226,8 +226,8 @@ function ZMKP_Hp_Balance(e)
 			rage_balanced = true;
 		end
 		eq.get_entity_list():MessageClose(e.self, false, 120, MT.Yellow, e.self:GetCleanName() .. " seems to be tipping in your favor.");
-		eq.set_next_hp_event(target_hp - 3)
-	elseif e.hp_event == (target_hp - 3) then
+		eq.set_next_hp_event(target_hp - 20) --Changed from 3%
+	elseif e.hp_event == (target_hp - 20) then
 		local id = e.self:GetNPCTypeID();
 		if id == 298125 then
 			speed_balanced = false;

--- a/tacvi/encounters/zmkp.lua
+++ b/tacvi/encounters/zmkp.lua
@@ -110,6 +110,7 @@ function ZMKP_Timer(e)
 			eq.signal(298128, 2); -- NPC: #Balance_of_Rage
 		else
 			e.self:ProcessSpecialAbilities(ZMKP_Active);
+      e.self:SetSpecialAbility(35, 0)
 			target_hp = target_hp - 10;
 			eq.set_next_hp_event(target_hp);
 		end
@@ -142,6 +143,8 @@ function ZMKP_Hp(e)
 		e.self:ProcessSpecialAbilities(ZMKP_Inactive);
 		e.self:SetOOCRegen(0);
 		e.self:WipeHateList();
+    e.self:SetSpecialAbility(35, 1)
+    e.self:BuffFadeAll()
 
 		eq.signal(298125, 2); -- NPC: #Balance_of_Speed
 		eq.signal(298126, 2); -- NPC: #Balance_of_Defense
@@ -187,7 +190,7 @@ function ZMKP_Signal_Balance(e)
 		e.self:WipeHateList();
 
 		-- lets double check
-		if e.self:GetHPRatio() <= (target_hp - 3) then
+		if e.self:GetHPRatio() <= (target_hp - 20) then --Changed from 3%
 			local id = e.self:GetNPCTypeID();
 			if id == 298125 then
 				speed_balanced = false;

--- a/tacvi/encounters/zmmd.lua
+++ b/tacvi/encounters/zmmd.lua
@@ -39,6 +39,7 @@ function ZMMD_Inactivate(e)
 	e.self:SetAppearance(3);
 	e.self:WipeHateList();
 	e.self:SetOOCRegen(0);
+  e.self:BuffFadeAll()
 end
 
 function ZMMD_Timer(e)


### PR DESCRIPTION
## Description
Mobs that go inactive with dots on them continue to take damage, making these fights trivial for dot classes.  Remove the cheese.
Additionally, fully fix Balancer to allow 20% leeway

## Type of Change
- [X] Bug fix
- [ ] New feature

## Testing
Tested combat with these NPCs until they go inactive, at which point debuffs are all removed.
Balancer correctly allows 20% lower health on the balancer Aneuks

## Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur.
