### PR TITLE
Fix for Lork quests

### DIFF
--- a/oggok/Lork.pl
+++ b/oggok/Lork.pl
@@ -1,4 +1,4 @@
-# items: 20523, 16547, 1717, 13227, 13355, 13356, 13357, 18840, 5030, 13358
+# items: 13227, 13355, 13356, 13357, 18840, 5030, 13358
 sub EVENT_SAY {
   if($text=~/hail/i) {
     quest::say("You $name. We hear of you. We need help. You [help Crakneks] or you [help self]?");
@@ -15,40 +15,31 @@ sub EVENT_SAY {
 }
 
 sub EVENT_ITEM {
-  if(plugin::check_handin(\%itemcount, 20523 => 1)) {
-    quest::say("Ay danks. Take dis to Uglan.");
-    quest::summonitem(16547); # Item: Stein
-  }
-  elsif(plugin::check_handin(\%itemcount, 1717 => 1)) {
-    quest::say("Arg! Dem damned Orcs and Dark Elves! To da hells with dem! I be wantin revenge! Bring me da hearts of da dark elf ammbassador's K'ryn who can be locat'd in da shamen tun'ls, and D'vinn who can be located in da crushbone with da orc emperor.");
-  }
-  elsif(plugin::check_handin(\%itemcount, 13227 => 1)) {
-    quest::say("Ahahaha! Da basterds! Here be a reward for ye!");
-    quest::summonitem(13355); # Item: Crude Stein
-  }
-  elsif(plugin::check_handin(\%itemcount, 13356 => 1)) {
+  if(plugin::check_handin(\%itemcount, 13356 => 1)) { # Item: Ogre Arm
     quest::say("Ahhh!! Boohoohoo. Nork!! That you arm. Me will take care of you now. Thank you for killing gator. You must be strong. Now you help Crakneks. We hear.. ohh, poor Nork, we hear trouble begins. Find ogre warrior [Uglan]. Give him this. It broken. He know where you from. Go. Nork.. Poor Nork.");
     quest::faction(232,10); # Faction: Craknek Warriors
     quest::faction(228,10); # Faction: Clurg
     quest::faction(261,-10); # Faction: Green Blood Knights
     quest::summonitem(13357); # Item: Cracked Stein
     quest::exp(50);
+    return;
   }
-  elsif(plugin::check_handin(\%itemcount, 18840 => 1)) {
+  elsif(plugin::check_handin(\%itemcount, 18840 => 1)) { # Item: Sealed Letter
     quest::say("What this!! So, dark elves think they can bash ogres. Replace with blue orcs. Dumb Zulort friend with dark elf ambassador in Oggok. We kill him. We kill Crushbone dark elf ambassador also. This slow down plan. We need a hero. Me guess you do. You go. Go bring Lork both Crushbone and Oggok dark elf hearts. Then you be hero.");
     quest::faction(232,10); # Faction: Craknek Warriors
     quest::faction(228,10); # Faction: Clurg
     quest::faction(261,-10); # Faction: Green Blood Knights
     quest::exp(100);
     quest::summonitem(5030); # Item: Bronze Two Handed Sword
+    return;
   }
-  elsif(plugin::check_handin(\%itemcount, 13358 => 1, 13227 => 1)) {
+  elsif(plugin::check_handin(\%itemcount, 13358 => 1, 13227 => 1)) { #Item: Black Heart, Black Heart
     quest::say("That show dark elves who strongest. Me hope you kill many blue orcs. You Craknek Hero now. You take this. It mine. Hero reward. You great ogre now. Smash best.");
     quest::faction(232,10); # Faction: Craknek Warriors
     quest::faction(228,10); # Faction: Clurg
     quest::faction(261,-10); # Faction: Green Blood Knights
     quest::exp(100);
-    quest::ChooseRandom(13359,13355,2136,2130,2135,2132,2128);
+    quest::summonitem(quest::ChooseRandom(13359,13355,2136,2130,2135,2132,2128)); #Item: Gatorsmash Maul, Crude Stein, Large Patchwork Boots, Large Patchwork Cloak, Large Patchwork Pants, Large Patchwork Sleeves, Large Patchwork Tunic
   }
   #do all other handins first with plugin, then let it do disciplines
   plugin::try_tome_handins(\%itemcount, $class, 'Warrior');


### PR DESCRIPTION
## Description
Lork's quests were very messed up, he had quests for other NPC's and his quest for the stein/maul was incorrect. All invalid quests were removed and the incorrect quest was corrected so they match what is expected.

## Type of Change
- [X] Bug fix

## Testing
Tested on a local dev box
<img width="747" height="587" alt="Screenshot 2025-09-19 175928" src="https://github.com/user-attachments/assets/cddf257f-d631-4066-8263-9e55b99f6b99" />


## Checklist
- [X] I have tested my changes
- [X] I have performed a self-review of my code. Ensuring variables, functions and methods are named in a human-readable way, comments are added only where naming of variables, functions and methods can't give enough context.
- [X] I own the changes of my code and take responsibility for the potential issues that occur.
